### PR TITLE
tests: Use cdc_cli_changefeed command to ensure correct changefeed removal

### DIFF
--- a/tests/integration_tests/kafka_log_info/run.sh
+++ b/tests/integration_tests/kafka_log_info/run.sh
@@ -22,7 +22,7 @@ function build_sink_uri() {
 
 function cleanup_changefeed() {
 	local id=$1
-	cdc cli changefeed remove --pd="${pd_addr}" --changefeed-id="$id" >/dev/null 2>&1 || true
+	cdc_cli_changefeed remove --pd="${pd_addr}" --changefeed-id="$id" >/dev/null 2>&1 || true
 }
 
 function stop_cdc() {


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses a minor inconsistency in the integration test script for Kafka log information. Specifically, it corrects the command used to remove a changefeed.

Issue Number: close #3159

### What is changed and how it works?

The change is a simple correction in the `tests/integration_tests/kafka_log_info/run.sh` script. The command `cdc cli changefeed remove` has been updated to `cdc_cli_changefeed remove`. This ensures that the correct executable is called to remove the changefeed during the cleanup phase of the integration test in next-gen mode. 

### Check List

#### Tests

* Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change is a correction to an integration test script and will not affect performance or compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
