### PR TITLE
fix(ci): pin tidb cluster version to release-8.5 to stabilize ci

### DIFF
--- a/tests/scripts/download-integration-test-binaries.sh
+++ b/tests/scripts/download-integration-test-binaries.sh
@@ -124,6 +124,12 @@ download_jq() {
 download_binaries() {
 	log_green "Downloading binaries..."
 
+	# FIXME: Temporarily pin branches to release-8.5 for stable CI, remove this once https://github.com/tikv/tikv/issues/18986 is resolved
+	TIDB_BRANCH="release-8.5"
+	TIKV_BRANCH="release-8.5"
+	PD_BRANCH="release-8.5"
+	TIFLASH_BRANCH="release-8.5"
+
 	# Get sha1 based on branch name
 	local tidb_branch_sha1=$(get_sha1 "tidb" "$TIDB_BRANCH")
 	local tikv_branch_sha1=$(get_sha1 "tikv" "$TIKV_BRANCH")


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2269

### What is changed and how it works?

**Related Issue:**
* Related to upstream issue: [[tikv/tikv#18986](https://github.com/tikv/tikv/issues/18986)](https://github.com/tikv/tikv/issues/18986)

#### What changes are included in this PR?

This PR introduces a temporary fix to stabilize our CI pipeline, which is currently blocked by a panic in the `master` branch of TiKV.

The primary change is in the `tests/scripts/download-integration-test-binaries.sh` script. I have hardcoded the branches for all TiDB cluster components to `release-8.5`.

Specifically, the following variables are set within the `download_binaries` function:
* `TIDB_BRANCH="release-8.5"`
* `TIKV_BRANCH="release-8.5"`
* `PD_BRANCH="release-8.5"`
* `TIFLASH_BRANCH="release-8.5"`

#### Why is this change necessary?

Our CI was previously pulling the latest `master` binaries for integration tests. Due to the bug described in [[tikv/tikv#18986](https://github.com/tikv/tikv/issues/18986)](https://github.com/tikv/tikv/issues/18986), any test executing index-related queries would cause TiKV to panic, failing the entire test suite. This has blocked all PRs from being merged.

By pinning these versions to the stable `release-8.5` branch, we ensure that our integration tests run against a known-good build of the TiDB cluster, thus avoiding the upstream panic and restoring CI stability.

#### Follow-up Action

This is a **temporary workaround**. A `FIXME` comment has been added to the code to highlight this. We must revert this change and return to using the `master` branches once the upstream TiKV issue is resolved.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
