### PR TITLE
Add automated release creation on tag push to streamline deployments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Auto Release
+permissions:
+  contents: write
+  packages: write
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Get the version
+        id: tag
+        run: echo "version=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
+      - name: Echo tag
+        run: echo ${{ steps.tag.outputs.version }}
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{needs.tag.outputs.version}}"
+          TITLE="${VERSION#v}"
+          NOTE="Download Link:
+          \`\`\`
+          wget https://tiup-mirrors.pingcap.com/cdc-$VERSION-linux-amd64.tar.gz
+          docker pull pingcap/ticdc:$VERSION
+          \`\`\`"
+          gh release create "$VERSION" --verify-tag -t "$TITLE" -n "$NOTE"


### PR DESCRIPTION
### What problem does this PR solve?

This PR introduces an automated release process for TiCDC using GitHub Actions. Previously, releases were a manual process, prone to errors and time-consuming. This automation streamlines the creation of GitHub releases, including tagging and providing download links, for every new tag pushed to the repository.

Issue Number: close #3113

### What is changed and how it works?

A new GitHub Actions workflow file, `.github/workflows/release.yaml`, has been added. This workflow is triggered on every `push` to a tag. It consists of two main jobs:

* **`tag` job:** This job extracts the version number from the Git tag.
* **`release` job:** This job uses the extracted version number to create a new GitHub release. It checks out the repository, then uses the `gh` CLI to create a release with the tag, a title derived from the tag (e.g., "v1.0.0" becomes "1.0.0"), and a release note that includes `wget` and `docker pull` commands for downloading the release artifacts.

### Check List

#### Tests

* No code

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change is purely for automation and does not affect the TiCDC binary or its functionality.

##### Do you need to update user documentation, monitoring documentation or design documentation?

No.

### Release note

```release-note
None
```
