### PR TITLE
[DNM] Test for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 	generate-next-gen-grafana
 
 
+
 FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1  }  }'
 
 PROJECT=ticdc


### PR DESCRIPTION
### What problem does this PR solve?
This PR addresses an issue where the `make test` command might not fail when tests produce output to stdout.

Issue Number: close #5774

### What is changed and how it works?
The `FAIL_ON_STDOUT` variable in the Makefile has been updated to ensure that any output to stdout during test execution will cause the `make test` command to exit with a non-zero status, indicating a failure.

*   Added a new line in the Makefile to ensure the `FAIL_ON_STDOUT` variable is correctly parsed.

### Check List
#### Tests
*   Unit test
*   Integration test

#### Questions
##### Will it cause performance regression or break compatibility?
No, this change should not cause performance regressions or break compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note
```release-note
Fix: Ensure `make test` fails on stdout output.
```
