### PR TITLE
chore(version): update fallback release version to v8.5.4-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ifeq ($(RELEASE_VERSION),)
 	RELEASE_VERSION := $(shell git describe --tags --dirty)
 endif
 ifeq ($(RELEASE_VERSION),)
-	RELEASE_VERSION := v8.5.4-release.1
+	RELEASE_VERSION := v8.5.4-release
 endif
 
 # Version LDFLAGS.


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2675

### What is changed and how it works?

This pull request updates the hardcoded fallback `RELEASE_VERSION` in the `Makefile`. The change aligns the default version with the new, planned release version of `v8.5.4-release`.

**Motivation**

The previous fallback version, `v9.0.0-alpha`, was a placeholder and is now outdated. To ensure all builds correctly identify their version, this default value needs to be updated.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
