### PR TITLE
Fix the cpu cost of too many select statement

### DIFF
--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -134,14 +134,6 @@ func (c *eventBroker) sendWatermark(
 	if counter != nil {
 		counter.Inc()
 	}
-	// select {
-	// case <-ctx.Done():
-	// 	return
-	// case c.messageCh <- resolvedEvent:
-	// 	if counter != nil {
-	// 		counter.Inc()
-	// 	}
-	// }
 }
 
 func (c *eventBroker) runScanWorker(ctx context.Context) {

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -130,15 +130,18 @@ func (c *eventBroker) sendWatermark(
 		common.ResolvedEvent{
 			DispatcherID: dispatcherID,
 			ResolvedTs:   watermark})
-	select {
-	case <-ctx.Done():
-		return
-	case c.messageCh <- resolvedEvent:
-		if counter != nil {
-			counter.Inc()
-		}
+	c.messageCh <- resolvedEvent
+	if counter != nil {
+		counter.Inc()
 	}
-
+	// select {
+	// case <-ctx.Done():
+	// 	return
+	// case c.messageCh <- resolvedEvent:
+	// 	if counter != nil {
+	// 		counter.Inc()
+	// 	}
+	// }
 }
 
 func (c *eventBroker) runScanWorker(ctx context.Context) {


### PR DESCRIPTION
With Select, SendWatermark will occupy 14% cpu. Without it, it only occupy 4%
![image](https://github.com/user-attachments/assets/73a8ba6d-4a1f-4848-970d-45c85725c50b)
![image](https://github.com/user-attachments/assets/92b70005-c5b4-4ec8-90c3-2c1d84d56168)
