### PR TITLE
Refactor TableSpan creation to use NewTableSpan constructor

### DIFF
--- a/downstreamadapter/dispatcher/event_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/event_dispatcher_test.go
@@ -34,10 +34,7 @@ import (
 var defaultAtomicity = config.DefaultAtomicityLevel()
 
 func getCompleteTableSpanWithTableID(keyspaceID uint32, tableID int64) (*heartbeatpb.TableSpan, error) {
-	tableSpan := &heartbeatpb.TableSpan{
-		KeyspaceID: keyspaceID,
-		TableID:    tableID,
-	}
+	tableSpan := heartbeatpb.NewTableSpan(tableID, nil, nil, keyspaceID)
 	startKey, endKey, err := common.GetKeyspaceTableRange(keyspaceID, tableSpan.TableID)
 	if err != nil {
 		return nil, err
@@ -59,9 +56,7 @@ func getCompleteTableSpan(keyspaceID uint32) (*heartbeatpb.TableSpan, error) {
 }
 
 func getUncompleteTableSpan() *heartbeatpb.TableSpan {
-	return &heartbeatpb.TableSpan{
-		TableID: 1,
-	}
+	return heartbeatpb.NewTableSpan(1, nil, nil, 0)
 }
 
 func newDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) *EventDispatcher {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_helper.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_helper.go
@@ -177,12 +177,12 @@ func createMergedSpan[T dispatcher.Dispatcher](changefeedID common.ChangeFeedID,
 	//
 	//	set the old dispatchers to waiting merge state.
 	//	now, we just create a non-working dispatcher, we will make the dispatcher into work when DoMerge() called
-	return &heartbeatpb.TableSpan{
-		KeyspaceID: prevTableSpan.KeyspaceID,
-		TableID:    prevTableSpan.TableID,
-		StartKey:   startKey,
-		EndKey:     endKey,
-	}, fakeStartTs, schemaID
+	return heartbeatpb.NewTableSpan(
+		prevTableSpan.TableID,
+		startKey,
+		endKey,
+		prevTableSpan.KeyspaceID,
+	), fakeStartTs, schemaID
 }
 
 func registerMergeDispatcher[T dispatcher.Dispatcher](changefeedID common.ChangeFeedID,

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -36,11 +36,7 @@ var mockSink = sink.NewMockSink(common.BlackHoleSinkType)
 
 // createTestDispatcher creates a test dispatcher with given parameters
 func createTestDispatcher(t *testing.T, manager *DispatcherManager, id common.DispatcherID, tableID int64, startKey, endKey []byte) *dispatcher.EventDispatcher {
-	span := &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: startKey,
-		EndKey:   endKey,
-	}
+	span := heartbeatpb.NewTableSpan(tableID, startKey, endKey, 0)
 	var redoTs atomic.Uint64
 	redoTs.Store(math.MaxUint64)
 	defaultAtomicity := config.DefaultAtomicityLevel()

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -73,9 +73,7 @@ func (m *mockDispatcher) GetChangefeedID() common.ChangeFeedID {
 }
 
 func (m *mockDispatcher) GetTableSpan() *heartbeatpb.TableSpan {
-	return &heartbeatpb.TableSpan{
-		TableID: 1,
-	}
+	return heartbeatpb.NewTableSpan(1, nil, nil, 0)
 }
 
 func (m *mockDispatcher) GetBDRMode() bool {

--- a/downstreamadapter/eventcollector/event_collector_test.go
+++ b/downstreamadapter/eventcollector/event_collector_test.go
@@ -167,7 +167,7 @@ func TestProcessMessage(t *testing.T) {
 
 	seq.Store(1)
 	done := make(chan struct{})
-	d := &mockEventDispatcher{id: did, tableSpan: &heartbeatpb.TableSpan{TableID: 1}}
+	d := &mockEventDispatcher{id: did, tableSpan: heartbeatpb.NewTableSpan(1, nil, nil, 0)}
 	d.handle = func(e commonEvent.Event) {
 		require.Equal(t, e.GetSeq(), seq.Add(1))
 		require.Equal(t, events[e.GetSeq()], e)
@@ -205,9 +205,9 @@ func TestRemoveLastDispatcher(t *testing.T) {
 	cfID1 := common.NewChangefeedID(common.DefaultKeyspaceNamme)
 	cfID2 := common.NewChangefeedID(common.DefaultKeyspaceNamme)
 
-	d1 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: &heartbeatpb.TableSpan{TableID: 1}, changefeedID: cfID1}
-	d2 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: &heartbeatpb.TableSpan{TableID: 2}, changefeedID: cfID1}
-	d3 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: &heartbeatpb.TableSpan{TableID: 3}, changefeedID: cfID2}
+	d1 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: heartbeatpb.NewTableSpan(1, nil, nil, 0), changefeedID: cfID1}
+	d2 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: heartbeatpb.NewTableSpan(2, nil, nil, 0), changefeedID: cfID1}
+	d3 := &mockEventDispatcher{id: common.NewDispatcherID(), tableSpan: heartbeatpb.NewTableSpan(3, nil, nil, 0), changefeedID: cfID2}
 
 	// Add dispatchers
 	c.AddDispatcher(d1, 1024)

--- a/heartbeatpb/table_span.go
+++ b/heartbeatpb/table_span.go
@@ -41,3 +41,14 @@ func (s *TableSpan) Copy() *TableSpan {
 		KeyspaceID: s.KeyspaceID,
 	}
 }
+
+// NewTableSpan creates a new TableSpan with all fields specified.
+// This constructor ensures all fields are properly initialized.
+func NewTableSpan(tableID int64, startKey, endKey []byte, keyspaceID uint32) *TableSpan {
+	return &TableSpan{
+		TableID:    tableID,
+		StartKey:   startKey,
+		EndKey:     endKey,
+		KeyspaceID: keyspaceID,
+	}
+}

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -108,21 +108,13 @@ func TestEventStoreInteractionWithSubClient(t *testing.T) {
 	cfID := common.NewChangefeedID4Test("default", "test-cf")
 
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  1,
-			StartKey: []byte("a"),
-			EndKey:   []byte("e"),
-		}
+		span := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("e"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID1, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
 	// add a dispatcher with the same span
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  1,
-			StartKey: []byte("a"),
-			EndKey:   []byte("e"),
-		}
+		span := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("e"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -135,11 +127,7 @@ func TestEventStoreInteractionWithSubClient(t *testing.T) {
 	}
 	// add a dispatcher with a containing span
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  1,
-			StartKey: []byte("a"),
-			EndKey:   []byte("b"),
-		}
+		span := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("b"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID3, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -170,31 +158,19 @@ func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
 	cfID := common.NewChangefeedID4Test("default", "test-cf")
 	// add a dispatcher to create a subscription
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID1, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
 	// add a dispatcher(onlyReuse=true) with a non-containing span which should fail
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("i"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("i"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, true, false)
 		require.False(t, ok)
 	}
 	// when the existing subscription is not initialized, add a dispatcher(onlyReuse=true) should fail
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID3, span, 100, func(watermark uint64, latestCommitTs uint64) {}, true, false)
 		require.False(t, ok)
 	}
@@ -202,11 +178,7 @@ func TestEventStoreOnlyReuseDispatcher(t *testing.T) {
 	markSubStatsInitializedForTest(store, tableID)
 	// add a dispatcher(onlyReuse=true) with a containing span which should success
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID3, span, 100, func(watermark uint64, latestCommitTs uint64) {}, true, false)
 		require.True(t, ok)
 	}
