### PR TITLE
Fix: Make the next-gen metrics script compatible with macOS

### DIFF
--- a/scripts/generate-next-gen-metrics.sh
+++ b/scripts/generate-next-gen-metrics.sh
@@ -67,7 +67,6 @@ jq '
 
 echo "Userscope dashboard created at '$NEXT_GEN_USER_FILE'"
 
-"$SED_CMD" "${SED_INPLACE_ARGS[@]}" 's/\([^$]\)tidb_cluster_id/\1sharedpool_id/g' "$NEXT_GEN_SHARED_FILE"
 "$SED_CMD" "${SED_INPLACE_ARGS[@]}" 's/\([^$]\)tidb_cluster/\1sharedpool_id/g' "$NEXT_GEN_SHARED_FILE"
 
 echo "Sharedscope dashboard created at '$NEXT_GEN_SHARED_FILE'"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #3348

### What is changed and how it works?

The changes in this PR modify the `sed` command within the `scripts/generate-next-gen-metrics.sh` script. Specifically, the word boundary anchors `\<` and `\>` have been removed from the regular expressions used to replace metric names.

- **Before:** The script used `s/\([^$]\)\<tidb_cluster/\1sharedpool_id/g`. The `\<` and `\>` were intended to match whole words.
- **After:** The script now uses `s/\([^$]\)tidb_cluster/\1sharedpool_id/g`. By removing the word boundary anchors, the `sed` command will correctly replace the target strings regardless of whether they are part of a larger word, ensuring accurate metric name transformations across different `sed` versions.

### Check List

#### Tests

- Manual test (add detailed scripts or steps below)
    1. Clone the repository and checkout this branch.
    2. Run the script `scripts/generate-next-gen-metrics.sh`.
    3. Inspect the generated `next-gen-metrics/sharedscope.json` file.
    4. Verify that `tidb_cluster` is correctly replaced with `sharedpool_id` only when they appear as standalone terms, and not as part of other words.

<img width="1528" height="706" alt="image" src="https://github.com/user-attachments/assets/928e9f18-4dc7-44e3-9109-d75350a26342" />


#### Questions

##### Will it cause performance regression or break compatibility?

No, this change is unlikely to cause performance regression. It only modifies the regular expression used for string replacement. It might improve compatibility by ensuring the script works as expected with different `sed` versions.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, user-facing documentation should not need updates as this is a script internal to the project.

### Release note

```release-note
None
```
