### PR TITLE
sink: add checkpointTs message for Pulsar and BlackHole sink

### DIFF
--- a/coordinator/changefeed/changefeed.go
+++ b/coordinator/changefeed/changefeed.go
@@ -187,7 +187,11 @@ func (c *Changefeed) ForceUpdateStatus(newStatus *heartbeatpb.MaintainerStatus) 
 }
 
 func (c *Changefeed) NeedCheckpointTsMessage() bool {
-	return c.sinkType == common.KafkaSinkType || c.sinkType == common.CloudStorageSinkType
+	switch c.sinkType {
+	case common.KafkaSinkType, common.PulsarSinkType, common.CloudStorageSinkType, common.BlackHoleSinkType:
+		return true
+	}
+	return false
 }
 
 func (c *Changefeed) SetIsNew(isNew bool) {

--- a/downstreamadapter/sink/blackhole/sink.go
+++ b/downstreamadapter/sink/blackhole/sink.go
@@ -69,7 +69,8 @@ func (s *sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 	return nil
 }
 
-func (s *sink) AddCheckpointTs(_ uint64) {
+func (s *sink) AddCheckpointTs(ts uint64) {
+	log.Debug("BlackHoleSink: Checkpoint Ts Event", zap.Uint64("ts", ts))
 }
 
 func (s *sink) Close(_ bool) {}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #442 close https://github.com/pingcap/ticdc/issues/3211

### What is changed and how it works?
Checkpoint Message Eligibility: The NeedCheckpointTsMessage function has been updated to ensure that both Pulsar and BlackHole sink types are now recognized as requiring checkpointTs messages.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