@@ -241,11 +213,7 @@ func TestEventStoreOnlyReuseDispatcherSuccess(t *testing.T) {
 
 	// 1. Register a dispatcher to create a large subscription.
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("z"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("z"), 0)
 		ok := es.RegisterDispatcher(cfID, dispatcherID1, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -254,11 +222,7 @@ func TestEventStoreOnlyReuseDispatcherSuccess(t *testing.T) {
 	// 2. Register a second dispatcher with onlyReuse=true, whose span is contained
 	//    by the first subscription. This registration should succeed.
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("y"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("y"), 0)
 		ok := es.RegisterDispatcher(cfID, dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, true, false)
 		require.True(t, ok)
 	}
@@ -266,11 +230,7 @@ func TestEventStoreOnlyReuseDispatcherSuccess(t *testing.T) {
 	// 3. Register a third dispatcher with onlyReuse=true, whose span is an exact match
 	//    to the first subscription. This registration should also succeed.
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("z"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("z"), 0)
 		ok := es.RegisterDispatcher(cfID, dispatcherID3, span, 100, func(watermark uint64, latestCommitTs uint64) {}, true, false)
 		require.True(t, ok)
 	}
@@ -287,21 +247,13 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 	cfID := common.NewChangefeedID4Test("default", "test-cf")
 	// add a subscription to create a subscription
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID1, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
 	// add a dispatcher(onlyReuse=false) with a non-containing span
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("c"),
-			EndKey:   []byte("i"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("c"), []byte("i"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -313,11 +265,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 	}
 	// add a dispatcher(onlyReuse=false) with a containing span
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID3, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -335,11 +283,7 @@ func TestEventStoreNonOnlyReuseDispatcher(t *testing.T) {
 	}
 	// add a dispatcher(onlyReuse=false) with the same span
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID4, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 		subStats := store.(*eventStore).dispatcherMeta.tableStats[tableID]
@@ -382,21 +326,13 @@ func TestEventStoreUpdateCheckpointTs(t *testing.T) {
 	cfID := common.NewChangefeedID4Test("default", "test-cf")
 	// add first dispatcher
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID1, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
 	// add a dispatcher(onlyReuse=false) with a containing span
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -470,22 +406,14 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	// ============ prepare two subscriptions ============
 	// add a dispatcher to create an subscription
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID1, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
 	// add a dispatcher(onlyReuse=false) with a containing span
 	// it will reuse the first subscription and create a new one
 	{
-		span := &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("b"),
-			EndKey:   []byte("h"),
-		}
+		span := heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0)
 		ok := store.RegisterDispatcher(cfID, dispatcherID2, span, 100, func(watermark uint64, latestCommitTs uint64) {}, false, false)
 		require.True(t, ok)
 	}
@@ -500,11 +428,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	updateSubStatResolvedTs(1, 200)
 	{
 		iter := store.GetIterator(dispatcherID2, common.DataRange{
-			Span: &heartbeatpb.TableSpan{
-				TableID:  tableID,
-				StartKey: []byte("b"),
-				EndKey:   []byte("h"),
-			},
+			Span:          heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0),
 			CommitTsStart: 100,
 			CommitTsEnd:   150,
 		})
@@ -516,11 +440,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	updateSubStatResolvedTs(2, 200)
 	{
 		iter := store.GetIterator(dispatcherID2, common.DataRange{
-			Span: &heartbeatpb.TableSpan{
-				TableID:  tableID,
-				StartKey: []byte("b"),
-				EndKey:   []byte("h"),
-			},
+			Span:          heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0),
 			CommitTsStart: 100,
 			CommitTsEnd:   150,
 		})
@@ -544,11 +464,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	updateSubStatResolvedTs(1, 220)
 	{
 		iter := store.GetIterator(dispatcherID2, common.DataRange{
-			Span: &heartbeatpb.TableSpan{
-				TableID:  tableID,
-				StartKey: []byte("b"),
-				EndKey:   []byte("h"),
-			},
+			Span:          heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0),
 			CommitTsStart: 100,
 			CommitTsEnd:   220,
 		})
@@ -578,11 +494,7 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 	updateSubStatResolvedTs(2, 220)
 	{
 		iter := store.GetIterator(dispatcherID2, common.DataRange{
-			Span: &heartbeatpb.TableSpan{
-				TableID:  tableID,
-				StartKey: []byte("b"),
-				EndKey:   []byte("h"),
-			},
+			Span:          heartbeatpb.NewTableSpan(tableID, []byte("b"), []byte("h"), 0),
 			CommitTsStart: 100,
 			CommitTsEnd:   220,
 		})
@@ -717,7 +629,7 @@ func TestEventStoreGetIteratorConcurrently(t *testing.T) {
 	// 1. Register a dispatcher.
 	dispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangefeedID4Test("default", "test-cf")
-	span := &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("z")}
+	span := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
 	startTs := uint64(100)
 	var resolvedTs atomic.Uint64
 	resolvedTs.Store(startTs)
@@ -849,11 +761,7 @@ func TestEventStoreIter_NextWithFiltering(t *testing.T) {
 
 	var subID uint64 = 1
 	var tableID int64 = 42
-	iteratorSpan := &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: []byte("keyB"),
-		EndKey:   []byte("keyD"),
-	}
+	iteratorSpan := heartbeatpb.NewTableSpan(tableID, []byte("keyB"), []byte("keyD"), 0)
 
 	// This test now focuses on a single, more comprehensive scenario.
 	for _, tc := range testCases {

--- a/logservice/logpuller/priority_queue_test.go
+++ b/logservice/logpuller/priority_queue_test.go
@@ -37,7 +37,7 @@ type mockPriorityTask struct {
 func newMockPriorityTask(priority int, description string) *mockPriorityTask {
 	// Create a minimal regionInfo for testing
 	verID := tikv.NewRegionVerID(1, 1, 1)
-	span := heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("z")}
+	span := *heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
 
 	// Create a subscribedSpan with atomic resolvedTs
 	subscribedSpan := &subscribedSpan{
@@ -441,7 +441,7 @@ func TestPriorityQueue_RealPriorityTaskIntegration(t *testing.T) {
 
 	// Create real priority tasks with different types
 	verID := tikv.NewRegionVerID(1, 1, 1)
-	span := heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("z")}
+	span := *heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
 
 	subscribedSpan := &subscribedSpan{
 		resolvedTs: atomic.Uint64{},

--- a/logservice/logpuller/region_event_handler_test.go
+++ b/logservice/logpuller/region_event_handler_test.go
@@ -49,11 +49,7 @@ func TestHandleEventEntryEventOutOfOrder(t *testing.T) {
 	ds := dynstream.NewParallelDynamicStream(&regionEventHandler{}, option)
 	ds.Start()
 
-	span := heartbeatpb.TableSpan{
-		TableID:  100,
-		StartKey: common.ToComparableKey([]byte{}), // TODO: remove spanz dependency
-		EndKey:   common.ToComparableKey(common.UpperBoundKey),
-	}
+	span := *heartbeatpb.NewTableSpan(100, common.ToComparableKey([]byte{}), common.ToComparableKey(common.UpperBoundKey), 0)
 	subID := SubscriptionID(999)
 	eventCh := make(chan common.RawKVEntry, 1000)
 	consumeKVEvents := func(events []common.RawKVEntry, _ func()) bool {
@@ -220,14 +216,10 @@ func TestHandleResolvedTs(t *testing.T) {
 	state1 := newRegionFeedState(regionInfo{verID: tikv.NewRegionVerID(1, 1, 1)}, uint64(subID1), worker)
 	state1.start()
 	{
-		span := heartbeatpb.TableSpan{
-			TableID:  100,
-			StartKey: common.ToComparableKey([]byte{}), // TODO: remove spanz dependency
-			EndKey:   common.ToComparableKey(common.UpperBoundKey),
-		}
+		span := *heartbeatpb.NewTableSpan(100, common.ToComparableKey([]byte{}), common.ToComparableKey(common.UpperBoundKey), 0)
 		subSpan := &subscribedSpan{
 			subID:             subID1,
-			span:              heartbeatpb.TableSpan{},
+			span:              *heartbeatpb.NewTableSpan(0, nil, nil, 0),
 			rangeLock:         regionlock.NewRangeLock(uint64(subID1), span.StartKey, span.EndKey, 1),
 			consumeKVEvents:   consumeKVEvents,
 			advanceResolvedTs: advanceResolvedTs,
@@ -244,11 +236,7 @@ func TestHandleResolvedTs(t *testing.T) {
 	state2 := newRegionFeedState(regionInfo{verID: tikv.NewRegionVerID(2, 2, 2)}, uint64(subID2), worker)
 	state2.start()
 	{
-		span := heartbeatpb.TableSpan{
-			TableID:  100,
-			StartKey: common.ToComparableKey([]byte{}), // TODO: remove spanz dependency
-			EndKey:   common.ToComparableKey(common.UpperBoundKey),
-		}
+		span := *heartbeatpb.NewTableSpan(100, common.ToComparableKey([]byte{}), common.ToComparableKey(common.UpperBoundKey), 0)
 		subSpan := &subscribedSpan{
 			subID:             subID2,
 			span:              span,
@@ -268,11 +256,7 @@ func TestHandleResolvedTs(t *testing.T) {
 	state3 := newRegionFeedState(regionInfo{verID: tikv.NewRegionVerID(3, 3, 3)}, uint64(subID3), worker)
 	state3.start()
 	{
-		span := heartbeatpb.TableSpan{
-			TableID:  100,
-			StartKey: common.ToComparableKey([]byte{}), // TODO: remove spanz dependency
-			EndKey:   common.ToComparableKey(common.UpperBoundKey),
-		}
+		span := *heartbeatpb.NewTableSpan(100, common.ToComparableKey([]byte{}), common.ToComparableKey(common.UpperBoundKey), 0)
 		subSpan := &subscribedSpan{
 			subID:             subID3,
 			span:              span,

--- a/logservice/logpuller/region_req_cache_test.go
+++ b/logservice/logpuller/region_req_cache_test.go
@@ -26,11 +26,7 @@ import (
 func createTestRegionInfo(subID SubscriptionID, regionID uint64) regionInfo {
 	verID := tikv.NewRegionVerID(regionID, 1, 1)
 
-	span := heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("start"),
-		EndKey:   []byte("end"),
-	}
+	span := *heartbeatpb.NewTableSpan(1, []byte("start"), []byte("end"), 0)
 
 	subscribedSpan := &subscribedSpan{
 		subID:   subID,

--- a/logservice/logpuller/regionlock/region_range_lock_test.go
+++ b/logservice/logpuller/regionlock/region_range_lock_test.go
@@ -65,9 +65,7 @@ func mustLockRangeStale(
 	res := l.LockRange(ctx, []byte(startKey), []byte(endKey), regionID, version)
 	spans := make([]heartbeatpb.TableSpan, 0)
 	for i := 0; i < len(expectRetrySpans); i += 2 {
-		spans = append(spans, heartbeatpb.TableSpan{
-			StartKey: []byte(expectRetrySpans[i]), EndKey: []byte(expectRetrySpans[i+1]),
-		})
+		spans = append(spans, *heartbeatpb.NewTableSpan(0, []byte(expectRetrySpans[i]), []byte(expectRetrySpans[i+1]), 0))
 	}
 	mustStale(t, res, spans...)
 }

--- a/logservice/logpuller/regionlock/util_test.go
+++ b/logservice/logpuller/regionlock/util_test.go
@@ -31,32 +31,32 @@ func TestCheckRegionsLeftCover(t *testing.T) {
 	}{
 		{
 			regions: []*metapb.Region{},
-			span:    heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}}, cover: false,
+			span:    *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0), cover: false,
 		},
 		{regions: []*metapb.Region{
 			{StartKey: nil, EndKey: nil},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}}, cover: true},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0), cover: true},
 		{regions: []*metapb.Region{
 			{StartKey: []byte{1}, EndKey: []byte{2}},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}}, cover: true},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0), cover: true},
 		{regions: []*metapb.Region{
 			{StartKey: []byte{0}, EndKey: []byte{4}},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}}, cover: true},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0), cover: true},
 		{regions: []*metapb.Region{
 			{StartKey: []byte{1}, EndKey: []byte{2}},
 			{StartKey: []byte{2}, EndKey: []byte{3}},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{3}}, cover: true},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{3}, 0), cover: true},
 		{regions: []*metapb.Region{
 			{StartKey: []byte{1}, EndKey: []byte{2}},
 			{StartKey: []byte{3}, EndKey: []byte{4}},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{4}}, cover: false},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{4}, 0), cover: false},
 		{regions: []*metapb.Region{
 			{StartKey: []byte{1}, EndKey: []byte{2}},
 			{StartKey: []byte{2}, EndKey: []byte{3}},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{4}}, cover: true},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{4}, 0), cover: true},
 		{regions: []*metapb.Region{
 			{StartKey: []byte{2}, EndKey: []byte{3}},
-		}, span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{3}}, cover: false},
+		}, span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{3}, 0), cover: false},
 	}
 
 	for _, tc := range cases {
@@ -74,19 +74,19 @@ func TestCutRegionsLeftCoverSpan(t *testing.T) {
 	}{
 		{
 			regions: []*metapb.Region{},
-			span:    heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			span:    *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 			covered: nil,
 		},
 		{
 			regions: []*metapb.Region{{StartKey: nil, EndKey: nil}},
-			span:    heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			span:    *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 			covered: []*metapb.Region{{StartKey: nil, EndKey: nil}},
 		},
 		{
 			regions: []*metapb.Region{
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 			},
-			span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 			covered: []*metapb.Region{
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 			},
@@ -95,7 +95,7 @@ func TestCutRegionsLeftCoverSpan(t *testing.T) {
 			regions: []*metapb.Region{
 				{StartKey: []byte{0}, EndKey: []byte{4}},
 			},
-			span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 			covered: []*metapb.Region{
 				{StartKey: []byte{0}, EndKey: []byte{4}},
 			},
@@ -105,7 +105,7 @@ func TestCutRegionsLeftCoverSpan(t *testing.T) {
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 				{StartKey: []byte{2}, EndKey: []byte{3}},
 			},
-			span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{3}},
+			span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{3}, 0),
 			covered: []*metapb.Region{
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 				{StartKey: []byte{2}, EndKey: []byte{3}},
@@ -116,7 +116,7 @@ func TestCutRegionsLeftCoverSpan(t *testing.T) {
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 				{StartKey: []byte{3}, EndKey: []byte{4}},
 			},
-			span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{4}},
+			span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{4}, 0),
 			covered: []*metapb.Region{
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 			},
@@ -126,7 +126,7 @@ func TestCutRegionsLeftCoverSpan(t *testing.T) {
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 				{StartKey: []byte{2}, EndKey: []byte{3}},
 			},
-			span: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{4}},
+			span: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{4}, 0),
 			covered: []*metapb.Region{
 				{StartKey: []byte{1}, EndKey: []byte{2}},
 				{StartKey: []byte{2}, EndKey: []byte{3}},
@@ -136,7 +136,7 @@ func TestCutRegionsLeftCoverSpan(t *testing.T) {
 			regions: []*metapb.Region{
 				{StartKey: []byte{2}, EndKey: []byte{3}},
 			},
-			span:    heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{3}},
+			span:    *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{3}, 0),
 			covered: nil,
 		},
 	}

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -713,11 +713,12 @@ func (s *subscriptionClient) divideSpanAndScheduleRegionRequests(
 		}
 
 		for _, regionMeta := range regionMetas {
-			regionSpan := heartbeatpb.TableSpan{
-				StartKey:   regionMeta.StartKey,
-				EndKey:     regionMeta.EndKey,
-				KeyspaceID: subscribedSpan.span.KeyspaceID,
-			}
+			regionSpan := *heartbeatpb.NewTableSpan(
+				0,
+				regionMeta.StartKey,
+				regionMeta.EndKey,
+				subscribedSpan.span.KeyspaceID,
+			)
 			// NOTE: the End key return by the PD API will be nil to represent the biggest key.
 			// So we need to fix it by calling spanz.HackSpan.
 			regionSpan = common.HackTableSpan(regionSpan)

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -39,11 +39,7 @@ func TestGenerateResolveLockTask(t *testing.T) {
 		resolveLockTaskCh: make(chan resolveLockTask, 10),
 	}
 	client.ctx, client.cancel = context.WithCancel(context.Background())
-	rawSpan := heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte{'a'},
-		EndKey:   []byte{'z'},
-	}
+	rawSpan := *heartbeatpb.NewTableSpan(1, []byte{'a'}, []byte{'z'}, 0)
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
 	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0)
