### PR TITLE
maintainer: accept checkpoint fallback when seq increases

### DIFF
--- a/tests/integration_tests/checkpoint_race_ddl_crash/run.sh
+++ b/tests/integration_tests/checkpoint_race_ddl_crash/run.sh
@@ -184,7 +184,7 @@ function run() {
 
 	echo "All workloads completed"
 
-	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 500
+	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 100
 
 	echo "=== Checkpoint race condition test completed successfully ==="
 }

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -151,7 +151,7 @@ storage_groups=(
 	# G05
 	'move_table drop_many_tables'
 	# G06
-	'cdc default_value'
+	'cdc default_value checkpoint_race_ddl_crash'
 	# G07
 	'merge_table resolve_lock force_replicate_table'
 	# G08


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/2943

### What is changed and how it works?

#### Problem
  - In scenarios that rapidly create tables while repeatedly crashing (e.g. checkpoint_race_ddl_crash), newly spawned dispatchers start with older start-ts but higher heartbeat seq.
  - The maintainer rejected those heartbeats because checkpointTs fell back, so etcd kept the stale (larger) checkpoint.
  - After the next restart, TiCDC resumed from that stale checkpoint and skipped the real events in between, leading to data loss for storage sink consumers.

#### Summary
- allow updating checkpointTsByCapture when heartbeat seq increases, even if checkpointTs rewinds
- apply the same handling to redoTsByCapture for redo watermarks

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
