### PR TITLE
changefeed: keep nodeTasks clean when stopping changefeeds

### DIFF
--- a/coordinator/changefeed/changefeed_db.go
+++ b/coordinator/changefeed/changefeed_db.go
@@ -121,13 +121,14 @@ func (db *ChangefeedDB) StopByChangefeedID(cfID common.ChangeFeedID, remove bool
 	if !ok {
 		return ""
 	}
+
+	// Remove from replication tracking
+	db.RemoveReplicaWithoutLock(cf)
+
 	nodeID := cf.GetNodeID()
 	if nodeID != "" {
 		cf.SetNodeID("")
 	}
-
-	// Remove from replication tracking
-	db.RemoveReplicaWithoutLock(cf)
 
 	if remove {
 		log.Info("remove changefeed", zap.String("changefeed", cf.ID.String()))


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/2968

### What is changed and how it works?

- ensure StopByChangefeedID removes replicas before clearing their node IDs so node task maps
    are updated correctly
- extend TestStopByChangefeedID and TestRemoveChangefeed to assert GetByNodeID/
  GetTaskSizePerNode no longer report the stopped replicas, guarding regressions from the
  previous ordering bug

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