@@ -161,7 +157,7 @@ func TestSubscriptionWithFailedTiKV(t *testing.T) {
 	}()
 
 	subID := client.AllocSubscriptionID()
-	span := heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("b")}
+	span := *heartbeatpb.NewTableSpan(1, []byte("a"), []byte("b"), 0)
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool {
 		// should not reach here
 		require.True(t, false)
@@ -218,7 +214,7 @@ func TestErrCacheDispatchWithFullChannelAndCanceledContext(t *testing.T) {
 	mockErrInfo := regionErrorInfo{
 		regionInfo: regionInfo{
 			verID: tikv.NewRegionVerID(1, 1, 1),
-			span:  heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("b")},
+			span:  *heartbeatpb.NewTableSpan(1, []byte("a"), []byte("b"), 0),
 		},
 		err: errors.New("test error"),
 	}

--- a/logservice/schemastore/ddl_job_fetcher.go
+++ b/logservice/schemastore/ddl_job_fetcher.go
@@ -272,23 +272,23 @@ func getAllDDLSpan(keyspaceID uint32) ([]heartbeatpb.TableSpan, error) {
 		return nil, err
 	}
 
-	spans = append(spans, heartbeatpb.TableSpan{
-		TableID:    JobTableID,
-		StartKey:   common.ToComparableKey(start),
-		EndKey:     common.ToComparableKey(end),
-		KeyspaceID: keyspaceID,
-	})
+	spans = append(spans, *heartbeatpb.NewTableSpan(
+		JobTableID,
+		common.ToComparableKey(start),
+		common.ToComparableKey(end),
+		keyspaceID,
+	))
 
 	start, end, err = common.GetKeyspaceTableRange(keyspaceID, JobHistoryID)
 	if err != nil {
 		return nil, err
 	}
-	spans = append(spans, heartbeatpb.TableSpan{
-		TableID:    JobHistoryID,
-		StartKey:   common.ToComparableKey(start),
-		EndKey:     common.ToComparableKey(end),
-		KeyspaceID: keyspaceID,
-	})
+	spans = append(spans, *heartbeatpb.NewTableSpan(
+		JobHistoryID,
+		common.ToComparableKey(start),
+		common.ToComparableKey(end),
+		keyspaceID,
+	))
 	return spans, nil
 }
 

--- a/maintainer/barrier_test.go
+++ b/maintainer/barrier_test.go
@@ -1200,23 +1200,26 @@ func TestBarrierEventWithDispatcherReallocation(t *testing.T) {
 	startKey := span.StartKey
 	endKey := span.EndKey
 
-	dispatcherA := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: startKey,
-		EndKey:   append(startKey, byte('a')),
-	}, startTs, common.DefaultMode)
+	dispatcherA := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		startKey,
+		append(startKey, byte('a')),
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
-	dispatcherB := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: append(startKey, byte('a')),
-		EndKey:   append(startKey, byte('b')),
-	}, startTs, common.DefaultMode)
+	dispatcherB := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		append(startKey, byte('a')),
+		append(startKey, byte('b')),
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
-	dispatcherC := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: append(startKey, byte('b')),
-		EndKey:   endKey,
-	}, startTs, common.DefaultMode)
+	dispatcherC := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		append(startKey, byte('b')),
+		endKey,
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
 	// add dispatcher to spanController and set to replicating state
 	spanController.AddReplicatingSpan(dispatcherA)
@@ -1273,23 +1276,26 @@ func TestBarrierEventWithDispatcherReallocation(t *testing.T) {
 	require.Nil(t, spanController.GetTaskByID(dispatcherC.ID))
 
 	// create new dispatcher E, F, G
-	dispatcherE := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: append(startKey, byte('a')),
-		EndKey:   append(startKey, byte('b')),
-	}, startTs, common.DefaultMode)
+	dispatcherE := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		append(startKey, byte('a')),
+		append(startKey, byte('b')),
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
-	dispatcherF := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: append(startKey, byte('b')),
-		EndKey:   endKey,
-	}, startTs, common.DefaultMode)
+	dispatcherF := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		append(startKey, byte('b')),
+		endKey,
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
-	dispatcherG := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: startKey,
-		EndKey:   append(startKey, byte('a')),
-	}, startTs, common.DefaultMode)
+	dispatcherG := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		startKey,
+		append(startKey, byte('a')),
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
 	spanController.AddReplicatingSpan(dispatcherE)
 	spanController.AddReplicatingSpan(dispatcherF)
@@ -1403,11 +1409,12 @@ func TestBarrierEventWithDispatcherScheduling(t *testing.T) {
 	ddlTs := uint64(10)
 
 	span := common.TableIDToComparableSpan(0, tableID)
-	dispatcherA := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, &heartbeatpb.TableSpan{
-		TableID:  tableID,
-		StartKey: span.StartKey,
-		EndKey:   span.EndKey,
-	}, startTs, common.DefaultMode)
+	dispatcherA := replica.NewSpanReplication(cfID, common.NewDispatcherID(), schemaID, heartbeatpb.NewTableSpan(
+		tableID,
+		span.StartKey,
+		span.EndKey,
+		span.KeyspaceID,
+	), startTs, common.DefaultMode)
 
 	// Add dispatcher A to spanController and set to replicating state
 	spanController.AddReplicatingSpan(dispatcherA)

--- a/maintainer/maintainer_controller_helper.go
+++ b/maintainer/maintainer_controller_helper.go
@@ -166,12 +166,7 @@ func (c *Controller) splitTableByRegionCount(tableID int64, mode int64) error {
 	}
 
 	span := common.TableIDToComparableSpan(c.GetKeyspaceID(), tableID)
