### PR TITLE
feat(filter): move start ts ddl filter to ShouldIgnoreDDL

### DIFF
--- a/cmd/filter-helper/main.go
+++ b/cmd/filter-helper/main.go
@@ -73,12 +73,12 @@ func runFilter(cmd *cobra.Command, args []string) {
 		fmt.Printf("Table: %s, Not matched filter rule\n", table)
 	case "ddl":
 		ddlType := timodel.ActionCreateTable
-		discard := ft.ShouldDiscardDDL(tableAndSchema[0], tableAndSchema[1], ddlType, nil, 0)
+		discard := ft.ShouldDiscardDDL(tableAndSchema[0], tableAndSchema[1], ddlType, nil)
 		if discard {
 			fmt.Printf("DDL: %s, should be discard by event filter rule\n", ddl)
 			return
 		}
-		ignored, err := ft.ShouldIgnoreDDL(tableAndSchema[0], tableAndSchema[1], ddl, ddlType, nil)
+		ignored, err := ft.ShouldIgnoreDDL(tableAndSchema[0], tableAndSchema[1], ddl, ddlType, nil, 0)
 		if err != nil {
 			fmt.Printf("filter ddl error: %s, error: %v\n", ddl, err)
 			return

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -1613,7 +1613,7 @@ func buildDDLEventCommon(rawEvent *PersistedDDLEvent, tableFilter filter.Filter,
 func filterDDL(tableFilter filter.Filter, schema, table, query string, ddlType model.ActionType, tableInfo *model.TableInfo, startTs uint64) (bool, bool, error) {
 	filtered, notSync := false, false
 	if tableFilter != nil && schema != "" && table != "" {
-		filtered = tableFilter.ShouldDiscardDDL(schema, table, ddlType, common.WrapTableInfo(schema, tableInfo), startTs)
+		filtered = tableFilter.ShouldDiscardDDL(schema, table, ddlType, common.WrapTableInfo(schema, tableInfo))
 	}
 	if !filtered {
 		// If the DDL is not filtered, we need to check whether the DDL should be synced to downstream.
@@ -1630,7 +1630,7 @@ func filterDDL(tableFilter filter.Filter, schema, table, query string, ddlType m
 			// Thus, we set `NotSync` to true.
 			// If the table is not filtered, we should send the DML events to downstream.
 			// So we set `NotSync` to false, and this corresponding DDL can be applied to log service.
-			notSync, err = tableFilter.ShouldIgnoreDDL(schema, table, query, ddlType, common.WrapTableInfo(schema, tableInfo))
+			notSync, err = tableFilter.ShouldIgnoreDDL(schema, table, query, ddlType, common.WrapTableInfo(schema, tableInfo), startTs)
 			if err != nil {
 				return false, false, err
 			}
@@ -2495,7 +2495,7 @@ func buildDDLEventForCreateTables(rawEvent *PersistedDDLEvent, tableFilter filte
 	allFiltered := true
 	for _, info := range rawEvent.MultipleTableInfos {
 		if tableFilter != nil && tableFilter.ShouldDiscardDDL(
-			rawEvent.SchemaName, info.Name.O, model.ActionType(rawEvent.Type), common.WrapTableInfo(rawEvent.SchemaName, info), rawEvent.StartTs) {
+			rawEvent.SchemaName, info.Name.O, model.ActionType(rawEvent.Type), common.WrapTableInfo(rawEvent.SchemaName, info)) {
 			continue
 		}
 		allFiltered = false


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2429

### What is changed and how it works?

This PR resolves the issue where DDLs filtered by `ignore-txn-start-ts` were dropped too early, preventing internal components like the maintainer from receiving critical schema updates.

The core of the problem was that the `start_ts` check was located in `ShouldDiscardDDL`. This meant that a DDL (e.g., `CREATE TABLE`) would be completely removed from the pipeline, and the maintainer would never learn about the new table.

This PR moves the `start_ts` filtering logic from `ShouldDiscardDDL` to `ShouldIgnoreDDL`. With this change, a DDL filtered by its start timestamp will now be:
1.  Processed and used to update the maintainer's internal schema state.
2.  "Ignored" by the dispatcher and not sent to the downstream sink.

This ensures internal schema consistency while still respecting the `ignore-txn-start-ts` configuration.

### Summary of Changes:

* **`pkg/filter/filter.go`**:
    * The `Filter` interface has been modified:
        * `ShouldDiscardDDL`: The `startTs uint64` parameter has been removed.
        * `ShouldIgnoreDDL`: The `startTs uint64` parameter has been added.
    * The implementation of `ShouldDiscardDDL` no longer contains the check for `f.shouldIgnoreStartTs(startTs)`.
    * The implementation of `ShouldIgnoreDDL` now includes the `f.shouldIgnoreStartTs(startTs)` check at the beginning of the function.

* **`pkg/filter/filter_test.go`**:
    * Tests have been updated to reflect the logic change.
    * In `TestShouldDiscardDDL`, the test case for filtering by `IgnoreTxnStartTs` has been removed.
    * In `TestShouldIgnoreDDL`, a new test case has been added to verify that a DDL with a matching `start_ts` is now correctly *ignored*.
    * All function calls to `ShouldDiscardDDL` and `ShouldIgnoreDDL` in the tests have been updated to match the new function signatures.

* **`logservice/schemastore/persist_storage_ddl_handlers.go`**:
    * Calls to `tableFilter.ShouldDiscardDDL` and `tableFilter.ShouldIgnoreDDL` within the `filterDDL` and `buildDDLEventForCreateTables` functions have been updated to align with the modified interface signatures.

* **`cmd/filter-helper/main.go`**:
    * The calls to `ft.ShouldDiscardDDL` and `ft.ShouldIgnoreDDL` in the command-line helper tool have been updated to match the new signatures.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
