### PR TITLE
maintainer: fix data race in Controller.taskHandles concurrent access

### DIFF
--- a/maintainer/maintainer_controller_bootstrap.go
+++ b/maintainer/maintainer_controller_bootstrap.go
@@ -275,6 +275,7 @@ func (c *Controller) initializeComponents(
 	c.barrier = NewBarrier(c.spanController, c.operatorController, c.cfConfig.Scheduler.EnableTableAcrossNodes, allNodesResp, common.DefaultMode)
 
 	// Start scheduler
+	c.taskHandlesMu.Lock()
 	c.taskHandles = append(c.taskHandles, c.schedulerController.Start(c.taskPool)...)
 
 	if c.enableRedo {
@@ -282,6 +283,7 @@ func (c *Controller) initializeComponents(
 	}
 	// Start operator controller
 	c.taskHandles = append(c.taskHandles, c.taskPool.Submit(c.operatorController, time.Now()))
+	c.taskHandlesMu.Unlock()
 }
 
 func (c *Controller) prepareSchemaInfoResponse(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/ticdc/issues/2830

This PR fixes a data race issue in the `capture_session_done_during_task` integration test where `Controller.taskHandles` slice was accessed concurrently without proper synchronization.

**Root Cause**:
- **Write operation**: `Controller.initializeComponents()` appends task handles during maintainer bootstrap
- **Read operation**: `Manager.Close()` iterates through maintainers and accesses `controller.taskHandles` during server shutdown
- **Race condition**: These operations can happen simultaneously when server shuts down during maintainer initialization

### What is changed and how it works?

**Solution**: Added `sync.RWMutex` to protect concurrent access to `taskHandles` slice.

**Changes**:
1. **Added mutex field**:
   ```go
   taskHandles   []*threadpool.TaskHandle
   taskHandlesMu sync.RWMutex  // Protects taskHandles access
   ```

2. **Protected write operations** in `initializeComponents()`:
   ```go
   c.taskHandlesMu.Lock()
   c.taskHandles = append(c.taskHandles, ...)  // All append operations
   c.taskHandlesMu.Unlock()
   ```

3. **Protected read operations** in `Stop()`:
   ```go
   c.taskHandlesMu.RLock()
   for _, handler := range c.taskHandles {
       handler.Cancel()
   }
   c.taskHandlesMu.RUnlock()
   ```

### Test Coverage

- ✅ Integration test `capture_session_done_during_task` passes
- ✅ No data race detected with `go test -race`
- ✅ No performance regression

### Release note

```release-note
- Fixed data race in maintainer Controller.taskHandles concurrent access during server shutdown
```