### PR TITLE
Fix: Return nil on keyspace meta load failure to prevent panics

### DIFF
--- a/maintainer/maintainer_manager.go
+++ b/maintainer/maintainer_manager.go
@@ -234,8 +234,8 @@ func (m *Manager) onAddMaintainerRequest(req *heartbeatpb.AddMaintainerRequest) 
 	keyspaceManager := appcontext.GetService[keyspace.Manager](appcontext.KeyspaceManager)
 	keyspaceMeta, err := keyspaceManager.LoadKeyspace(ctx, cfID.Keyspace())
 	if err != nil {
-		// BUG tenfyzhong 2025-09-11 17:29:08 how to process err
 		log.Error("load keyspace meta fail", zap.String("keyspace", cfID.Keyspace()))
+		return nil
 	}
 
 	maintainer := NewMaintainer(cfID, m.conf, info, m.nodeInfo, m.taskScheduler, req.CheckpointTs, req.IsNewChangefeed, keyspaceMeta.Id)
@@ -264,8 +264,8 @@ func (m *Manager) onRemoveMaintainerRequest(msg *messaging.TargetMessage) *heart
 		keyspaceManager := appcontext.GetService[keyspace.Manager](appcontext.KeyspaceManager)
 		keyspaceMeta, err := keyspaceManager.LoadKeyspace(ctx, cfID.Keyspace())
 		if err != nil {
-			// BUG tenfyzhong 2025-09-11 17:29:08 how to process err
 			log.Error("load keyspace meta fail", zap.String("keyspace", cfID.Keyspace()))
+			return nil
 		}
 
 		// it's cascade remove, we should remove the dispatcher from all node


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses an issue where the TiCDC maintainer manager was not properly handling errors when loading keyspace metadata. Previously, if `keyspaceManager.LoadKeyspace` returned an error, the program would log the error but continue execution, potentially leading to unexpected behavior or crashes.

Issue Number: close #2912

### What is changed and how it works?

The changes in this PR ensure that when an error occurs during the loading of keyspace metadata in both `onAddMaintainerRequest` and `onRemoveMaintainerRequest` functions, the function now returns `nil` immediately after logging the error. This prevents further execution with incomplete or invalid data, making the error handling more robust.

### Check List

#### Tests

* Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change is a bug fix and should not introduce performance regressions or break compatibility. It improves error handling.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
