### PR TITLE
Add build constraint to exclude migrate tests from nextgen builds

### DIFF
--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nextgen
+
 package migrate
 
 import (


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses an issue where the `migrate_test.go` file was being compiled in the `nextgen` build mode, leading to unexpected test behavior or failures. The `//go:build !nextgen` directive ensures that this test file is excluded from the `nextgen` build.

Issue Number: close #3039

### What is changed and how it works?

- Added the `//go:build !nextgen` build tag to `pkg/migrate/migrate_test.go`. This explicitly tells the Go compiler to exclude this file when building with the `nextgen` tag.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No, this change only affects which test files are compiled in specific build modes and does not alter any runtime behavior or existing functionality.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
