### PR TITLE
consumer: fix a panic when flushing a large number of dml events

### DIFF
--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -200,7 +200,7 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 				zap.Any("tables", tableIDs))
 			return w.mysqlSink.WriteBlockEvent(ddl)
 		case <-ticker.C:
-			log.Warn("DML events are not flushed in time",
+			log.Warn("DML events cannot be flushed in time",
 				zap.Uint64("DDLCommitTs", commitTs), zap.String("query", ddl.Query),
 				zap.Int("total", total), zap.Int64("flushed", flushed.Load()))
 		}
@@ -309,7 +309,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 				zap.Int("total", total), zap.Duration("duration", time.Since(start)))
 			return nil
 		case <-ticker.C:
-			log.Warn("DML events are not flushed in time", zap.Uint64("watermark", watermark),
+			log.Warn("DML events cannot be flushed in time", zap.Uint64("watermark", watermark),
 				zap.Int("total", total), zap.Int64("flushed", flushed.Load()))
 		}
 	}

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -191,7 +191,7 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 				zap.Any("tables", tableIDs))
 			return w.mysqlSink.WriteBlockEvent(ddl)
 		case <-ticker.C:
-			log.Warn("DML events are not flushed in time",
+			log.Warn("DML events cannot be flushed in time",
 				zap.Uint64("DDLCommitTs", commitTs), zap.String("query", ddl.Query),
 				zap.Int("total", total), zap.Int64("flushed", flushed.Load()))
 		}
@@ -299,7 +299,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 				zap.Int("total", total), zap.Duration("duration", time.Since(start)))
 			return nil
 		case <-ticker.C:
-			log.Panic("DML events are not flushed in time", zap.Uint64("watermark", watermark),
+			log.Warn("DML events cannot be flushed in time", zap.Uint64("watermark", watermark),
 				zap.Int("total", total), zap.Int64("flushed", flushed.Load()))
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #1327

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
