### PR TITLE
fix(ci): improve robustness of integration test cleanup script

### DIFF
--- a/tests/integration_tests/_utils/cleanup_process
+++ b/tests/integration_tests/_utils/cleanup_process
@@ -15,8 +15,8 @@ while [ $counter -lt $retry_count ]; do
 		exit 0
 	fi
 	((counter += 1))
-	sleep 0.5
-	killall $process || true
+	sleep 1
+	killall -9 $process || true
 	echo "wait process $process exit for $counter-th time..."
 done
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2650

### What is changed and how it works?

This PR addresses intermittent failures in the integration test suite caused by the `cleanup_process` script failing to terminate processes. The existing script was not forceful enough to handle processes that became unresponsive.

This change makes the cleanup mechanism more reliable by ensuring lingering processes are terminated effectively.

### Description of Changes

The script `tests/integration_tests/_utils/cleanup_process` has been modified in two ways:

1.  **Use `killall -9` for Forceful Termination**
    * **Previous Behavior:** The script used `killall $process`, which sends a `SIGTERM` signal. This is a graceful shutdown request that a process can ignore.
    * **New Behavior:** The script now uses `killall -9 $process`, which sends the `SIGKILL` signal.
    * **Reasoning:** Unlike `SIGTERM`, the `SIGKILL` signal cannot be caught or ignored by the process. It forces the operating system to terminate the process immediately. This guarantees that a hung or unresponsive process will be cleaned up, preventing the script from failing.

2.  **Increase Sleep Interval to 1 Second**
    * **Previous Behavior:** The script waited for `0.5` seconds between kill attempts (`sleep 0.5`).
    * **New Behavior:** The wait interval has been increased to `1` second (`sleep 1`).
    * **Reasoning:** Increasing the delay provides a longer grace period for the process to terminate after the signal is sent. This is especially helpful on slower or heavily loaded systems, reducing the likelihood of the script making unnecessary and repeated kill attempts before the process has had a chance to exit.

Together, these changes significantly increase the reliability of our integration test cleanup process, leading to more stable CI/CD runs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
