### PR TITLE
codec: add more details for ErrMessageTooLarge

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -254,7 +254,7 @@ var (
 		errors.RFCCodeText("CDC:ErrSinkInvalidConfig"),
 	)
 	ErrMessageTooLarge = errors.Normalize(
-		"message is too large",
+		"message is too large. table:%s, length:%d, maxMessageBytes:%d",
 		errors.RFCCodeText("CDC:ErrMessageTooLarge"),
 	)
 	ErrStorageSinkInvalidDateSeparator = errors.Normalize(

--- a/pkg/sink/codec/avro/encoder.go
+++ b/pkg/sink/codec/avro/encoder.go
@@ -93,7 +93,7 @@ func (a *BatchEncoder) AppendRowChangedEvent(
 			zap.Int("maxMessageBytes", a.config.MaxMessageBytes),
 			zap.Int("length", message.Length()),
 			zap.Any("table", e.TableInfo.TableName))
-		return errors.ErrMessageTooLarge.GenWithStackByArgs(message.Length())
+		return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), message.Length(), a.config.MaxMessageBytes)
 	}
 
 	a.result = append(a.result, message)

--- a/pkg/sink/codec/canal/canal_json_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_encoder.go
@@ -468,13 +468,13 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 				zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
 				zap.Int("length", originLength),
 				zap.Any("table", e.TableInfo.TableName))
-			return errors.ErrMessageTooLarge.GenWithStackByArgs()
+			return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), originLength, c.config.MaxMessageBytes)
 		}
 
 		if c.config.LargeMessageHandle.HandleKeyOnly() {
 			value, err = newJSONMessageForDML(e, c.config, true, "")
 			if err != nil {
-				return errors.ErrMessageTooLarge.GenWithStackByArgs()
+				return errors.Trace(err)
 			}
 			value, err = common.Compress(
 				c.config.ChangefeedID, c.config.LargeMessageHandle.LargeMessageHandleCompression, value,
@@ -491,7 +491,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 					zap.Int("originLength", originLength),
 					zap.Int("length", length),
 					zap.Any("table", e.TableInfo.TableName))
-				return errors.ErrMessageTooLarge.GenWithStackByArgs()
+				return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), length, c.config.MaxMessageBytes)
 			}
 			log.Warn("Single message is too large for canal-json, only encode handle-key columns",
 				zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
@@ -543,7 +543,7 @@ func (c *JSONRowEventEncoder) newClaimCheckLocationMessage(
 			zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
 			zap.Int("length", length),
 			zap.Any("table", event.TableInfo.TableName))
-		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(length)
+		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), length, c.config.MaxMessageBytes)
 	}
 	return result, nil
 }

--- a/pkg/sink/codec/canal/canal_json_txn_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder.go
@@ -76,7 +76,7 @@ func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error 
 				zap.Int("maxMessageBytes", j.config.MaxMessageBytes),
 				zap.Int("length", length),
 				zap.Any("table", event.TableInfo.TableName))
-			return errors.ErrMessageTooLarge.GenWithStackByArgs()
+			return errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), length, j.config.MaxMessageBytes)
 		}
 		j.valueBuf.Write(value)
 		j.valueBuf.Write(j.terminator)

--- a/pkg/sink/codec/open/encoder.go
+++ b/pkg/sink/codec/open/encoder.go
@@ -103,7 +103,7 @@ func (d *batchEncoder) AppendRowChangedEvent(
 				zap.Int("length", length),
 				zap.Any("table", e.TableInfo.TableName),
 				zap.Any("key", key))
-			return errors.ErrMessageTooLarge.GenWithStackByArgs()
+			return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), length, d.config.MaxMessageBytes)
 		}
 
 		if d.config.LargeMessageHandle.EnableClaimCheck() {
@@ -127,7 +127,7 @@ func (d *batchEncoder) AppendRowChangedEvent(
 					zap.Int("maxMessageBytes", d.config.MaxMessageBytes),
 					zap.Int("length", length),
 					zap.Any("key", key))
-				return errors.ErrMessageTooLarge.GenWithStackByArgs()
+				return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), length, d.config.MaxMessageBytes)
 			}
 		}
 
@@ -144,7 +144,7 @@ func (d *batchEncoder) AppendRowChangedEvent(
 					zap.Int("length", length),
 					zap.Any("table", e.TableInfo.TableName),
 					zap.Any("key", key))
-				return errors.ErrMessageTooLarge.GenWithStackByArgs()
+				return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), length, d.config.MaxMessageBytes)
 			}
 		}
 	}

--- a/pkg/sink/codec/simple/encoder.go
+++ b/pkg/sink/codec/simple/encoder.go
@@ -77,7 +77,7 @@ func (e *Encoder) AppendRowChangedEvent(ctx context.Context, _ string, event *co
 			zap.Int("maxMessageBytes", e.config.MaxMessageBytes),
 			zap.Int("length", length),
 			zap.Any("table", event.TableInfo.TableName))
-		return errors.ErrMessageTooLarge.GenWithStackByArgs()
+		return errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), length, e.config.MaxMessageBytes)
 	}
 
 	var claimCheckLocation string
@@ -113,7 +113,7 @@ func (e *Encoder) AppendRowChangedEvent(ctx context.Context, _ string, event *co
 		zap.Int("maxMessageBytes", e.config.MaxMessageBytes),
 		zap.Int("length", result.Length()),
 		zap.Any("table", event.TableInfo.TableName))
-	return errors.ErrMessageTooLarge.GenWithStackByArgs()
+	return errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), result.Length(), e.config.MaxMessageBytes)
 }
 
 // Build implement the RowEventEncoder interface
@@ -157,7 +157,7 @@ func (e *Encoder) EncodeDDLEvent(event *commonEvent.DDLEvent) (*common.Message, 
 			zap.Int("maxMessageBytes", e.config.MaxMessageBytes),
 			zap.Int("length", result.Length()),
 			zap.Any("table", event.TableInfo.TableName))
-		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs()
+		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), result.Length(), e.config.MaxMessageBytes)
 	}
 	return result, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3515

### What is changed and how it works?
Enhanced Error Message: The ErrMessageTooLarge error message has been updated to include more specific details: the table name, the actual message length, and the configured maximum message bytes. This provides clearer context for debugging.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
```
[CDC:ErrMessageTooLarge]message is too large. table:t, length:245, maxMessageBytes:100
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
