### PR TITLE
Refactor: Remove GcState

### DIFF
--- a/cmd/cdc/cli/cli_unsafe_reset.go
+++ b/cmd/cdc/cli/cli_unsafe_reset.go
@@ -17,15 +17,12 @@ import (
 	"context"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/cmd/cdc/factory"
 	"github.com/pingcap/ticdc/cmd/util"
-	"github.com/pingcap/ticdc/pkg/config/kerneltype"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/txnutil/gc"
 	"github.com/spf13/cobra"
 	pd "github.com/tikv/pd/client"
-	"go.uber.org/zap"
 )
 
 // unsafeResetOptions defines flags for the `cli unsafe reset` command.
@@ -89,23 +86,9 @@ func (o *unsafeResetOptions) run(cmd *cobra.Command) error {
 		return errors.Trace(err)
 	}
 
-	if kerneltype.IsClassic() {
-		err := gc.UnifyDeleteGcSafepoint(ctx, o.pdClient, 0, o.etcdClient.GetGCServiceID())
-		if err != nil {
-			return errors.Trace(err)
-		}
-	} else {
-		// Next gen mode, remove gc barriers
-		_, infoMap, err := o.etcdClient.GetChangeFeeds(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		keyspaceNameMap := make(map[string]struct{})
-		for key := range infoMap {
-			keyspaceNameMap[key.Keyspace] = struct{}{}
-		}
-		removeKeyspaceGCBarrier(ctx, o.pdClient, o.etcdClient.GetGCServiceID(), keyspaceNameMap)
+	err = gc.UnifyDeleteGcSafepoint(ctx, o.pdClient, 0, o.etcdClient.GetGCServiceID())
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	cmd.Println("reset and all metadata truncated in PD!")
@@ -130,19 +113,4 @@ func newCmdReset(f factory.Factory, commonOptions *unsafeCommonOptions) *cobra.C
 	o.addFlags(command)
 
 	return command
-}
-
-func removeKeyspaceGCBarrier(ctx context.Context, pdCli pd.Client, serviceID string, keyspaceNameMap map[string]struct{}) {
-	for keyspace := range keyspaceNameMap {
-		keyspaceMeta, err := pdCli.LoadKeyspace(ctx, keyspace)
-		if err != nil {
-			log.Warn("load keyspace error", zap.String("keyspace", keyspace), zap.Error(err))
-			continue
-		}
-		err = gc.UnifyDeleteGcSafepoint(ctx, pdCli, keyspaceMeta.Id, serviceID)
-		if err != nil {
-			log.Warn("DeleteGcSafepoint error", zap.Uint32("keyspaceID", keyspaceMeta.Id), zap.String("keyspace", keyspace), zap.String("serviceID", serviceID), zap.Error(err))
-			continue
-		}
-	}
 }

--- a/coordinator/changefeed/changefeed_db.go
+++ b/coordinator/changefeed/changefeed_db.go
@@ -318,37 +318,6 @@ func (db *ChangefeedDB) CalculateGlobalGCSafepoint() uint64 {
 	return minCpts
 }
 
-// CalculateKeyspaceGCBarrier calculates the minimum keyspace-based checkpointTs of all changefeeds that replicating the upstream TiDB cluster.
-func (db *ChangefeedDB) CalculateKeyspaceGCBarrier() map[common.KeyspaceMeta]uint64 {
-	db.lock.RLock()
-	defer db.lock.RUnlock()
-
-	keyspaceGCBarrier := make(map[common.KeyspaceMeta]uint64)
-	for _, cf := range db.changefeeds {
-		info := cf.GetInfo()
-		if info == nil || !info.NeedBlockGC() {
-			continue
-		}
-
-		meta := common.KeyspaceMeta{
-			ID:   info.KeyspaceID,
-			Name: cf.ID.Keyspace(),
-		}
-
-		minCpts := keyspaceGCBarrier[meta]
-		if minCpts == 0 {
-			minCpts = math.MaxUint64
-		}
-
-		checkpointTs := cf.GetLastSavedCheckPointTs()
-		if minCpts > checkpointTs {
-			keyspaceGCBarrier[meta] = checkpointTs
-		}
-
-	}
-	return keyspaceGCBarrier
-}
-
 // ReplaceStoppedChangefeed updates the stopped changefeed
 func (db *ChangefeedDB) ReplaceStoppedChangefeed(cf *config.ChangeFeedInfo) {
 	db.lock.Lock()

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -840,10 +840,6 @@ func (c *Controller) calculateGlobalGCSafepoint() uint64 {
 	return c.changefeedDB.CalculateGlobalGCSafepoint()
 }
 
-func (c *Controller) calculateKeyspaceGCBarrier() map[common.KeyspaceMeta]uint64 {
-	return c.changefeedDB.CalculateKeyspaceGCBarrier()
-}
-
 func shouldRunChangefeed(state config.FeedState) bool {
 	switch state {
 	case config.StateStopped, config.StateFailed, config.StateFinished:

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -584,14 +584,6 @@ var (
 		"updating service safepoint failed",
 		errors.RFCCodeText("CDC:ErrUpdateServiceSafepointFailed"),
 	)
-	ErrUpdateGCBarrierFailed = errors.Normalize(
-		"updating gc barrier failed",
-		errors.RFCCodeText("CDC:ErrUpdateGCBarrierFailed"),
-	)
-	ErrGetGCBarrierFailed = errors.Normalize(
-		"get gc barrier failed",
-		errors.RFCCodeText("CDC:ErrGetGCBarrierFailed"),
-	)
 	ErrLoadKeyspaceFailed = errors.Normalize(
 		"loading keyspace failed",
 		errors.RFCCodeText("CDC:ErrLoadKeyspaceFailed"),

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -23,9 +23,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/common"
 	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/config"
-	"github.com/pingcap/ticdc/pkg/config/kerneltype"
 	"github.com/pingcap/ticdc/pkg/errors"
-	"github.com/pingcap/ticdc/pkg/keyspace"
 	"github.com/pingcap/ticdc/pkg/pdutil"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
@@ -43,15 +41,6 @@ type Manager interface {
 	// Set `forceUpdate` to force Manager update.
 	TryUpdateGCSafePoint(ctx context.Context, checkpointTs common.Ts, forceUpdate bool) error
 	CheckStaleCheckpointTs(ctx context.Context, changefeedID common.ChangeFeedID, checkpointTs common.Ts) error
-	// TryUpdateKeyspaceGCBarrier tries to update gc barrier of a keyspace
-	TryUpdateKeyspaceGCBarrier(ctx context.Context, keyspaceID uint32, keyspaceName string, checkpointTs common.Ts, forceUpdate bool) error
-}
-
-// keyspaceGCBarrierInfo is the gc info for a keyspace
-type keyspaceGCBarrierInfo struct {
-	lastSucceededTime time.Time
-	lastSafePointTs   uint64
-	isTiCDCBlockGC    bool
 }
 
 type gcManager struct {
@@ -69,11 +58,6 @@ type gcManager struct {
 	// key => keyspaceID
 	// value => time.Time
 	keyspaceLastUpdatedTimeMap sync.Map
-
-	// keyspaceGCBarrierInfoMap store gc info of each keyspace
-	// key => keyspaceID
-	// value => keyspaceGcInfo
-	keyspaceGCBarrierInfoMap sync.Map
 }
 
 // NewManager creates a new Manager.
@@ -140,10 +124,7 @@ func (m *gcManager) TryUpdateGCSafePoint(
 func (m *gcManager) CheckStaleCheckpointTs(
 	ctx context.Context, changefeedID common.ChangeFeedID, checkpointTs common.Ts,
 ) error {
-	if kerneltype.IsClassic() {
-		return m.checkStaleCheckPointTsGlobal(changefeedID, checkpointTs)
-	}
-	return m.checkStaleCheckpointTsKeyspace(ctx, changefeedID, checkpointTs)
+	return m.checkStaleCheckPointTsGlobal(changefeedID, checkpointTs)
 }
 
 func checkStaleCheckpointTs(
@@ -180,85 +161,6 @@ func checkStaleCheckpointTs(
 	return nil
 }
 
-func (m *gcManager) checkStaleCheckpointTsKeyspace(ctx context.Context, changefeedID common.ChangeFeedID, checkpointTs common.Ts) error {
-	keyspaceManager := appcontext.GetService[keyspace.Manager](appcontext.KeyspaceManager)
-	keyspaceMeta, err := keyspaceManager.LoadKeyspace(ctx, changefeedID.Keyspace())
-	if err != nil {
-		return err
-	}
-
-	barrierInfo := new(keyspaceGCBarrierInfo)
-	o, ok := m.keyspaceGCBarrierInfoMap.Load(keyspaceMeta.Id)
-	if ok {
-		barrierInfo = o.(*keyspaceGCBarrierInfo)
-	}
-
-	return checkStaleCheckpointTs(changefeedID, checkpointTs, m.pdClock, barrierInfo.isTiCDCBlockGC, barrierInfo.lastSafePointTs, m.gcTTL)
-}
-
 func (m *gcManager) checkStaleCheckPointTsGlobal(changefeedID common.ChangeFeedID, checkpointTs common.Ts) error {
 	return checkStaleCheckpointTs(changefeedID, checkpointTs, m.pdClock, m.isTiCDCBlockGC.Load(), m.lastSafePointTs.Load(), m.gcTTL)
-}
-
-func (m *gcManager) TryUpdateKeyspaceGCBarrier(ctx context.Context, keyspaceID uint32, keyspaceName string, checkpointTs common.Ts, forceUpdate bool) error {
-	var lastUpdatedTime time.Time
-	if lastUpdatedTimeResult, ok := m.keyspaceLastUpdatedTimeMap.Load(keyspaceID); ok {
-		lastUpdatedTime = lastUpdatedTimeResult.(time.Time)
-	}
-	if time.Since(lastUpdatedTime) < gcSafepointUpdateInterval && !forceUpdate {
-		return nil
-	}
-	m.keyspaceLastUpdatedTimeMap.Store(keyspaceID, time.Now())
-
-	gcCli := m.pdClient.GetGCStatesClient(keyspaceID)
-	ttl := time.Duration(m.gcTTL) * time.Second
-	_, err := SetGCBarrier(ctx, gcCli, m.gcServiceID, checkpointTs, ttl)
-	// align to classic mode, if the checkpointTs is less than TxnSafePoint,
-	// we can also use the TxnSafePoint as the lastSafePointTs
-	if err != nil && !errors.IsGCBarrierTSBehindTxnSafePointError(err) {
-		log.Warn("updateKeyspaceGCBarrier failed",
-			zap.Uint32("keyspaceID", keyspaceID),
-			zap.Uint64("safePointTs", checkpointTs),
-			zap.Error(err))
-		var lastSucceededTime time.Time
-		if barrierInfoObj, ok := m.keyspaceGCBarrierInfoMap.Load(keyspaceID); ok {
-			barrierInfo := barrierInfoObj.(*keyspaceGCBarrierInfo)
-			lastSucceededTime = barrierInfo.lastSucceededTime
-		}
-		if time.Since(lastSucceededTime) >= time.Duration(m.gcTTL)*time.Second {
-			return errors.ErrUpdateGCBarrierFailed.Wrap(err)
-		}
-		return nil
-	}
-
-	actual, err := UnifyGetServiceGCSafepoint(ctx, m.pdClient, keyspaceID, m.gcServiceID)
-	if err != nil {
-		return err
-	}
-
-	failpoint.Inject("InjectActualGCSafePoint", func(val failpoint.Value) {
-		actual = uint64(val.(int))
-	})
-
-	if actual > checkpointTs {
-		log.Warn("update gc barrier failed, the gc barrier is larger than checkpointTs",
-			zap.Uint64("actual", actual), zap.Uint64("checkpointTs", checkpointTs))
-	}
-
-	// if the min checkpoint ts is equal to the current gc barrier ts, it means
-	// that the service gc barrier ts set by TiCDC is the min service gc barrier ts
-	newBarrierInfo := &keyspaceGCBarrierInfo{
-		lastSucceededTime: time.Now(),
-		lastSafePointTs:   actual,
-		isTiCDCBlockGC:    actual == checkpointTs,
-	}
-	m.keyspaceGCBarrierInfoMap.Store(keyspaceID, newBarrierInfo)
-
-	minGCBarrierMetric := minGCBarrierGauge.WithLabelValues(keyspaceName)
-	minGCBarrierMetric.Set(float64(oracle.ExtractPhysical(actual)))
-
-	cdcGcBarrierMetric := cdcGCBarrierGauge.WithLabelValues(keyspaceName)
-	cdcGcBarrierMetric.Set(float64(oracle.ExtractPhysical(checkpointTs)))
-
-	return nil
 }

--- a/pkg/txnutil/gc/metrics.go
+++ b/pkg/txnutil/gc/metrics.go
@@ -33,30 +33,10 @@ var (
 			Name:      "cdc_gc_safepoint",
 			Help:      "the value of CDC GC safepoint",
 		})
-
-	minGCBarrierGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "ticdc",
-			Subsystem: "gc",
-			Name:      "min_gc_barrier",
-			Help:      "The min value all of GC barrier",
-		}, []string{"namespace"},
-	)
-
-	cdcGCBarrierGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "ticdc",
-			Subsystem: "gc",
-			Name:      "cdc_gc_barrier",
-			Help:      "The value of CDC GC barrier",
-		}, []string{"namespace"},
-	)
 )
 
 // InitMetrics registers all metrics used gc manager
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(minServiceGCSafePointGauge)
 	registry.MustRegister(cdcGCSafePointGauge)
-	registry.MustRegister(minGCBarrierGauge)
-	registry.MustRegister(cdcGCBarrierGauge)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Remove GCState which is not used in classic mode.

Issue Number: close #3111

### What is changed and how it works?

* **`cmd/cdc/cli/cli_unsafe_reset.go`:** The `unsafeResetOptions.run` method now unconditionally calls `gc.UnifyDeleteGcSafepoint` to reset GC safepoints, removing the conditional logic for "next-gen" mode. The helper function `removeKeyspaceGCBarrier` has been deleted as it's no longer needed.
* **`coordinator/changefeed/changefeed_db.go`:** The `CalculateKeyspaceGCBarrier` method has been removed, as keyspace-specific GC barrier calculations are no longer required.
* **`coordinator/controller.go`:** Methods related to calculating and updating keyspace GC barriers (`calculateKeyspaceGCBarrier`, `updateAllKeyspaceGcBarriers`, `updateKeyspaceGcBarrier`) have been removed.
* **`coordinator/coordinator.go`:** The `updateGCSafepointByChangefeed` and `updateGCSafepoint` methods have been simplified to no longer branch based on `kerneltype.IsNextGen()`.
* **`pkg/errors/error.go`:** Error definitions related to GC barriers (`ErrUpdateGCBarrierFailed`, `ErrGetGCBarrierFailed`) have been removed.
* **`pkg/txnutil/gc/gc_manager.go`:**
  * The `Manager` interface no longer includes `TryUpdateKeyspaceGCBarrier`.
  * The `gcManager` struct has been simplified by removing `keyspaceGCBarrierInfoMap` and `keyspaceLastUpdatedTimeMap`.
  * The `CheckStaleCheckpointTs` method now only calls `checkStaleCheckPointTsGlobal`.
  * The `checkStaleCheckpointTsKeyspace` method has been removed.
  * The `TryUpdateKeyspaceGCBarrier` method has been removed.
* **`pkg/txnutil/gc/gc_service.go`:**
  * The `EnsureChangefeedStartTsSafety` function now only calls the classic implementation.
  * The `ensureChangefeedStartTsSafetyNextGen` function has been removed.
  * `UnifyGetServiceGCSafepoint` now only returns the result from the classic mode implementation.
  * `SetGCBarrier`, `getGCState`, and `DeleteGCBarrier` have been removed as they were specific to next-gen GC barrier management.
* **`pkg/txnutil/gc/metrics.go`:** `minGCBarrierGauge` and `cdcGCBarrierGauge` have been removed.

### Check List

#### Tests

* Unit test
* Integration test
* Manual test (add detailed scripts or steps below)
* No code

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