-	wholeSpan := &heartbeatpb.TableSpan{
-		TableID:    span.TableID,
-		StartKey:   span.StartKey,
-		EndKey:     span.EndKey,
-		KeyspaceID: c.GetKeyspaceID(),
-	}
+	wholeSpan := heartbeatpb.NewTableSpan(span.TableID, span.StartKey, span.EndKey, c.GetKeyspaceID())
 	splitter := spanController.GetSplitter()
 	if splitter == nil {
 		return errors.ErrInternalCheckFailed.GenWithStackByArgs("splitter is nil")

--- a/maintainer/maintainer_controller_test.go
+++ b/maintainer/maintainer_controller_test.go
@@ -123,7 +123,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableMoreThanNodeNum(t *testing.T) {
 		// generate 100 groups
 		totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		for j := 0; j < 4; j++ {
-			span := &heartbeatpb.TableSpan{TableID: int64(i), StartKey: appendNew(totalSpan.StartKey, byte('a'+j)), EndKey: appendNew(totalSpan.StartKey, byte('b'+j))}
+			span := heartbeatpb.NewTableSpan(int64(i), appendNew(totalSpan.StartKey, byte('a'+j)), appendNew(totalSpan.StartKey, byte('b'+j)), totalSpan.KeyspaceID)
 			dispatcherID := common.NewDispatcherID()
 			spanReplica := replica.NewSpanReplication(cfID, dispatcherID, 1, span, 1, common.DefaultMode)
 			spanReplica.SetNodeID(nodeID)
@@ -233,7 +233,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableLessThanNodeNum(t *testing.T) {
 		// generate 100 groups
 		totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		for j := 0; j < 2; j++ {
-			span := &heartbeatpb.TableSpan{TableID: int64(i), StartKey: appendNew(totalSpan.StartKey, byte('a'+j)), EndKey: appendNew(totalSpan.StartKey, byte('b'+j))}
+			span := heartbeatpb.NewTableSpan(int64(i), appendNew(totalSpan.StartKey, byte('a'+j)), appendNew(totalSpan.StartKey, byte('b'+j)), totalSpan.KeyspaceID)
 			dispatcherID := common.NewDispatcherID()
 			spanReplica := replica.NewSpanReplication(cfID, dispatcherID, 1, span, 1, common.DefaultMode)
 			spanReplica.SetNodeID(nodeIDList[j%2])
@@ -352,7 +352,7 @@ func TestSplitBalanceGroupsWithNodeRemove(t *testing.T) {
 		// generate 100 groups
 		totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		for j := 0; j < 6; j++ {
-			span := &heartbeatpb.TableSpan{TableID: int64(i), StartKey: appendNew(totalSpan.StartKey, byte('a'+j)), EndKey: appendNew(totalSpan.StartKey, byte('b'+j))}
+			span := heartbeatpb.NewTableSpan(int64(i), appendNew(totalSpan.StartKey, byte('a'+j)), appendNew(totalSpan.StartKey, byte('b'+j)), totalSpan.KeyspaceID)
 			dispatcherID := common.NewDispatcherID()
 			spanReplica := replica.NewSpanReplication(cfID, dispatcherID, 1, span, 1, common.DefaultMode)
 			spanReplica.SetNodeID(nodeIDList[j%3])
@@ -457,7 +457,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 	// span1
 	startKey := appendNew(totalSpan.StartKey, byte('a'))
 	endKey := appendNew(totalSpan.StartKey, byte('b'))
-	span1 := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: startKey, EndKey: endKey}
+	span1 := heartbeatpb.NewTableSpan(int64(1), startKey, endKey, totalSpan.KeyspaceID)
 	spanReplica := replica.NewSpanReplication(cfID, common.NewDispatcherID(), 1, span1, 1, common.DefaultMode)
 	spanReplica.SetNodeID(nodeIDList[1])
 	regionCache.SetRegions(fmt.Sprintf("%s-%s", span1.StartKey, span1.EndKey), []*tikv.Region{
@@ -497,7 +497,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 	// span2
 	startKey = appendNew(totalSpan.StartKey, byte('b'))
 	endKey = appendNew(totalSpan.StartKey, byte('c'))
-	span2 := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: startKey, EndKey: endKey}
+	span2 := heartbeatpb.NewTableSpan(int64(1), startKey, endKey, totalSpan.KeyspaceID)
 	spanReplica = replica.NewSpanReplication(cfID, common.NewDispatcherID(), 1, span2, 1, common.DefaultMode)
 	spanReplica.SetNodeID(nodeIDList[0])
 	regionCache.SetRegions(fmt.Sprintf("%s-%s", span2.StartKey, span2.EndKey), []*tikv.Region{
@@ -522,7 +522,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 	// span3
 	startKey = appendNew(totalSpan.StartKey, byte('c'))
 	endKey = appendNew(totalSpan.StartKey, byte('d'))
-	span3 := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: startKey, EndKey: endKey}
+	span3 := heartbeatpb.NewTableSpan(int64(1), startKey, endKey, totalSpan.KeyspaceID)
 	spanReplica = replica.NewSpanReplication(cfID, common.NewDispatcherID(), 1, span3, 1, common.DefaultMode)
 	spanReplica.SetNodeID(nodeIDList[1])
 	regionCache.SetRegions(fmt.Sprintf("%s-%s", span3.StartKey, span3.EndKey), []*tikv.Region{
@@ -547,7 +547,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 	// span4
 	startKey = appendNew(totalSpan.StartKey, byte('d'))
 	endKey = appendNew(totalSpan.StartKey, byte('e'))
-	span4 := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: startKey, EndKey: endKey}
+	span4 := heartbeatpb.NewTableSpan(int64(1), startKey, endKey, totalSpan.KeyspaceID)
 	spanReplica = replica.NewSpanReplication(cfID, common.NewDispatcherID(), 1, span4, 1, common.DefaultMode)
 	spanReplica.SetNodeID(nodeIDList[2])
 	regionCache.SetRegions(fmt.Sprintf("%s-%s", span4.StartKey, span4.EndKey), []*tikv.Region{
@@ -572,7 +572,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 	// span5
 	startKey = appendNew(totalSpan.StartKey, byte('e'))
 	endKey = appendNew(totalSpan.StartKey, byte('f'))
-	span5 := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: startKey, EndKey: endKey}
+	span5 := heartbeatpb.NewTableSpan(int64(1), startKey, endKey, totalSpan.KeyspaceID)
 	spanReplica = replica.NewSpanReplication(cfID, common.NewDispatcherID(), 1, span5, 1, common.DefaultMode)
 	spanReplica.SetNodeID(nodeIDList[0])
 	regionCache.SetRegions(fmt.Sprintf("%s-%s", span5.StartKey, span5.EndKey), []*tikv.Region{
@@ -597,7 +597,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 	// span6
 	startKey = appendNew(totalSpan.StartKey, byte('f'))
 	endKey = totalSpan.EndKey
-	span6 := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: startKey, EndKey: endKey}
+	span6 := heartbeatpb.NewTableSpan(int64(1), startKey, endKey, totalSpan.KeyspaceID)
 	spanReplica = replica.NewSpanReplication(cfID, common.NewDispatcherID(), 1, span6, 1, common.DefaultMode)
 	spanReplica.SetNodeID(nodeIDList[2])
 	regionCache.SetRegions(fmt.Sprintf("%s-%s", span6.StartKey, span6.EndKey), []*tikv.Region{
@@ -1033,7 +1033,7 @@ func TestBalance(t *testing.T) {
 	s := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
 	for i := 0; i < 100; i++ {
 		sz := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
-		span := &heartbeatpb.TableSpan{TableID: sz.TableID, StartKey: sz.StartKey, EndKey: sz.EndKey}
+		span := heartbeatpb.NewTableSpan(sz.TableID, sz.StartKey, sz.EndKey, sz.KeyspaceID)
 		dispatcherID := common.NewDispatcherID()
 		spanReplica := replica.NewSpanReplication(cfID, dispatcherID, 1, span, 1, common.DefaultMode)
 		spanReplica.SetNodeID("node1")
@@ -1116,7 +1116,7 @@ func TestDefaultSpanIntoSplit(t *testing.T) {
 		},
 	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
 	totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, 1)
-	span := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: totalSpan.StartKey, EndKey: totalSpan.EndKey}
+	span := heartbeatpb.NewTableSpan(int64(1), totalSpan.StartKey, totalSpan.EndKey, totalSpan.KeyspaceID)
 	dispatcherID := common.NewDispatcherID()
 	spanReplica := replica.NewSpanReplication(cfID, dispatcherID, 1, span, 1, common.DefaultMode)
 	spanReplica.SetNodeID("node1")
@@ -1258,7 +1258,7 @@ func TestStoppedWhenMoving(t *testing.T) {
 	s := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
 	for i := 0; i < 2; i++ {
 		sz := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
-		span := &heartbeatpb.TableSpan{TableID: sz.TableID, StartKey: sz.StartKey, EndKey: sz.EndKey}
+		span := heartbeatpb.NewTableSpan(sz.TableID, sz.StartKey, sz.EndKey, sz.KeyspaceID)
 		dispatcherID := common.NewDispatcherID()
 		spanReplica := replica.NewSpanReplication(cfID, dispatcherID, 1, span, 1, common.DefaultMode)
 		spanReplica.SetNodeID("node1")
@@ -1309,7 +1309,7 @@ func TestFinishBootstrap(t *testing.T) {
 	s := NewController(cfID, 1, &mockThreadPool{},
 		config.GetDefaultReplicaConfig(), ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
 	totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, 1)
-	span := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: totalSpan.StartKey, EndKey: totalSpan.EndKey}
+	span := heartbeatpb.NewTableSpan(int64(1), totalSpan.StartKey, totalSpan.EndKey, totalSpan.KeyspaceID)
 	schemaStore := eventservice.NewMockSchemaStore()
 	schemaStore.SetTables(
 		[]commonEvent.Table{
@@ -1405,8 +1405,8 @@ func TestSplitTableWhenBootstrapFinished(t *testing.T) {
 		testutil.MockRegionWithKeyRange(2, appendNew(totalSpan2.StartKey, 'a'), totalSpan2.EndKey),
 	})
 
-	span1 := &heartbeatpb.TableSpan{TableID: 1, StartKey: appendNew(totalSpan.StartKey, 'a'), EndKey: appendNew(totalSpan.StartKey, 'b')}
-	span2 := &heartbeatpb.TableSpan{TableID: 1, StartKey: appendNew(totalSpan.StartKey, 'b'), EndKey: appendNew(totalSpan.StartKey, 'c')}
+	span1 := heartbeatpb.NewTableSpan(1, appendNew(totalSpan.StartKey, 'a'), appendNew(totalSpan.StartKey, 'b'), totalSpan.KeyspaceID)
+	span2 := heartbeatpb.NewTableSpan(1, appendNew(totalSpan.StartKey, 'b'), appendNew(totalSpan.StartKey, 'c'), totalSpan.KeyspaceID)
 
 	reportedSpans := []*heartbeatpb.BootstrapTableSpan{
 		{
@@ -1452,58 +1452,58 @@ func TestMapFindHole(t *testing.T) {
 	}{
 		{ // 0. all found.
 			spans: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")},
-				{StartKey: []byte("t1_2"), EndKey: []byte("t2_0")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t2_0"), 0),
 			},
-			rang: &heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+			rang: heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 		},
 		{ // 1. on hole in the middle.
 			spans: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")},
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
-			rang: &heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+			rang: heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			expectedHole: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_3")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_3"), 0),
 			},
 		},
 		{ // 2. two holes in the middle.
 			spans: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_2"), EndKey: []byte("t1_3")},
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t1_3"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
-			rang: &heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+			rang: heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			expectedHole: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")},
-				{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0),
+				heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0),
 			},
 		},
 		{ // 3. all missing.
 			spans: []*heartbeatpb.TableSpan{},
-			rang:  &heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+			rang:  heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			expectedHole: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			},
 		},
 		{ // 4. start not found
 			spans: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
-			rang: &heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+			rang: heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			expectedHole: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_4")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_4"), 0),
 			},
 		},
 		{ // 5. end not found
 			spans: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
 			},
-			rang: &heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+			rang: heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			expectedHole: []*heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_1"), EndKey: []byte("t2_0")},
+				heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t2_0"), 0),
 			},
 		},
 	}

--- a/maintainer/maintainer_manager_test.go
+++ b/maintainer/maintainer_manager_test.go
@@ -317,22 +317,13 @@ func TestMaintainerBootstrapWithTablesReported(t *testing.T) {
 	}
 	for i := 1; i < 3; i++ {
 		span := common.TableIDToComparableSpan(keyspaceID, int64(i))
-		tableSpan := &heartbeatpb.TableSpan{
-			TableID:  int64(i),
-			StartKey: span.StartKey,
-			EndKey:   span.EndKey,
-		}
+		tableSpan := heartbeatpb.NewTableSpan(int64(i), span.StartKey, span.EndKey, keyspaceID)
 		dispatcherID := common.NewDispatcherID()
 		remotedIds = append(remotedIds, dispatcherID)
 		dispManager.bootstrapTables = append(dispManager.bootstrapTables, &heartbeatpb.BootstrapTableSpan{
-			ID:       dispatcherID.ToPB(),
-			SchemaID: 1,
-			Span: &heartbeatpb.TableSpan{
-				TableID:    tableSpan.TableID,
-				StartKey:   tableSpan.StartKey,
-				EndKey:     tableSpan.EndKey,
-				KeyspaceID: keyspaceID,
-			},
+			ID:              dispatcherID.ToPB(),
+			SchemaID:        1,
+			Span:            tableSpan,
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    10,
 		})

--- a/maintainer/operator/operator_add_test.go
+++ b/maintainer/operator/operator_add_test.go
@@ -32,11 +32,7 @@ func TestAddOperator_DestNodeRemoved(t *testing.T) {
 
 	// Create a new replica set for adding
 	dispatcherID := common.NewDispatcherID()
-	tableSpan := &heartbeatpb.TableSpan{
-		TableID:  200,
-		StartKey: []byte("a"),
-		EndKey:   []byte("b"),
-	}
+	tableSpan := heartbeatpb.NewTableSpan(200, []byte("a"), []byte("b"), 0)
 
 	absentReplicaSet := replica.NewSpanReplication(
 		changefeedID,

--- a/maintainer/operator/operator_merge.go
+++ b/maintainer/operator/operator_merge.go
@@ -76,12 +76,12 @@ func NewMergeDispatcherOperator(
 	}
 
 	// bind the new replica set to the node.
-	mergeTableSpan := &heartbeatpb.TableSpan{
-		TableID:    toMergedSpans[0].TableID,
-		StartKey:   toMergedSpans[0].StartKey,
-		EndKey:     toMergedSpans[len(toMergedSpans)-1].EndKey,
-		KeyspaceID: spanController.GetkeyspaceID(),
-	}
+	mergeTableSpan := heartbeatpb.NewTableSpan(
+		toMergedSpans[0].TableID,
+		toMergedSpans[0].StartKey,
+		toMergedSpans[len(toMergedSpans)-1].EndKey,
+		spanController.GetkeyspaceID(),
+	)
 
 	newReplicaSet := replica.NewSpanReplication(
 		toMergedReplicaSets[0].ChangefeedID,

--- a/maintainer/operator/operator_merge_test.go
+++ b/maintainer/operator/operator_merge_test.go
@@ -32,11 +32,7 @@ func setupMergeTestEnvironment(t *testing.T) (*span.Controller, []*replica.SpanR
 
 	// Create two consecutive spans to merge
 	dispatcherID1 := common.NewDispatcherID()
-	span1 := &heartbeatpb.TableSpan{
-		TableID:  100,
-		StartKey: []byte("a"),
-		EndKey:   []byte("m"),
-	}
+	span1 := heartbeatpb.NewTableSpan(100, []byte("a"), []byte("m"), 0)
 	status1 := &heartbeatpb.TableSpanStatus{
 		ID:              dispatcherID1.ToPB(),
 		ComponentStatus: heartbeatpb.ComponentState_Working,
@@ -52,11 +48,7 @@ func setupMergeTestEnvironment(t *testing.T) (*span.Controller, []*replica.SpanR
 	)
 
 	dispatcherID2 := common.NewDispatcherID()
-	span2 := &heartbeatpb.TableSpan{
-		TableID:  100,
-		StartKey: []byte("m"),
-		EndKey:   []byte("z"),
-	}
+	span2 := heartbeatpb.NewTableSpan(100, []byte("m"), []byte("z"), 0)
 	status2 := &heartbeatpb.TableSpanStatus{
 		ID:              dispatcherID2.ToPB(),
 		ComponentStatus: heartbeatpb.ComponentState_Working,

--- a/maintainer/operator/operator_split_test.go
+++ b/maintainer/operator/operator_split_test.go
@@ -32,16 +32,8 @@ func TestSplitOperator_OriginNodeRemovedBeforeStopped(t *testing.T) {
 
 	// Define split spans
 	splitSpans := []*heartbeatpb.TableSpan{
-		{
-			TableID:  100,
-			StartKey: []byte("a"),
-			EndKey:   []byte("m"),
-		},
-		{
-			TableID:  100,
-			StartKey: []byte("m"),
-			EndKey:   []byte("z"),
-		},
+		heartbeatpb.NewTableSpan(100, []byte("a"), []byte("m"), 0),
+		heartbeatpb.NewTableSpan(100, []byte("m"), []byte("z"), 0),
 	}
 
 	// Split targets are empty, meaning let scheduler decide
@@ -83,16 +75,8 @@ func TestSplitOperator_OriginNodeRemovedAfterStopped(t *testing.T) {
 
 	// Define split spans
 	splitSpans := []*heartbeatpb.TableSpan{
-		{
-			TableID:  100,
-			StartKey: []byte("a"),
-			EndKey:   []byte("m"),
-		},
-		{
-			TableID:  100,
-			StartKey: []byte("m"),
-			EndKey:   []byte("z"),
-		},
+		heartbeatpb.NewTableSpan(100, []byte("a"), []byte("m"), 0),
+		heartbeatpb.NewTableSpan(100, []byte("m"), []byte("z"), 0),
 	}
 
 	// Split targets are empty, meaning let scheduler decide

--- a/maintainer/replica/replication_span.go
+++ b/maintainer/replica/replication_span.go
@@ -126,12 +126,7 @@ func (r *SpanReplication) initStatus(status *heartbeatpb.TableSpanStatus) {
 
 func (r *SpanReplication) initGroupID() {
 	r.groupID = replica.DefaultGroupID
-	span := heartbeatpb.TableSpan{
-		TableID:    r.Span.TableID,
-		StartKey:   r.Span.StartKey,
-		EndKey:     r.Span.EndKey,
-		KeyspaceID: r.Span.KeyspaceID,
-	}
+	span := *r.Span.Copy()
 	// check if the table is split
 	totalSpan := common.TableIDToComparableSpan(span.KeyspaceID, span.TableID)
 	if !common.IsSubSpan(span, totalSpan) {

--- a/maintainer/replica/replication_span_test.go
+++ b/maintainer/replica/replication_span_test.go
@@ -58,9 +58,5 @@ func TestSpanReplication_NewAddDispatcherMessage(t *testing.T) {
 // getTableSpanByID returns a mock TableSpan for testing
 func getTableSpanByID(id common.TableID) *heartbeatpb.TableSpan {
 	totalSpan := common.TableIDToComparableSpan(0, id)
-	return &heartbeatpb.TableSpan{
-		TableID:  totalSpan.TableID,
-		StartKey: totalSpan.StartKey,
-		EndKey:   totalSpan.EndKey,
-	}
+	return heartbeatpb.NewTableSpan(totalSpan.TableID, totalSpan.StartKey, totalSpan.EndKey, totalSpan.KeyspaceID)
 }

--- a/maintainer/replica/split_span_checker_test.go
+++ b/maintainer/replica/split_span_checker_test.go
@@ -62,11 +62,7 @@ func splitTableSpanIntoMultiple(spanA *heartbeatpb.TableSpan, count int) []*hear
 		if i == count-1 {
 			endKey = spanA.EndKey
 		}
-		spans = append(spans, &heartbeatpb.TableSpan{
-			TableID:  spanA.TableID,
-			StartKey: startKey,
-			EndKey:   endKey,
-		})
+		spans = append(spans, heartbeatpb.NewTableSpan(spanA.TableID, startKey, endKey, spanA.KeyspaceID))
 	}
 
 	return spans
@@ -171,11 +167,7 @@ func TestSplitSpanChecker_RemoveReplica(t *testing.T) {
 	require.Contains(t, checker.allTasks, replicas[2].ID)
 
 	// Remove non-existing replica (no-op)
-	nonExistingReplica := NewSpanReplication(cfID, common.NewDispatcherID(), 100000, &heartbeatpb.TableSpan{
-		TableID:  100000,
-		StartKey: []byte{1},
-		EndKey:   []byte{2},
-	}, 1, common.DefaultMode)
+	nonExistingReplica := NewSpanReplication(cfID, common.NewDispatcherID(), 100000, heartbeatpb.NewTableSpan(100000, []byte{1}, []byte{2}, 0), 1, common.DefaultMode)
 	checker.RemoveReplica(nonExistingReplica)
 	require.Len(t, checker.allTasks, len(replicas)-1) // Should not change
 

--- a/maintainer/span/span_controller.go
+++ b/maintainer/span/span_controller.go
@@ -149,12 +149,7 @@ func (c *Controller) AddNewTable(table commonEvent.Table, startTs uint64) {
 	keyspaceID := c.GetkeyspaceID()
 
 	span := common.TableIDToComparableSpan(keyspaceID, table.TableID)
-	tableSpan := &heartbeatpb.TableSpan{
-		TableID:    table.TableID,
-		StartKey:   span.StartKey,
-		EndKey:     span.EndKey,
-		KeyspaceID: keyspaceID,
-	}
+	tableSpan := heartbeatpb.NewTableSpan(table.TableID, span.StartKey, span.EndKey, keyspaceID)
 	tableSpans := []*heartbeatpb.TableSpan{tableSpan}
 
 	// Determine if the table can be split based on configuration and table splittable status

--- a/maintainer/split/region_count_splitter.go
+++ b/maintainer/split/region_count_splitter.go
@@ -114,13 +114,12 @@ func (m *regionCountSplitter) split(
 				zap.Any("endKey", endKey))
 			return []*heartbeatpb.TableSpan{span}
 		}
-		spans = append(spans, &heartbeatpb.TableSpan{
-			TableID:    span.TableID,
-			StartKey:   startKey,
-			EndKey:     endKey,
-			KeyspaceID: m.keyspaceID,
-		},
-		)
+		spans = append(spans, heartbeatpb.NewTableSpan(
+			span.TableID,
+			startKey,
+			endKey,
+			m.keyspaceID,
+		))
 
 		if end == len(regions) {
 			break

--- a/maintainer/split/region_count_splitter_test.go
+++ b/maintainer/split/region_count_splitter_test.go
@@ -33,12 +33,12 @@ import (
 func TestRegionCountSplitSpan(t *testing.T) {
 	cache := NewMockRegionCache(nil)
 	appcontext.SetService(appcontext.RegionCache, cache)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")}, 1)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")}, 2)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_2"), EndKey: []byte("t1_3")}, 3)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")}, 4)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_4"), EndKey: []byte("t2_2")}, 5)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t2_2"), EndKey: []byte("t2_3")}, 6)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0), 1)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0), 2)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t1_3"), 0), 3)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0), 4)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_2"), 0), 5)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t2_2"), []byte("t2_3"), 0), 6)
 
 	cases := []struct {
 		span        *heartbeatpb.TableSpan
@@ -47,78 +47,78 @@ func TestRegionCountSplitSpan(t *testing.T) {
 		expectSpans []*heartbeatpb.TableSpan
 	}{
 		{
-			span: &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")},
+			span: heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0),
 			cfg: &config.ChangefeedSchedulerConfig{
 				RegionThreshold:    1,
 				RegionCountPerSpan: 1,
 			},
 			spansNum: 0,
 			expectSpans: []*heartbeatpb.TableSpan{
-				{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t1_1")},   // 1 region
-				{TableID: 1, StartKey: []byte("t1_1"), EndKey: []byte("t1_2")}, // 1 region
-				{TableID: 1, StartKey: []byte("t1_2"), EndKey: []byte("t1_3")}, // 1 region
-				{TableID: 1, StartKey: []byte("t1_3"), EndKey: []byte("t1_4")}, // 1 region
-				{TableID: 1, StartKey: []byte("t1_4"), EndKey: []byte("t2")},   // 1 region
+				heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t1_1"), 0),   // 1 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_1"), []byte("t1_2"), 0), // 1 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_2"), []byte("t1_3"), 0), // 1 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_3"), []byte("t1_4"), 0), // 1 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_4"), []byte("t2"), 0),   // 1 region
 			},
 		},
 		{
-			span: &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")},
+			span: heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0),
 			cfg: &config.ChangefeedSchedulerConfig{
 				RegionThreshold:    1,
 				RegionCountPerSpan: 2,
 			},
 			spansNum: 0,
 			expectSpans: []*heartbeatpb.TableSpan{
-				{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t1_2")},   // 2 region
-				{TableID: 1, StartKey: []byte("t1_2"), EndKey: []byte("t1_4")}, // 2 region
-				{TableID: 1, StartKey: []byte("t1_4"), EndKey: []byte("t2")},   // 1 region
+				heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t1_2"), 0),   // 2 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_2"), []byte("t1_4"), 0), // 2 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_4"), []byte("t2"), 0),   // 1 region
 			},
 		},
 		{
-			span: &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")},
+			span: heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0),
 			cfg: &config.ChangefeedSchedulerConfig{
 				RegionThreshold:    1,
 				RegionCountPerSpan: 3,
 			},
 			spansNum: 0,
 			expectSpans: []*heartbeatpb.TableSpan{
-				{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t1_3")}, // 3 region
-				{TableID: 1, StartKey: []byte("t1_3"), EndKey: []byte("t2")}, // 2 region
+				heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t1_3"), 0), // 3 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_3"), []byte("t2"), 0), // 2 region
 			},
 		},
 		{
-			span: &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")},
+			span: heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0),
 			cfg: &config.ChangefeedSchedulerConfig{
 				RegionThreshold:    1,
 				RegionCountPerSpan: 4,
 			},
 			spansNum: 0,
 			expectSpans: []*heartbeatpb.TableSpan{
-				{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t1_3")}, // 3 region
-				{TableID: 1, StartKey: []byte("t1_3"), EndKey: []byte("t2")}, // 2 region
+				heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t1_3"), 0), // 3 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_3"), []byte("t2"), 0), // 2 region
 			},
 		},
 		{
-			span: &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")},
+			span: heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0),
 			cfg: &config.ChangefeedSchedulerConfig{
 				RegionThreshold:    10,
 				RegionCountPerSpan: 2,
 			},
 			spansNum: 0,
 			expectSpans: []*heartbeatpb.TableSpan{
-				{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")}, // no split
+				heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0), // no split
 			},
 		},
 		{
-			span: &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")},
+			span: heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0),
 			cfg: &config.ChangefeedSchedulerConfig{
 				RegionThreshold:    1,
 				RegionCountPerSpan: 1,
 			},
 			spansNum: 2,
 			expectSpans: []*heartbeatpb.TableSpan{
-				{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t1_3")}, // 3 region
-				{TableID: 1, StartKey: []byte("t1_3"), EndKey: []byte("t2")}, // 2 region
+				heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t1_3"), 0), // 3 region
+				heartbeatpb.NewTableSpan(1, []byte("t1_3"), []byte("t2"), 0), // 2 region
 			},
 		},
 	}
