### PR TITLE
Skip release job for 'nextgen' versions to avoid publishing nextgen release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,9 @@ jobs:
         run: echo ${{ steps.tag.outputs.version }}
   release:
     name: release
-    runs-on: ubuntu-latest
     needs: tag
+    if: '!contains(needs.tag.outputs.version, ''nextgen'')'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{needs.tag.outputs.version}}"
-          TITLE="${VERSION#v}"
+          TITLE="${VERSION}"
           NOTE="Download Link:
           \`\`\`
           wget https://tiup-mirrors.pingcap.com/cdc-$VERSION-linux-amd64.tar.gz


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3162

### What is changed and how it works?

The `release` job in the `.github/workflows/release.yaml` file has been modified. Previously, the `TITLE` variable was derived from the `VERSION` by removing the leading 'v' using `${VERSION#v}`. This has been changed to simply use the `VERSION` directly. This ensures that the release title accurately reflects the version tag, including the 'v' prefix.

Additionally, a new conditional `if: '!contains(needs.tag.outputs.version, ''nextgen'')'` has been added to the `release` job. This ensures that the release job will not run for `nextgen` versions, preventing unintended releases.

### Check List

#### Tests

* No code

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change is purely related to the release workflow and does not affect the core functionality or performance of TiCDC. It also does not break compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, this change is internal to the CI/CD process and does not require updates to user, design, or monitoring documentation.

### Release note

```release-note
None
```
