### PR TITLE
Update Grafana dashboard to use `sharedpool_id` for metric filtering.

### DIFF
--- a/metrics/grafana/ticdc_new_arch_next_gen.json
+++ b/metrics/grafana/ticdc_new_arch_next_gen.json
@@ -21929,13 +21929,13 @@
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": "tidb_cluster",
+        "label": "sharedpool_id",
         "multi": false,
-        "name": "tidb_cluster",
+        "name": "sharedpool_id",
         "options": [],
         "query": {
-          "query": "label_values(go_goroutines{k8s_cluster=\"$k8s_cluster\"}, tidb_cluster)",
-          "refId": "local-tidb_cluster-Variable-Query"
+          "query": "label_values(go_goroutines{k8s_cluster=\"$k8s_cluster\"}, sharedpool_id)",
+          "refId": "local-sharedpool_id-Variable-Query"
         },
         "refresh": 2,
         "regex": "",

--- a/scripts/generate-next-gen-metrics.sh
+++ b/scripts/generate-next-gen-metrics.sh
@@ -67,7 +67,7 @@ jq '
 
 echo "Userscope dashboard created at '$NEXT_GEN_USER_FILE'"
 
-"$SED_CMD" "${SED_INPLACE_ARGS[@]}" 's/\<tidb_cluster_id=/sharedpool_id=/g' "$NEXT_GEN_SHARED_FILE"
-"$SED_CMD" "${SED_INPLACE_ARGS[@]}" 's/\<tidb_cluster=/sharedpool_id=/g' "$NEXT_GEN_SHARED_FILE"
+"$SED_CMD" "${SED_INPLACE_ARGS[@]}" 's/\([^$]\)\<tidb_cluster_id/\1sharedpool_id/g' "$NEXT_GEN_SHARED_FILE"
+"$SED_CMD" "${SED_INPLACE_ARGS[@]}" 's/\([^$]\)\<tidb_cluster/\1sharedpool_id/g' "$NEXT_GEN_SHARED_FILE"
 
 echo "Sharedscope dashboard created at '$NEXT_GEN_SHARED_FILE'"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3348

### What is changed and how it works?

The primary changes involve modifying the Grafana JSON dashboard file (`metrics/grafana/ticdc_new_arch_next_gen.json`) and the script used to generate it (`scripts/generate-next-gen-metrics.sh`).

In the Grafana dashboard JSON:

- All instances of `tidb_cluster` used as a label selector for TiCDC metrics have been replaced with `sharedpool_id`. This ensures that TiCDC metrics are correctly filtered and aggregated based on the shared pool identifier.
- The variable definition for `tidb_cluster` in the dashboard has been renamed to `tidb_cluster` and its query updated to fetch `tidb_cluster` labels, as this variable is still relevant for broader TiDB cluster context.

In the generation script:

- The script `scripts/generate-next-gen-metrics.sh` has been updated to correctly perform the substitution of `tidb_cluster_id` and `tidb_cluster` with `sharedpool_id` in the generated shared scope dashboard. This ensures that the generated dashboard reflects the corrected label usage.

### Check List

#### Tests

- Manual test (verify the Grafana dashboard displays correct data and filters are functional after applying the changes).

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change is purely a labeling and configuration update for Grafana dashboards and will not affect the performance or compatibility of TiCDC itself. It aims to improve the accuracy of monitoring.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes, it would be beneficial to update any documentation that refers to the specific labels used in the Grafana dashboards for TiCDC to reflect the change to `sharedpool_id`.

### Release note

```release-note
None
```