@@ -136,10 +136,10 @@ func TestRegionCountEvenlySplitSpan(t *testing.T) {
 	appcontext.SetService(appcontext.RegionCache, cache)
 	totalRegion := 1000
 	for i := 0; i < totalRegion; i++ {
-		cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{
-			StartKey: []byte(fmt.Sprintf("t1_%09d", i)),
-			EndKey:   []byte(fmt.Sprintf("t1_%09d", i+1)),
-		}, uint64(i+1))
+		cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0,
+			[]byte(fmt.Sprintf("t1_%09d", i)),
+			[]byte(fmt.Sprintf("t1_%09d", i+1)),
+			0), uint64(i+1))
 	}
 
 	cases := []struct {
@@ -214,7 +214,7 @@ func TestRegionCountEvenlySplitSpan(t *testing.T) {
 	}
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
-	spans := &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")}
+	spans := heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0)
 	for i, cs := range cases {
 		splitter := newRegionCountSplitter(common.DefaultKeyspaceID, cfID, cs.cfg.RegionCountPerSpan, cs.cfg.RegionThreshold)
 		spans := splitter.split(context.Background(), spans, cs.spansNum)
@@ -225,9 +225,9 @@ func TestRegionCountEvenlySplitSpan(t *testing.T) {
 func TestSplitSpanRegionOutOfOrder(t *testing.T) {
 	cache := NewMockRegionCache(nil)
 	appcontext.SetService(appcontext.RegionCache, cache)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")}, 1)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_1"), EndKey: []byte("t1_4")}, 2)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_2"), EndKey: []byte("t1_3")}, 3)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0), 1)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_4"), 0), 2)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t1_3"), 0), 3)
 
 	cfg := &config.ChangefeedSchedulerConfig{
 		RegionThreshold:    1,
@@ -235,10 +235,10 @@ func TestSplitSpanRegionOutOfOrder(t *testing.T) {
 	}
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	splitter := newRegionCountSplitter(common.DefaultKeyspaceID, cfID, cfg.RegionCountPerSpan, cfg.RegionCountPerSpan)
-	span := &heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")}
+	span := heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0)
 	spans := splitter.split(context.Background(), span, 0)
 	require.Equal(
-		t, []*heartbeatpb.TableSpan{{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t2")}}, spans)
+		t, []*heartbeatpb.TableSpan{heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0)}, spans)
 }
 
 // mockCache mocks tikv.RegionCache.

