### PR TITLE
Add KeyspaceID to log messages and Span struct to improve visibility into span operations.

### DIFF
--- a/maintainer/replica/replication_span.go
+++ b/maintainer/replica/replication_span.go
@@ -63,6 +63,7 @@ func NewSpanReplication(cfID common.ChangeFeedID,
 		Mode:         mode,
 	})
 	log.Info("new span replication created",
+		zap.Uint32("keyspaceID", span.KeyspaceID),
 		zap.String("changefeedID", cfID.Name()),
 		zap.String("id", id.String()),
 		zap.Int64("schemaID", SchemaID),
@@ -87,6 +88,7 @@ func NewWorkingSpanReplication(
 	r.SetNodeID(nodeID)
 	r.initStatus(status)
 	log.Info("new working span replication created",
+		zap.Uint32("keyspaceID", span.KeyspaceID),
 		zap.String("changefeedID", cfID.Name()),
 		zap.String("id", id.String()),
 		zap.String("nodeID", nodeID.String()),
@@ -134,9 +136,9 @@ func (r *SpanReplication) initGroupID() {
 		KeyspaceID: r.Span.KeyspaceID,
 	}
 	// check if the table is split
-	totalSpan := common.TableIDToComparableSpan(r.Span.KeyspaceID, span.TableID)
+	totalSpan := common.TableIDToComparableSpan(span.KeyspaceID, span.TableID)
 	if !common.IsSubSpan(span, totalSpan) {
-		log.Warn("invalid span range", zap.String("changefeedID", r.ChangefeedID.Name()),
+		log.Warn("invalid span range", zap.Uint32("keyspaceID", span.KeyspaceID), zap.String("changefeedID", r.ChangefeedID.Name()),
 			zap.String("id", r.ID.String()), zap.Int64("tableID", span.TableID),
 			zap.String("totalSpan", totalSpan.String()),
 			zap.String("start", hex.EncodeToString(span.StartKey)),

--- a/maintainer/split/region_count_splitter.go
+++ b/maintainer/split/region_count_splitter.go
@@ -110,9 +110,10 @@ func (m *regionCountSplitter) split(
 			return []*heartbeatpb.TableSpan{span}
 		}
 		spans = append(spans, &heartbeatpb.TableSpan{
-			TableID:  span.TableID,
-			StartKey: startKey,
-			EndKey:   endKey,
+			TableID:    span.TableID,
+			StartKey:   startKey,
+			EndKey:     endKey,
+			KeyspaceID: span.KeyspaceID,
 		},
 		)
 
@@ -132,6 +133,7 @@ func (m *regionCountSplitter) split(
 	spans[0].StartKey = span.StartKey
 	spans[len(spans)-1].EndKey = span.EndKey
 	log.Info("split span by region count",
+		zap.Uint32("keyspaceID", span.KeyspaceID),
 		zap.String("changefeed", m.changefeedID.Name()),
 		zap.String("span", span.String()),
 		zap.Int("spans", len(spans)),


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses an issue where the `KeyspaceID` was not being correctly propagated or logged in certain scenarios related to span replication and splitting. This can lead to incorrect data routing and potential data loss if the `KeyspaceID` is not accurately tracked.

Issue Number: close #2591

### What is changed and how it works?

The changes in this PR focus on ensuring the `KeyspaceID` is consistently included in log messages and `TableSpan` structures.

* **`replication_span.go`**:
  * Added `zap.Uint32("keyspaceID", span.KeyspaceID)` to the log messages in `NewSpanReplication` and `NewWorkingSpanReplication`. This ensures that when new span replications are created, the `KeyspaceID` is logged for easier debugging and auditing.
  * Added `zap.Uint32("keyspaceID", span.KeyspaceID)` to the log message in the `log.Warn` statement within `initGroupID`. This helps in identifying the specific keyspace involved when an invalid span range is detected.

* **`region_count_splitter.go`**:
  * Added `KeyspaceID: span.KeyspaceID` to the `heartbeatpb.TableSpan` struct when splitting spans by region count. This ensures that the `KeyspaceID` is part of the generated `TableSpan` objects, allowing for correct identification of the keyspace associated with the split regions.
  * Added `zap.Uint32("keyspaceID", span.KeyspaceID)` to the log message in `split`. This logs the `KeyspaceID` when spans are split by region count, providing better visibility into the splitting process.

### Check List

#### Tests

* Unit test
* Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

No, these changes are primarily for logging and data structure population, and should not introduce performance regressions or break compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, these changes are internal and do not require documentation updates.

### Release note

```release-note
None
```
