### PR TITLE
writer: optimize sql builder

### DIFF
--- a/downstreamadapter/writer/mysql_writer.go
+++ b/downstreamadapter/writer/mysql_writer.go
@@ -255,7 +255,7 @@ func (w *MysqlWriter) prepareDMLs(events []*common.DMLEvent) *preparedDMLs {
 			// INSERT(not in safe mode)
 			// or REPLACE(in safe mode) SQL.
 			if row.RowType == common.RowTypeInsert {
-				query, args = buildInsert(event.TableInfo, row, true, w.cfg.SafeMode)
+				query, args = buildInsert(event.TableInfo, row, w.cfg.SafeMode)
 				if query != "" {
 					sqls = append(sqls, query)
 					values = append(values, args)

--- a/downstreamadapter/writer/sql_builder_benchmark_test.go
+++ b/downstreamadapter/writer/sql_builder_benchmark_test.go
@@ -1,0 +1,56 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writer
+
+import (
+	"testing"
+)
+
+// BenchmarkOldBuildInsert-10: 1000000	      1101 ns/op	    7544 B/op	     103 allocs/op
+// BenchmarkBuildInsert-10:2492268	       530.9 ns/op	    2472 B/op	      87 allocs/op ( 2.49x )
+func BenchmarkBuildInsert(b *testing.B) {
+	insert, _, _, tableInfo := getRowForTest(b)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = buildInsert(tableInfo, insert, false)
+		}
+	})
+}
+
+// BenchmarkBuildDelete-10: 6709940	       204.4 ns/op	    1672 B/op	       7 allocs/op
+func BenchmarkBuildDelete(b *testing.B) {
+	_, delete, _, tableInfo := getRowForTest(b)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = buildDelete(tableInfo, delete)
+		}
+	})
+}
+
+// BenchmarkOldBuildUpdate-10: 918433	      1526 ns/op	    9722 B/op	     101 allocs/op
+// BenchmarkBuildUpdate-10: 1381165	       878.6 ns/op	    6440 B/op	      91 allocs/op ( 1.50x )
+func BenchmarkBuildUpdate(b *testing.B) {
+	_, _, update, tableInfo := getRowForTest(b)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = buildUpdate(tableInfo, update)
+		}
+	})
+}

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -254,6 +254,13 @@ const (
 	HandleIndexTableIneligible = -2
 )
 
+const (
+	preSQLInsert = iota
+	preSQLReplace
+	preSQLUpdate
+	preSQLDelete
+)
+
 // TableInfo provides meta data describing a DB table.
 type TableInfo struct {
 	*model.TableInfo
@@ -317,6 +324,7 @@ type TableInfo struct {
 	virtualColumnCount int
 	// rowColInfosWithoutVirtualCols is the same as rowColInfos, but without virtual columns
 	rowColInfosWithoutVirtualCols *[]rowcodec.ColInfo
+	PreSQLs                       map[string]string
 }
 
 func (ti *TableInfo) initRowColInfosWithoutVirtualCols() {
@@ -424,6 +432,78 @@ func (ti *TableInfo) initColumnsFlag() {
 			ti.ColumnsFlag[colInfo.ID] = flag
 		}
 	}
+}
+
+func (ti *TableInfo) initPreSQLs() {
+	ti.PreSQLs = make(map[string]string)
+	ti.PreSQLs["insert"] = ti.genPreSQLInsert(false, true)
+	ti.PreSQLs["replace"] = ti.genPreSQLInsert(true, true)
+	ti.PreSQLs["update"] = ti.genPreSQLUpdate()
+}
+
+func (ti *TableInfo) genPreSQLInsert(isReplace bool, needPlaceHolder bool) string {
+	var builder strings.Builder
+	colList := "(" + ti.getColumnList(false) + ")"
+	quoteTable := ti.TableName.QuoteString()
+	if isReplace {
+		builder.WriteString("REPLACE INTO " + quoteTable + " " + colList + " VALUES ")
+	} else {
+		builder.WriteString("INSERT INTO " + quoteTable + " " + colList + " VALUES ")
+	}
+	if needPlaceHolder {
+		builder.WriteString("(" + placeHolder(len(ti.Columns)-ti.virtualColumnCount) + ")")
+	}
+	return builder.String()
+}
+
+func (ti *TableInfo) genPreSQLUpdate() string {
+	var builder strings.Builder
+	builder.WriteString("UPDATE " + ti.TableName.QuoteString() + " SET ")
+	builder.WriteString(ti.getColumnList(true))
+	return builder.String()
+}
+
+// placeHolder returns a string with n placeholders separated by commas
+// n must be greater or equal than 1, or the function will panic
+func placeHolder(n int) string {
+	var builder strings.Builder
+	builder.Grow((n-1)*2 + 1)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("?")
+	}
+	return builder.String()
+}
+
+func (ti *TableInfo) getColumnList(isUpdate bool) string {
+	var b strings.Builder
+	for i, col := range ti.Columns {
+		if col == nil || ti.ColumnsFlag[col.ID].IsGeneratedColumn() {
+			continue
+		}
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(QuoteName(col.Name.O))
+		if isUpdate {
+			b.WriteString(" = ?")
+		}
+	}
+	return b.String()
+}
+
+func (ti *TableInfo) GetPreInsertSQL() string {
+	return ti.PreSQLs["insert"]
+}
+
+func (ti *TableInfo) GetPreReplaceSQL() string {
+	return ti.PreSQLs["replace"]
+}
+
+func (ti *TableInfo) GetPreUpdateSQL() string {
+	return ti.PreSQLs["update"]
 }
 
 // GetColumnInfo returns the column info by ID
@@ -725,6 +805,9 @@ func WrapTableInfo(schemaID int64, schemaName string, version uint64, info *mode
 	ti.initRowColInfosWithoutVirtualCols()
 	ti.findHandleIndex()
 	ti.initColumnsFlag()
+	// This function must be called after the functions above were called
+	// because it depends on the result of the functions above
+	ti.initPreSQLs()
 	return ti
 }
 


### PR DESCRIPTION
# Performance Optimization for SQL Query Builders

## Overview
This PR significantly enhances the performance of our SQL query building functions, specifically targeting `buildInsert` and `buildUpdate`.

## Key Improvements
- `buildInsert`: 2.5x performance boost
- `buildUpdate`: 1.5x performance boost

## Details
I've optimized the internal logic of these functions to reduce computational overhead and memory allocation. These enhancements will lead to faster query generation, particularly beneficial for operations involving large tables (has many columns).

## Impact
- Faster query generation for INSERT and UPDATE operations
- Reduced latency in database-heavy operations
- Improved overall application performance, especially in data-intensive scenarios

## Testing
Performance benchmarks have been run to verify the improvements.