--- a/maintainer/split/splitter_test.go
+++ b/maintainer/split/splitter_test.go
@@ -59,12 +59,12 @@ func TestSplitter_Split_ByRegion(t *testing.T) {
 	// Set up RegionCache service for testing
 	cache := NewMockRegionCache(nil)
 	appcontext.SetService(appcontext.RegionCache, cache)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")}, 1)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")}, 2)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_2"), EndKey: []byte("t1_3")}, 3)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")}, 4)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t1_4"), EndKey: []byte("t2_2")}, 5)
-	cache.regions.ReplaceOrInsert(heartbeatpb.TableSpan{StartKey: []byte("t2_2"), EndKey: []byte("t2_3")}, 6)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0), 1)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0), 2)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t1_3"), 0), 3)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0), 4)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_2"), 0), 5)
+	cache.regions.ReplaceOrInsert(*heartbeatpb.NewTableSpan(0, []byte("t2_2"), []byte("t2_3"), 0), 6)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	cfg := &config.ChangefeedSchedulerConfig{
@@ -75,15 +75,11 @@ func TestSplitter_Split_ByRegion(t *testing.T) {
 
 	splitter := NewSplitter(0, cfID, cfg)
 
-	span := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("t1"),
-		EndKey:   []byte("t2"),
-	}
+	span := heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t2"), 0)
 
 	// Test splitting by region count
 	spans := splitter.Split(context.Background(), span, 2, SplitTypeRegionCount)
 	re.Equal(2, len(spans))
-	re.Equal(&heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1"), EndKey: []byte("t1_3")}, spans[0])
-	re.Equal(&heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("t1_3"), EndKey: []byte("t2")}, spans[1])
+	re.Equal(heartbeatpb.NewTableSpan(1, []byte("t1"), []byte("t1_3"), 0), spans[0])
+	re.Equal(heartbeatpb.NewTableSpan(1, []byte("t1_3"), []byte("t2"), 0), spans[1])
 }

--- a/maintainer/split/write_bytes_splitter_test.go
+++ b/maintainer/split/write_bytes_splitter_test.go
@@ -226,7 +226,7 @@ func TestSplitRegionsByWrittenKeysConfig(t *testing.T) {
 	}
 
 	// When PD returns no regions, split should return empty spans
-	spans := splitter.split(context.Background(), &heartbeatpb.TableSpan{}, 3)
+	spans := splitter.split(context.Background(), heartbeatpb.NewTableSpan(0, nil, nil, 0), 3)
 	require.Empty(t, spans)
 }
 

--- a/maintainer/testutil/test_util.go
+++ b/maintainer/testutil/test_util.go
@@ -33,11 +33,7 @@ import (
 // GetTableSpanByID returns a mock TableSpan for testing
 func GetTableSpanByID(id common.TableID) *heartbeatpb.TableSpan {
 	totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, id)
-	return &heartbeatpb.TableSpan{
-		TableID:  totalSpan.TableID,
-		StartKey: totalSpan.StartKey,
-		EndKey:   totalSpan.EndKey,
-	}
+	return heartbeatpb.NewTableSpan(totalSpan.TableID, totalSpan.StartKey, totalSpan.EndKey, totalSpan.KeyspaceID)
 }
 
 // InitializeTestServices sets up the node manager and message center for testing

--- a/pkg/common/format_test.go
+++ b/pkg/common/format_test.go
@@ -179,12 +179,8 @@ func TestFormatTableSpan(t *testing.T) {
 			isEmptyString: true,
 		},
 		{
-			name: "normal span",
-			input: &heartbeatpb.TableSpan{
-				TableID:  1,
-				StartKey: []byte("start"),
-				EndKey:   []byte("end"),
-			},
+			name:          "normal span",
+			input:         heartbeatpb.NewTableSpan(1, []byte("start"), []byte("end"), 0),
 			isEmptyString: false,
 		},
 	}

