### PR TITLE
eventcollector: fix reset ts

### DIFF
--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -167,7 +167,7 @@ func (d *dispatcherStat) registerTo(serverID node.ID) {
 
 // commitReady is used to notify the event service to start sending events.
 func (d *dispatcherStat) commitReady(serverID node.ID) {
-	d.doReset(serverID, d.target.GetStartTs())
+	d.doReset(serverID, d.getResetTs())
 }
 
 // reset is used to reset the dispatcher to the specified commitTs,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3122 

### What is changed and how it works?

This pull request addresses a bug within the `eventcollector` component by refining how timestamps are determined for dispatcher reset operations. The change ensures that the system utilizes the appropriate timestamp, thereby preventing potential inconsistencies and promoting accurate state management during event processing.

### Highlights

* **Timestamp Correction**: The method used to obtain the timestamp for resetting the event dispatcher has been corrected. Previously, it used the `target`'s start timestamp, which has now been replaced with a dedicated `getResetTs()` method.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
