### PR TITLE
Add tenfyzhong to the approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,4 +11,5 @@ approvers:
   - sdojjy
   - wk989898
   - wlwilliamx
+  - tenfyzhong
 reviewers: []


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #2555

### What is changed and how it works?

This PR adds `tenfyzhong` to the list of approvers in the `OWNERS` file. This is a routine maintenance task to ensure that the correct individuals are designated for code review and approval within the TiCDC project.

### Check List

#### Tests

- No code

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change only affects the `OWNERS` file and does not modify any code logic.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