--- a/pkg/common/span_hash_map.go
+++ b/pkg/common/span_hash_map.go
@@ -110,11 +110,8 @@ func toHashableSpan(span heartbeatpb.TableSpan) hashableSpan {
 
 // toSpan converts to Span.
 func (h hashableSpan) toSpan() heartbeatpb.TableSpan {
-	return heartbeatpb.TableSpan{
-		TableID:  h.TableID,
-		StartKey: unsafeStringToBytes(h.StartKey),
-		EndKey:   unsafeStringToBytes(h.EndKey),
-	}
+	span := heartbeatpb.NewTableSpan(h.TableID, unsafeStringToBytes(h.StartKey), unsafeStringToBytes(h.EndKey), 0)
+	return *span
 }
 
 // unsafeStringToBytes converts string to byte without memory allocation.

--- a/pkg/common/span_test.go
+++ b/pkg/common/span_test.go
@@ -76,29 +76,29 @@ func TestIntersect(t *testing.T) {
 		res *heartbeatpb.TableSpan
 	}{
 		{
-			lhs: heartbeatpb.TableSpan{StartKey: nil, EndKey: []byte{1}},
-			rhs: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: nil},
+			lhs: *heartbeatpb.NewTableSpan(0, nil, []byte{1}, 0),
+			rhs: *heartbeatpb.NewTableSpan(0, []byte{1}, nil, 0),
 			res: nil,
 		},
 		{
-			lhs: heartbeatpb.TableSpan{StartKey: nil, EndKey: nil},
-			rhs: heartbeatpb.TableSpan{StartKey: nil, EndKey: nil},
-			res: &heartbeatpb.TableSpan{StartKey: nil, EndKey: nil},
+			lhs: *heartbeatpb.NewTableSpan(0, nil, nil, 0),
+			rhs: *heartbeatpb.NewTableSpan(0, nil, nil, 0),
+			res: heartbeatpb.NewTableSpan(0, nil, nil, 0),
 		},
 		{
-			lhs: heartbeatpb.TableSpan{StartKey: nil, EndKey: nil},
-			rhs: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
-			res: &heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			lhs: *heartbeatpb.NewTableSpan(0, nil, nil, 0),
+			rhs: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
+			res: heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 		},
 		{
-			lhs: heartbeatpb.TableSpan{StartKey: []byte{0}, EndKey: []byte{3}},
-			rhs: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
-			res: &heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			lhs: *heartbeatpb.NewTableSpan(0, []byte{0}, []byte{3}, 0),
+			rhs: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
+			res: heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 		},
 		{
-			lhs: heartbeatpb.TableSpan{StartKey: []byte{0}, EndKey: []byte{2}},
-			rhs: heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
-			res: &heartbeatpb.TableSpan{StartKey: []byte{1}, EndKey: []byte{2}},
+			lhs: *heartbeatpb.NewTableSpan(0, []byte{0}, []byte{2}, 0),
+			rhs: *heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
+			res: heartbeatpb.NewTableSpan(0, []byte{1}, []byte{2}, 0),
 		},
 	}
 

--- a/pkg/common/table_span.go
+++ b/pkg/common/table_span.go
@@ -105,3 +105,15 @@ func KeyspaceDDLSpan(keyspaceID uint32) *heartbeatpb.TableSpan {
 func LessTableSpan(t1, t2 *heartbeatpb.TableSpan) bool {
 	return t1.Less(t2)
 }
+
+// NewTableSpan creates a new TableSpan with all fields specified.
+// This is a convenience wrapper around heartbeatpb.NewTableSpan.
+func NewTableSpan(tableID int64, startKey, endKey []byte, keyspaceID uint32) *heartbeatpb.TableSpan {
+	return heartbeatpb.NewTableSpan(tableID, startKey, endKey, keyspaceID)
+}
+
+// NewTableSpanFromKeys creates a new TableSpan from keys without a TableID.
+// This is useful for creating spans that represent key ranges rather than specific tables.
+func NewTableSpanFromKeys(startKey, endKey []byte, keyspaceID uint32) *heartbeatpb.TableSpan {
+	return heartbeatpb.NewTableSpan(0, startKey, endKey, keyspaceID)
+}

--- a/pkg/common/table_span_test.go
+++ b/pkg/common/table_span_test.go
@@ -21,11 +21,7 @@ import (
 )
 
 func TestMergeDataRange(t *testing.T) {
-	span1 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}
+	span1 := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
 	dataRange1 := NewDataRange(1, span1, 10, 20)
 	dataRange2 := NewDataRange(1, span1, 15, 25)
 
@@ -43,32 +39,16 @@ func TestMergeDataRange(t *testing.T) {
 	require.Equal(t, expectedDataRange, mergedDataRange)
 
 	// Case 3: Merge two data ranges with different spans.
-	span2 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("b"),
-		EndKey:   []byte("y"),
-	}
+	span2 := heartbeatpb.NewTableSpan(1, []byte("b"), []byte("y"), 0)
 	dataRange4 := NewDataRange(1, span2, 10, 20)
 	mergedDataRange = dataRange1.Merge(dataRange4)
 	require.Nil(t, mergedDataRange)
 }
 
 func TestDataRangeEqual(t *testing.T) {
-	span1 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}
-	span2 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}
-	span3 := &heartbeatpb.TableSpan{
-		TableID:  2,
-		StartKey: []byte("b"),
-		EndKey:   []byte("y"),
-	}
+	span1 := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
+	span2 := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
+	span3 := heartbeatpb.NewTableSpan(2, []byte("b"), []byte("y"), 0)
 
 	dataRange1 := NewDataRange(1, span1, 10, 20)
 	dataRange2 := NewDataRange(1, span2, 10, 20)
@@ -81,21 +61,9 @@ func TestDataRangeEqual(t *testing.T) {
 }
 
 func TestTableSpanLess(t *testing.T) {
-	span1 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}
-	span2 := &heartbeatpb.TableSpan{
-		TableID:  2,
-		StartKey: []byte("b"),
-		EndKey:   []byte("y"),
-	}
-	span3 := &heartbeatpb.TableSpan{
-		TableID:  2,
-		StartKey: []byte("c"),
-		EndKey:   []byte("x"),
-	}
+	span1 := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
+	span2 := heartbeatpb.NewTableSpan(2, []byte("b"), []byte("y"), 0)
+	span3 := heartbeatpb.NewTableSpan(2, []byte("c"), []byte("x"), 0)
 
 	require.True(t, span1.Less(span2))
 	require.False(t, span2.Less(span1))
@@ -103,21 +71,9 @@ func TestTableSpanLess(t *testing.T) {
 }
 
 func TestTableSpanEqual(t *testing.T) {
-	span1 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}
-	span2 := &heartbeatpb.TableSpan{
-		TableID:  1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}
-	span3 := &heartbeatpb.TableSpan{
-		TableID:  2,
-		StartKey: []byte("b"),
-		EndKey:   []byte("y"),
-	}
+	span1 := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
+	span2 := heartbeatpb.NewTableSpan(1, []byte("a"), []byte("z"), 0)
+	span3 := heartbeatpb.NewTableSpan(2, []byte("b"), []byte("y"), 0)
 
 	require.True(t, span1.Equal(span2))
 	require.False(t, span1.Equal(span3))

--- a/pkg/eventservice/event_scanner_test.go
+++ b/pkg/eventservice/event_scanner_test.go
@@ -1144,7 +1144,7 @@ func TestScanSession(t *testing.T) {
 		ctx := context.Background()
 		dispStat := &dispatcherStat{}
 		dataRange := common.DataRange{
-			Span:          &heartbeatpb.TableSpan{TableID: 123},
+			Span:          heartbeatpb.NewTableSpan(123, nil, nil, 0),
 			CommitTsStart: 100,
 			CommitTsEnd:   200,
 		}
@@ -1450,9 +1450,7 @@ func TestScanAndMergeEventsSingleUKUpdate(t *testing.T) {
 	}
 
 	dataRange := common.DataRange{
-		Span: &heartbeatpb.TableSpan{
-			TableID: tableID,
-		},
+		Span:          heartbeatpb.NewTableSpan(tableID, nil, nil, 0),
 		CommitTsStart: updateEvent.StartTs,
 		CommitTsEnd:   updateEvent.CRTs + 100,
 	}

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -406,17 +406,13 @@ func newMockDispatcherInfo(t *testing.T, startTs uint64, dispatcherID common.Dis
 		id:           dispatcherID,
 		changefeedID: common.NewChangefeedID4Test("default", "test"),
 		topic:        "topic1",
-		span: &heartbeatpb.TableSpan{
-			TableID:  tableID,
-			StartKey: []byte("a"),
-			EndKey:   []byte("z"),
-		},
-		startTs:    startTs,
-		actionType: actionType,
-		filter:     filter,
-		bdrMode:    false,
-		integrity:  config.GetDefaultReplicaConfig().Integrity,
-		tz:         time.Local,
+		span:         heartbeatpb.NewTableSpan(tableID, []byte("a"), []byte("z"), 0),
+		startTs:      startTs,
+		actionType:   actionType,
+		filter:       filter,
+		bdrMode:      false,
+		integrity:    config.GetDefaultReplicaConfig().Integrity,
+		tz:           time.Local,
 	}
 }
 

--- a/pkg/pdutil/api_client_test.go
+++ b/pkg/pdutil/api_client_test.go
@@ -213,14 +213,14 @@ func TestScanRegions(t *testing.T) {
 		}
 		return RegionsInfo{Regions: regions[start:end]}
 	}
-	rs, err := pc.scanRegions(context.Background(), heartbeatpb.TableSpan{}, []string{mockPDServer.URL}, 1)
+	rs, err := pc.scanRegions(context.Background(), *heartbeatpb.NewTableSpan(0, nil, nil, 0), []string{mockPDServer.URL}, 1)
 	require.NoError(t, err)
 	require.Equal(t, 7, len(rs))
 
 	handler = func() RegionsInfo {
 		return RegionsInfo{Regions: regions}
 	}
-	rs, err = pc.scanRegions(context.Background(), heartbeatpb.TableSpan{}, []string{mockPDServer.URL}, 1024)
+	rs, err = pc.scanRegions(context.Background(), *heartbeatpb.NewTableSpan(0, nil, nil, 0), []string{mockPDServer.URL}, 1024)
 	require.NoError(t, err)
 	require.Equal(t, 7, len(rs))
 
@@ -234,7 +234,7 @@ func TestScanRegions(t *testing.T) {
 	}
 	rs, err = pc.scanRegions(
 		context.Background(),
-		heartbeatpb.TableSpan{StartKey: []byte{0, 2, 0}, EndKey: []byte{0, 3}},
+		*heartbeatpb.NewTableSpan(0, []byte{0, 2, 0}, []byte{0, 3}, 0),
 		[]string{mockPDServer.URL}, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rs))
@@ -257,7 +257,7 @@ func TestScanRegions(t *testing.T) {
 	}
 	rs, err = pc.scanRegions(
 		context.Background(),
-		heartbeatpb.TableSpan{StartKey: []byte{0, 2, 0}, EndKey: []byte{0, 4, 0}},
+		*heartbeatpb.NewTableSpan(0, []byte{0, 2, 0}, []byte{0, 4, 0}, 0),
 		[]string{mockPDServer.URL}, 1)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(rs))

