### PR TITLE
*: correct table ID for partitioned tables in DDL events 

### DIFF
--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -558,25 +558,15 @@ func NewTableInfo(schemaName string, tableName string, tableID int64, isPartitio
 	return ti
 }
 
-// WrapTableInfoWithTableID creates a TableInfo from a model.TableInfo.
-// It explicitly uses the provided tableID instead of the one from info.ID.
-// This is used to create TableInfo wrappers for physical partitions,
-// ensuring they carry the physical partition ID, not the logical table ID.
-func WrapTableInfoWithTableID(schemaName string, info *model.TableInfo, tableID int64) *TableInfo {
-	// search column schema object
-	sharedColumnSchemaStorage := GetSharedColumnSchemaStorage()
-	columnSchema := sharedColumnSchemaStorage.GetOrSetColumnSchema(info)
-	return NewTableInfo(schemaName, info.Name.O, tableID, info.GetPartitionInfo() != nil, columnSchema, info)
-}
-
 // WrapTableInfo creates a TableInfo from a model.TableInfo.
-// This function is a convenience wrapper around WrapTableInfoWithTableID,
-// defaulting to use the logical table ID (info.ID).
 func WrapTableInfo(schemaName string, info *model.TableInfo) *TableInfo {
 	if info == nil {
 		return nil
 	}
-	return WrapTableInfoWithTableID(schemaName, info, info.ID)
+	// search column schema object
+	sharedColumnSchemaStorage := GetSharedColumnSchemaStorage()
+	columnSchema := sharedColumnSchemaStorage.GetOrSetColumnSchema(info)
+	return NewTableInfo(schemaName, info.Name.O, info.ID, info.GetPartitionInfo() != nil, columnSchema, info)
 }
 
 // NewTableInfo4Decoder is only used by the codec decoder for the test purpose,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3297 close #2984

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->
Since https://github.com/pingcap/ticdc/pull/2884 uses physical table ID for DDL events, it is not correct and the logical table id should be used.
#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
