### PR TITLE
config: add scan limit debug config

### DIFF
--- a/pkg/config/debug.go
+++ b/pkg/config/debug.go
@@ -85,11 +85,13 @@ func NewDefaultSchemaStoreConfig() *SchemaStoreConfig {
 // EventServiceConfig represents config for event service
 type EventServiceConfig struct {
 	ScanTaskQueueSize int `toml:"scan-task-queue-size" json:"scan-task-queue-size"`
+	ScanLimitInBytes  int `toml:"scan-limit-in-bytes" json:"scan-limit-in-bytes"`
 }
 
 // NewDefaultEventServiceConfig return the default event service configuration
 func NewDefaultEventServiceConfig() *EventServiceConfig {
 	return &EventServiceConfig{
 		ScanTaskQueueSize: 1024 * 8,
+		ScanLimitInBytes:  1024 * 1024 * 256, // 256MB
 	}
 }

--- a/pkg/eventservice/dispatcher_stat.go
+++ b/pkg/eventservice/dispatcher_stat.go
@@ -36,8 +36,6 @@ const (
 	minScanLimitInBytes     = 1024 * 128      // 128KB
 	maxScanLimitInBytes     = 1024 * 1024 * 4 // 4MB
 	updateScanLimitInterval = time.Second * 10
-
-	maxScanLimitInBytesPerSecond = 1024 * 1024 * 256 // 256MB/s
 )
 
 // Store the progress of the dispatcher, and the incremental events stats.

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -103,6 +103,8 @@ func newEventBroker(
 	scanTaskQueueSize := config.GetGlobalServerConfig().Debug.EventService.ScanTaskQueueSize / scanWorkerCount
 	sendMessageQueueSize := basicChannelSize * 4
 
+	scanLimitInBytes := config.GetGlobalServerConfig().Debug.EventService.ScanLimitInBytes
+
 	g, ctx := errgroup.WithContext(ctx)
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -124,7 +126,7 @@ func newEventBroker(
 		messageCh:               make([]chan *wrapEvent, sendMessageWorkerCount),
 		cancel:                  cancel,
 		g:                       g,
-		scanRateLimiter:         rate.NewLimiter(rate.Limit(maxScanLimitInBytesPerSecond), maxScanLimitInBytesPerSecond),
+		scanRateLimiter:         rate.NewLimiter(rate.Limit(scanLimitInBytes), scanLimitInBytes),
 	}
 	// Initialize metrics collector
 	c.metricsCollector = newMetricsCollector(c)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #1638 

### What is changed and how it works?

When starting the CDC server, you can use the following configuration to limit the scanning speed of the eventBroker.
```
[debug]
[debug.event-service]
scan-limit-in-bytes = 1048576
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