--- a/pkg/spanz/btree_map_test.go
+++ b/pkg/spanz/btree_map_test.go
@@ -26,49 +26,49 @@ func TestSpanMap(t *testing.T) {
 	m := NewBtreeMap[int]()
 
 	// Insert then get.
-	m.ReplaceOrInsert(heartbeatpb.TableSpan{TableID: 1}, 1)
-	v, ok := m.Get(heartbeatpb.TableSpan{TableID: 1})
+	m.ReplaceOrInsert(*heartbeatpb.NewTableSpan(1, nil, nil, 0), 1)
+	v, ok := m.Get(*heartbeatpb.NewTableSpan(1, nil, nil, 0))
 	require.Equal(t, v, 1)
 	require.True(t, ok)
 	require.Equal(t, 1, m.Len())
-	require.True(t, m.Has(heartbeatpb.TableSpan{TableID: 1}))
+	require.True(t, m.Has(*heartbeatpb.NewTableSpan(1, nil, nil, 0)))
 
 	// Insert then get again.
-	m.ReplaceOrInsert(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}}, 2)
+	m.ReplaceOrInsert(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0), 2)
 	require.Equal(t, 2, m.Len())
-	v, ok = m.Get(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	v, ok = m.Get(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0))
 	require.Equal(t, v, 2)
 	require.True(t, ok)
 
 	// Overwrite then get.
 	old, ok := m.ReplaceOrInsert(
-		heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}, EndKey: []byte{1}}, 3)
+		*heartbeatpb.NewTableSpan(1, []byte{1}, []byte{1}, 0), 3)
 	require.Equal(t, old, 2)
 	require.True(t, ok)
 	require.Equal(t, 2, m.Len())
-	require.True(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}}))
-	v, ok = m.Get(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	require.True(t, m.Has(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0)))
+	v, ok = m.Get(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0))
 	require.Equal(t, v, 3)
 	require.True(t, ok)
 
 	// get value
-	v = m.GetV(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	v = m.GetV(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0))
 	require.Equal(t, v, 3)
 
 	// Delete than get value
-	v, ok = m.Delete(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	v, ok = m.Delete(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0))
 	require.Equal(t, v, 3)
 	require.True(t, ok)
 	require.Equal(t, 1, m.Len())
-	require.False(t, m.Has(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}}))
-	v = m.GetV(heartbeatpb.TableSpan{TableID: 1, StartKey: []byte{1}})
+	require.False(t, m.Has(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0)))
+	v = m.GetV(*heartbeatpb.NewTableSpan(1, []byte{1}, nil, 0))
 	require.Equal(t, v, 0)
 
 	// Pointer value
 	mp := NewBtreeMap[*int]()
 	vp := &v
-	mp.ReplaceOrInsert(heartbeatpb.TableSpan{TableID: 1}, vp)
-	vp1, ok := mp.Get(heartbeatpb.TableSpan{TableID: 1})
+	mp.ReplaceOrInsert(*heartbeatpb.NewTableSpan(1, nil, nil, 0), vp)
+	vp1, ok := mp.Get(*heartbeatpb.NewTableSpan(1, nil, nil, 0))
 	require.Equal(t, vp, vp1)
 	require.True(t, ok)
 	require.Equal(t, 1, m.Len())
@@ -79,21 +79,21 @@ func TestMapAscend(t *testing.T) {
 
 	m := NewBtreeMap[int]()
 	for i := 0; i < 4; i++ {
-		m.ReplaceOrInsert(heartbeatpb.TableSpan{TableID: int64(i)}, i)
+		m.ReplaceOrInsert(*heartbeatpb.NewTableSpan(int64(i), nil, nil, 0), i)
 	}
 
 	j := 0
 	m.Ascend(func(span heartbeatpb.TableSpan, value int) bool {
-		require.Equal(t, heartbeatpb.TableSpan{TableID: int64(j)}, span)
+		require.Equal(t, *heartbeatpb.NewTableSpan(int64(j), nil, nil, 0), span)
 		j++
 		return true
 	})
 	require.Equal(t, 4, j)
 
 	j = 0
-	m.AscendRange(heartbeatpb.TableSpan{TableID: 1}, heartbeatpb.TableSpan{TableID: 2},
+	m.AscendRange(*heartbeatpb.NewTableSpan(1, nil, nil, 0), *heartbeatpb.NewTableSpan(2, nil, nil, 0),
 		func(span heartbeatpb.TableSpan, value int) bool {
-			require.Equal(t, heartbeatpb.TableSpan{TableID: 1}, span)
+			require.Equal(t, *heartbeatpb.NewTableSpan(1, nil, nil, 0), span)
 			j++
 			return true
 		})
@@ -111,97 +111,97 @@ func TestMapFindHole(t *testing.T) {
 	}{
 		{ // 0. all found.
 			spans: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")},
-				{StartKey: []byte("t1_2"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t2_0"), 0),
 			},
 			rang: [2]heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0")},
-				{StartKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), nil, 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t2_0"), nil, 0),
 			},
 			expectedFound: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")},
-				{StartKey: []byte("t1_2"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t2_0"), 0),
 			},
 		},
 		{ // 1. on hole in the middle.
 			spans: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")},
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
 			rang: [2]heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0")},
-				{StartKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), nil, 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t2_0"), nil, 0),
 			},
 			expectedFound: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")},
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
 			expectedHole: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_3")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_3"), 0),
 			},
 		},
 		{ // 2. two holes in the middle.
 			spans: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_2"), EndKey: []byte("t1_3")},
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t1_3"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
 			rang: [2]heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0")},
-				{StartKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), nil, 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t2_0"), nil, 0),
 			},
 			expectedFound: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
-				{StartKey: []byte("t1_2"), EndKey: []byte("t1_3")},
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_2"), []byte("t1_3"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
 			expectedHole: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_1"), EndKey: []byte("t1_2")},
-				{StartKey: []byte("t1_3"), EndKey: []byte("t1_4")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t1_2"), 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t1_3"), []byte("t1_4"), 0),
 			},
 		},
 		{ // 3. all missing.
 			spans: []heartbeatpb.TableSpan{},
 			rang: [2]heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0")},
-				{StartKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), nil, 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t2_0"), nil, 0),
 			},
 			expectedHole: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t2_0"), 0),
 			},
 		},
 		{ // 4. start not found
 			spans: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
 			rang: [2]heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0")},
-				{StartKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), nil, 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t2_0"), nil, 0),
 			},
 			expectedFound: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_4"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_4"), []byte("t2_0"), 0),
 			},
 			expectedHole: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_4")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_4"), 0),
 			},
 		},
 		{ // 5. end not found
 			spans: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
 			},
 			rang: [2]heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0")},
-				{StartKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), nil, 0),
+				*heartbeatpb.NewTableSpan(0, []byte("t2_0"), nil, 0),
 			},
 			expectedFound: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_0"), EndKey: []byte("t1_1")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_0"), []byte("t1_1"), 0),
 			},
 			expectedHole: []heartbeatpb.TableSpan{
-				{StartKey: []byte("t1_1"), EndKey: []byte("t2_0")},
+				*heartbeatpb.NewTableSpan(0, []byte("t1_1"), []byte("t2_0"), 0),
 			},
 		},
 	}

--- a/pkg/spanz/convert.go
+++ b/pkg/spanz/convert.go
@@ -38,7 +38,8 @@ func HexKey(key []byte) string {
 func ArrayToSpan(in []heartbeatpb.Table) []heartbeatpb.TableSpan {
 	out := make([]heartbeatpb.TableSpan, 0, len(in))
 	for _, table := range in {
-		out = append(out, heartbeatpb.TableSpan{TableID: table.GetTableID()})
+		span := heartbeatpb.NewTableSpan(table.GetTableID(), nil, nil, 0)
+		out = append(out, *span)
 	}
 	return out
 }
@@ -72,11 +73,8 @@ func toHashableSpan(span heartbeatpb.TableSpan) hashableSpan {
 
 // toSpan converts to Span.
 func (h hashableSpan) toSpan() heartbeatpb.TableSpan {
-	return heartbeatpb.TableSpan{
-		TableID:  h.TableID,
-		StartKey: unsafeStringToBytes(h.StartKey),
-		EndKey:   unsafeStringToBytes(h.EndKey),
-	}
+	span := heartbeatpb.NewTableSpan(h.TableID, unsafeStringToBytes(h.StartKey), unsafeStringToBytes(h.EndKey), 0)
+	return *span
 }
 
 // unsafeStringToBytes converts string to byte without memory allocation.

--- a/pkg/spanz/convert_test.go
+++ b/pkg/spanz/convert_test.go
@@ -34,7 +34,7 @@ func TestHashableSpan(t *testing.T) {
 }
 
 func TestHashableSpanHeapAlloc(t *testing.T) {
-	span := heartbeatpb.TableSpan{TableID: 1}
+	span := *heartbeatpb.NewTableSpan(1, nil, nil, 0)
 	for i := 0; i < 10; i++ {
 		span.StartKey = append(span.StartKey, byte(i))
 		span.EndKey = append(span.EndKey, byte(i))


### PR DESCRIPTION
### What problem does this PR solve?

This PR refactors the `heartbeatpb.TableSpan` struct by introducing a `NewTableSpan` constructor. This constructor ensures that all fields of `TableSpan` are properly initialized, preventing potential issues arising from uninitialized fields. This change aims to improve code robustness and maintainability by enforcing consistent initialization patterns for `TableSpan` objects across the codebase.

Issue Number: close #2689

### What is changed and how it works?

The primary change is the addition of the `NewTableSpan` function in `heartbeatpb/table_span.go`. This function serves as a factory for creating `TableSpan` instances, ensuring that `TableID`, `StartKey`, `EndKey`, and `KeyspaceID` are all explicitly set.

Throughout the codebase, instances of `heartbeatpb.TableSpan` that were previously created using struct literals (e.g., `&heartbeatpb.TableSpan{...}`) are now replaced with calls to `heartbeatpb.NewTableSpan(...)`. This systematic replacement ensures that all `TableSpan` objects are created using the new, safer constructor.

The `NewTableSpan` constructor is designed to be flexible and can be used to create `TableSpan` objects with any combination of fields populated, while still ensuring that all fields have a defined zero value if not explicitly provided.

### Check List

#### Tests

* Unit test
* Integration test
* Manual test (add detailed scripts or steps below)
* No code

#### Questions

##### Will it cause performance regression or break compatibility?

No, this change should not cause performance regressions. The `NewTableSpan` constructor is a simple initialization function, and replacing struct literals with constructor calls is a common refactoring that does not impact performance.

This change is backward-compatible as it only affects how `TableSpan` objects are created internally. Existing code that reads `TableSpan` objects will continue to function correctly.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No, this change is an internal refactoring and does not require updates to user-facing documentation, design documents, or monitoring configurations.

### Release note

```release-note
None
```
