### PR TITLE
fix(api): some checks should not be executed if changefeed config and sink uri are not changed

### DIFF
--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -636,6 +636,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		return
 	}
 
+	var configUpdated, sinkURIUpdated bool
 	if updateCfConfig.TargetTs != 0 {
 		if updateCfConfig.TargetTs <= oldCfInfo.StartTs {
 			_ = c.Error(errors.ErrChangefeedUpdateRefused.GenWithStack(
@@ -646,51 +647,56 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		oldCfInfo.TargetTs = updateCfConfig.TargetTs
 	}
 	if updateCfConfig.ReplicaConfig != nil {
+		configUpdated = true
 		oldCfInfo.Config = updateCfConfig.ReplicaConfig.ToInternalReplicaConfig()
 	}
 	if updateCfConfig.SinkURI != "" {
+		sinkURIUpdated = true
 		oldCfInfo.SinkURI = updateCfConfig.SinkURI
 	}
 	if updateCfConfig.StartTs != 0 {
 		_ = c.Error(errors.ErrAPIInvalidParam.GenWithStack("start_ts can not be updated"))
 		return
 	}
-	// verify replicaConfig
-	sinkURIParsed, err := url.Parse(oldCfInfo.SinkURI)
-	if err != nil {
-		_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err))
-		return
-	}
-	err = oldCfInfo.Config.ValidateAndAdjust(sinkURIParsed)
-	if err != nil {
-		_ = c.Error(errors.WrapError(errors.ErrInvalidReplicaConfig, err))
-		return
-	}
 
-	scheme := sinkURIParsed.Scheme
-	topic := strings.TrimFunc(sinkURIParsed.Path, func(r rune) bool {
-		return r == '/'
-	})
-	protocol, _ := config.ParseSinkProtocolFromString(util.GetOrZero(oldCfInfo.Config.Sink.Protocol))
-
-	keyspaceManager := appcontext.GetService[keyspace.KeyspaceManager](appcontext.KeyspaceManager)
-
-	kvStorage, err := keyspaceManager.GetStorage(keyspaceName)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-
-	// use checkpointTs get snapshot from kv storage
-	ineligibleTables, _, err := getVerifiedTables(ctx, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
-	if err != nil {
-		_ = c.Error(errors.ErrChangefeedUpdateRefused.GenWithStackByCause(err))
-		return
-	}
-	if !oldCfInfo.Config.ForceReplicate && !oldCfInfo.Config.IgnoreIneligibleTable {
-		if len(ineligibleTables) != 0 {
-			_ = c.Error(errors.ErrTableIneligible.GenWithStackByArgs(ineligibleTables))
+	if configUpdated || sinkURIUpdated {
+		// verify replicaConfig
+		sinkURIParsed, err := url.Parse(oldCfInfo.SinkURI)
+		if err != nil {
+			_ = c.Error(errors.WrapError(errors.ErrSinkURIInvalid, err))
 			return
+		}
+		err = oldCfInfo.Config.ValidateAndAdjust(sinkURIParsed)
+		if err != nil {
+			_ = c.Error(errors.WrapError(errors.ErrInvalidReplicaConfig, err))
+			return
+		}
+
+		scheme := sinkURIParsed.Scheme
+		topic := strings.TrimFunc(sinkURIParsed.Path, func(r rune) bool {
+			return r == '/'
+		})
+		protocol, _ := config.ParseSinkProtocolFromString(util.GetOrZero(oldCfInfo.Config.Sink.Protocol))
+
+		keyspaceManager := appcontext.GetService[keyspace.KeyspaceManager](appcontext.KeyspaceManager)
+
+		kvStorage, err := keyspaceManager.GetStorage(keyspaceName)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		// use checkpointTs get snapshot from kv storage
+		ineligibleTables, _, err := getVerifiedTables(ctx, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
+		if err != nil {
+			_ = c.Error(errors.ErrChangefeedUpdateRefused.GenWithStackByCause(err))
+			return
+		}
+		if !oldCfInfo.Config.ForceReplicate && !oldCfInfo.Config.IgnoreIneligibleTable {
+			if len(ineligibleTables) != 0 {
+				_ = c.Error(errors.ErrTableIneligible.GenWithStackByArgs(ineligibleTables))
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION

<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2226

### What is changed and how it works?

This PR fixes a bug in the `UpdateChangefeed` API endpoint where sink and table eligibility validations were being executed unnecessarily. Previously, any update request to a changefeed would trigger a full validation of the `sink-uri` and `replica-config`. This could cause the API call to fail due to validation errors that were unrelated to the requested change.

This fix makes the update process more robust and intuitive by ensuring these intensive checks are only performed when the relevant configuration is actually being changed.

#### Detailed changes
1.  **Introduce Tracking Flags:** Two new boolean variables, `configUpdated` and `sinkURIUpdated`, are introduced in the `UpdateChangefeed` function. These flags are used to track whether the `replica-config` or `sink-uri` fields are included in the update request payload.

2.  **Conditional Validation Logic:** The entire block of code responsible for sink validation has been wrapped in a conditional statement: `if configUpdated || sinkURIUpdated`.

3.  **Skipped Checks:** As a result, the following checks are now skipped if the sink URI and replica config are not being updated:
    * Parsing the `sink-uri`.
    * Validating the replica config via `oldCfInfo.Config.ValidateAndAdjust()`.
    * Verifying table eligibility by calling `getVerifiedTables()`, which involves accessing KV storage. This was a significant source of potential failures for unrelated updates.

This change ensures that users can safely update fields without triggering unrelated and potentially failing validation logic, leading to a more reliable API experience.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
