### PR TITLE
sink: add dry run mode for mysql sink

### DIFF
--- a/downstreamadapter/writer/config.go
+++ b/downstreamadapter/writer/config.go
@@ -92,6 +92,8 @@ type MysqlConfig struct {
 	BatchDMLEnable  bool
 	MultiStmtEnable bool
 	CachePrepStmts  bool
+	// DryRun is used to enable dry-run mode. In dry-run mode, the writer will not write data to the downstream.
+	DryRun bool
 }
 
 // NewConfig returns the default mysql backend config.

--- a/downstreamadapter/writer/helper.go
+++ b/downstreamadapter/writer/helper.go
@@ -89,6 +89,12 @@ func GenBasicDSN(cfg *MysqlConfig) (*dmysql.Config, error) {
 		port = "4000"
 	}
 
+	dryRun := cfg.sinkURI.Query().Get("dry-run")
+	if dryRun == "true" {
+		log.Info("dry-run mode is enabled, will not write data to downstream")
+		cfg.DryRun = true
+	}
+
 	// This will handle the IPv6 address format.
 	var dsn *dmysql.Config
 	var err error

--- a/downstreamadapter/writer/mysql_writer.go
+++ b/downstreamadapter/writer/mysql_writer.go
@@ -107,6 +107,11 @@ func (w *MysqlWriter) asyncExecAddIndexDDLIfTimeout(event *common.TxnEvent) erro
 }
 
 func (w *MysqlWriter) execDDL(event *common.TxnEvent) error {
+	if w.cfg.DryRun {
+		log.Info("Dry run DDL", zap.String("sql", event.GetDDLQuery()))
+		return nil
+	}
+
 	shouldSwitchDB := needSwitchDB(event)
 
 	ctx := context.Background()
@@ -167,10 +172,14 @@ func (w *MysqlWriter) Flush(events []*common.TxnEvent, workerNum int) error {
 	if dmls.rowCount == 0 {
 		return nil
 	}
-	if err := w.execDMLWithMaxRetries(dmls); err != nil {
-		log.Error("execute DMLs failed", zap.Error(err))
-		return errors.Trace(err)
+
+	if !w.cfg.DryRun {
+		if err := w.execDMLWithMaxRetries(dmls); err != nil {
+			log.Error("execute DMLs failed", zap.Error(err))
+			return errors.Trace(err)
+		}
 	}
+
 	for _, event := range events {
 		if event.PostTxnFlushed != nil {
 			event.PostTxnFlushed()
@@ -260,6 +269,7 @@ func (w *MysqlWriter) prepareDMLs(events []*common.TxnEvent) *preparedDMLs {
 }
 
 func (w *MysqlWriter) execDMLWithMaxRetries(dmls *preparedDMLs) error {
+
 	if len(dmls.sqls) != len(dmls.values) {
 		log.Error("unexpected number of sqls and values",
 			zap.Strings("sqls", dmls.sqls),

--- a/downstreamadapter/writer/mysql_writer.go
+++ b/downstreamadapter/writer/mysql_writer.go
@@ -178,6 +178,11 @@ func (w *MysqlWriter) Flush(events []*common.TxnEvent, workerNum int) error {
 			log.Error("execute DMLs failed", zap.Error(err))
 			return errors.Trace(err)
 		}
+	} else {
+		// dry run mode, just record the metrics
+		w.statistics.RecordBatchExecution(func() (int, int64, error) {
+			return dmls.rowCount, 0, nil
+		})
 	}
 
 	for _, event := range events {


### PR DESCRIPTION
# What is dry-run mode?
When dry-run is enabled, all SQL will not be executed downstream. This is useful for testing when there are not enough resources for downstream.

# How to enable dry-run mode？
By adding dry-run=true in sink-uri.
"sink_uri":"mysql://root@127.0.0.1:3306?dry-run=true"