### PR TITLE
fix(middleware): fix bug by calling rows.Next() before rows.Scan() in doVerify

### DIFF
--- a/api/middleware/authenticate_middleware.go
+++ b/api/middleware/authenticate_middleware.go
@@ -139,13 +139,17 @@ func doVerify(dsnStr string) error {
 		}
 	}()
 
-	var name, value string
-	err = rows.Scan(&name, &value)
-	if err != nil {
-		log.Warn("failed to get ssl cipher", zap.Error(err),
-			zap.String("username", dsn.User))
+	if rows.Next() {
+		var name, value string
+		err = rows.Scan(&name, &value)
+		if err != nil {
+			log.Warn("failed to get ssl cipher", zap.Error(err),
+				zap.String("username", dsn.User))
+		}
+		log.Info("verify tidb user successfully", zap.String("username", dsn.User),
+			zap.String("sslCipherName", name), zap.String("sslCipherValue", value))
+	} else {
+		log.Warn("no ssl cipher found", zap.String("username", dsn.User))
 	}
-	log.Info("verify tidb user successfully", zap.String("username", dsn.User),
-		zap.String("sslCipherName", name), zap.String("sslCipherValue", value))
 	return nil
 }


### PR DESCRIPTION


<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #2939

### What is changed and how it works?

This PR fixes a bug in the `doVerify` function within `authenticate_middleware.go`. The previous code was attempting to call `rows.Scan()` directly on a `*sql.Rows` object without first calling `rows.Next()` to advance to the first result row.

According to the `database/sql` package conventions, `rows.Next()` must be called before every `rows.Scan()` to prepare the next (or first) row for reading.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
