### PR TITLE
metrics: use bytes(IEC) instead of bytes(SI)

### DIFF
--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -224,7 +224,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "binBps",
               "logBase": 1,
               "min": "0",
               "show": true
@@ -316,7 +316,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "binBps",
               "logBase": 1,
               "min": "0",
               "show": true
@@ -513,13 +513,13 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "binBps",
               "logBase": 1,
               "min": "0",
               "show": true
             },
             {
-              "format": "bytes",
+              "format": "binBps",
               "logBase": 1,
               "show": false
             }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1594

### What is changed and how it works?
For metrics representing a rate (bytes per second), the correct IEC unit in Grafana is binBps.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
<img width="2558" height="1299" alt="Screenshot 2025-08-04 at 12 00 01" src="https://github.com/user-attachments/assets/b521635b-9583-4cfb-8f3c-e3861f47ca61" />
<img width="2558" height="1299" alt="Screenshot 2025-08-04 at 12 01 05" src="https://github.com/user-attachments/assets/4ade5413-b81a-4684-a5b9-2e9aafb7c48e" />
<img width="2558" height="1299" alt="Screenshot 2025-08-04 at 12 01 42" src="https://github.com/user-attachments/assets/6db687a8-73c5-40f7-952e-37d4117954bf" />
#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
