### PR TITLE
[DNM] Test PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@
 	unit_test_in_verify_ci integration_test_build integration_test_build_fast integration_test_mysql integration_test_kafka integration_test_storage integration_test_pulsar \
 	generate-next-gen-grafana
 
-
 FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1  }  }'
 
 PROJECT=ticdc


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

### What is changed and how it works?

This PR removes the `FAIL_ON_STDOUT` variable from the Makefile. This variable was defined but not used, making it redundant. Removing it simplifies the Makefile without affecting any functionality.

### Check List

#### Tests

- No code

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change does not affect performance or compatibility as the variable was unused.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
