### PR TITLE
Refactor PID retrieval to use a dedicated function for clarity and maintainability

### DIFF
--- a/tests/integration_tests/availability/owner.sh
+++ b/tests/integration_tests/availability/owner.sh
@@ -139,7 +139,7 @@ function test_owner_retryable_error() {
 	# run another server
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_owner_retryable_error.server2 --addr "127.0.0.1:8301"
 	ensure $MAX_RETRIES "$CDC_BINARY cli capture list 2>&1 | grep -v \"$owner_id\" | grep -v cluster_id | grep id"
-	capture_pid=$(pgrep $CDC_BINARY | awk '{print $1}' | grep -v "$owner_pid")
+	capture_pid=$(get_cdc_pid 127.0.0.1 8301)
 	capture_id=$($CDC_BINARY cli capture list --server 'http://127.0.0.1:8301' 2>&1 | awk -F '"' '/\"id/{print $4}' | grep -v "$owner_id")
 	echo "capture_id:" $capture_id
 	# resign the first capture, the second capture campaigns to be owner.

--- a/tests/integration_tests/checkpoint_race_ddl_crash/run.sh
+++ b/tests/integration_tests/checkpoint_race_ddl_crash/run.sh
@@ -91,7 +91,7 @@ function simulate_crashes() {
 		echo "Simulating crash #$((crash_count + 1))"
 
 		# Kill CDC processes
-		cdc_pid_1=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8300")
+		cdc_pid_1=$(get_cdc_pid 127.0.0.1 8300)
 		if [ -z "$cdc_pid_1" ]; then
 			continue
 		fi

--- a/tests/integration_tests/ddl_for_split_tables_with_failover/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_failover/run.sh
@@ -91,7 +91,7 @@ function kill_server() {
 	while true; do
 		case $((RANDOM % 3)) in
 		0)
-			cdc_pid_1=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8300")
+			cdc_pid_1=$(get_cdc_pid 127.0.0.1 8300)
 			if [ -z "$cdc_pid_1" ]; then
 				continue
 			fi
@@ -101,7 +101,7 @@ function kill_server() {
 			run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0-$count" --addr "127.0.0.1:8300"
 			;;
 		1)
-			cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+			cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 			if [ -z "$cdc_pid_2" ]; then
 				continue
 			fi

--- a/tests/integration_tests/ddl_for_split_tables_with_merge_and_split/run.sh
+++ b/tests/integration_tests/ddl_for_split_tables_with_merge_and_split/run.sh
@@ -83,7 +83,7 @@ main() {
 	sleep 10
 
 	# restart node2 to disable failpoint
-	cdc_pid_1=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_1=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_1
 	sleep 5
 	export GO_FAILPOINTS=''

--- a/tests/integration_tests/fail_over_ddl_C/run.sh
+++ b/tests/integration_tests/fail_over_ddl_C/run.sh
@@ -81,7 +81,7 @@ function failOverCaseC-1() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")
@@ -136,7 +136,7 @@ function failOverCaseC-2() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")
@@ -198,7 +198,7 @@ function failOverCaseC-3() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")
@@ -260,7 +260,7 @@ function failOverCaseC-4() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")

--- a/tests/integration_tests/fail_over_ddl_F/run.sh
+++ b/tests/integration_tests/fail_over_ddl_F/run.sh
@@ -84,7 +84,7 @@ function failOverCaseF-1() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")
@@ -137,7 +137,7 @@ function failOverCaseF-2() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")
@@ -198,7 +198,7 @@ function failOverCaseF-3() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")
@@ -259,7 +259,7 @@ function failOverCaseF-4() {
 	check_coordinator_and_maintainer "127.0.0.1:8300" "test" 60
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "1-1" --addr "127.0.0.1:8301"
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 
 	# move table 1 to node 2
 	table_id=$(get_table_id "fail_over_ddl_test" "test1")

--- a/tests/integration_tests/fail_over_ddl_J/run.sh
+++ b/tests/integration_tests/fail_over_ddl_J/run.sh
@@ -96,7 +96,7 @@ function failOverCaseJ-1() {
 
 	sleep 10 # ensure dispatcher gets pass action
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 	# restart cdc server
 	export GO_FAILPOINTS=''
@@ -154,7 +154,7 @@ function failOverCaseJ-2() {
 
 	sleep 10 # ensure dispatcher gets pass action
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 	export GO_FAILPOINTS=''
 	# restart cdc server
@@ -217,7 +217,7 @@ function failOverCaseJ-3() {
 
 	sleep 10 # ensure dispatcher gets pass action
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 	# restart cdc server
 	export GO_FAILPOINTS=''
@@ -284,7 +284,7 @@ function failOverCaseJ-4() {
 
 	sleep 10 # ensure dispatcher gets pass action
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 
 	export GO_FAILPOINTS=''

--- a/tests/integration_tests/fail_over_ddl_L/run.sh
+++ b/tests/integration_tests/fail_over_ddl_L/run.sh
@@ -92,7 +92,7 @@ function failOverCaseL-1() {
 	# ensure the dispatcher pass the ddl event
 	sleep 15
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 
 	export GO_FAILPOINTS=''
@@ -144,7 +144,7 @@ function failOverCaseL-2() {
 	# ensure the dispatcher pass the ddl event
 	sleep 15
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 
 	export GO_FAILPOINTS=''
@@ -205,7 +205,7 @@ function failOverCaseL-3() {
 	# ensure the dispatcher pass the ddl event
 	sleep 15
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 
 	export GO_FAILPOINTS=''
@@ -271,7 +271,7 @@ function failOverCaseL-4() {
 	# ensure the dispatcher pass the ddl event
 	sleep 15
 
-	cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+	cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 	kill_cdc_pid $cdc_pid_2
 
 	export GO_FAILPOINTS=''

--- a/tests/integration_tests/fail_over_ddl_mix/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix/run.sh
@@ -155,7 +155,7 @@ function kill_server() {
 	for count in {1..10}; do
 		case $((RANDOM % 2)) in
 		0)
-			cdc_pid_1=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8300")
+			cdc_pid_1=$(get_cdc_pid 127.0.0.1 8300)
 			if [ -z "$cdc_pid_1" ]; then
 				continue
 			fi
@@ -165,7 +165,7 @@ function kill_server() {
 			run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0-$count" --addr "127.0.0.1:8300"
 			;;
 		1)
-			cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+			cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 			if [ -z "$cdc_pid_2" ]; then
 				continue
 			fi

--- a/tests/integration_tests/fail_over_ddl_mix_with_syncpoint/run.sh
+++ b/tests/integration_tests/fail_over_ddl_mix_with_syncpoint/run.sh
@@ -95,7 +95,7 @@ function kill_server() {
 	for count in {1..10}; do
 		case $((RANDOM % 2)) in
 		0)
-			cdc_pid_1=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8300")
+			cdc_pid_1=$(get_cdc_pid 127.0.0.1 8300)
 			if [ -z "$cdc_pid_1" ]; then
 				continue
 			fi
@@ -105,7 +105,7 @@ function kill_server() {
 			run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix "0-$count" --addr "127.0.0.1:8300"
 			;;
 		1)
-			cdc_pid_2=$(pgrep -f "$CDC_BINARY.*--addr 127.0.0.1:8301")
+			cdc_pid_2=$(get_cdc_pid 127.0.0.1 8301)
 			if [ -z "$cdc_pid_2" ]; then
 				continue
 			fi

--- a/tests/integration_tests/multi_changefeeds/run.sh
+++ b/tests/integration_tests/multi_changefeeds/run.sh
@@ -85,7 +85,7 @@ function run() {
 	# Stop one CDC server (simulate node failure)
 	echo "Stopping one CDC server to simulate node failure..."
 	# Find and kill one of the CDC processes (not the first one)
-	CDC_PIDS=$(pgrep -f "cdc.test.*8301")
+	CDC_PIDS=$(get_cdc_pid 127.0.0.1 8301)
 	if [ ! -z "$CDC_PIDS" ]; then
 		FIRST_PID=$(echo $CDC_PIDS | awk '{print $1}')
 		kill $FIRST_PID

--- a/tests/integration_tests/random_drop_message/run.sh
+++ b/tests/integration_tests/random_drop_message/run.sh
@@ -80,7 +80,7 @@ function kill_and_restart_nodes() {
 		local node_addr="127.0.0.1:830${node_to_kill}"
 
 		echo "[$(date)] Randomly selected CDC node $node_to_kill to kill (addr: $node_addr)..."
-		cdc_pid=$(pgrep -f "$CDC_BINARY.*--addr $node_addr")
+		cdc_pid=$(get_cdc_pid 127.0.0.1 830${node_to_kill})
 		if [ -n "$cdc_pid" ]; then
 			kill_cdc_pid $cdc_pid
 			echo "[$(date)] CDC node $node_to_kill killed, PID: $cdc_pid"


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses an issue where integration tests were using `pgrep -f` to find TiCDC process IDs. This method can be unreliable as it might match other processes or fail to find the correct one if the command line arguments are not exactly as expected. This can lead to flaky tests and difficulty in debugging.

The solution is to introduce a helper function `get_cdc_pid` that specifically queries the TiCDC process based on its listening address, making the PID retrieval more robust and less prone to errors.

Issue Number: close #2989

### What is changed and how it works?

- A new bash function `get_cdc_pid` has been added to the integration test framework. This function takes an IP address and port as arguments and uses `pgrep` with a more precise pattern to find the PID of the TiCDC server listening on that specific address.
- All instances in the integration tests that previously used `pgrep -f "$CDC_BINARY.*--addr <ip>:<port>"` have been updated to use the new `get_cdc_pid <ip> <port>` function. This ensures a more reliable way of identifying and managing TiCDC process IDs during test execution.

### Check List

#### Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change only affects how PIDs are retrieved within integration tests and does not impact the TiCDC server's runtime performance or compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, this is an internal test infrastructure improvement and does not require any documentation updates.

### Release note

```release-note
None
```
