### PR TITLE
api: fix verification for changefeed config

### DIFF
--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -1514,7 +1514,7 @@ func getVerifiedTables(
 		return ineligibleTables, eligibleTables, nil
 	}
 
-	eventRouter, err := eventrouter.NewEventRouter(replicaConfig.Sink, topic, config.IsPulsarScheme(protocol.String()), protocol == config.ProtocolAvro)
+	eventRouter, err := eventrouter.NewEventRouter(replicaConfig.Sink, topic, config.IsPulsarScheme(scheme), protocol == config.ProtocolAvro)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/downstreamadapter/sink/eventrouter/topic/expression_pulsar_test.go
+++ b/downstreamadapter/sink/eventrouter/topic/expression_pulsar_test.go
@@ -1,0 +1,195 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateForPulsar(t *testing.T) {
+	t.Parallel()
+	schema := "schema"
+	table := "table"
+	testTopicCases := []struct {
+		name          string // test case name
+		expression    string
+		wantErr       string
+		expectedTopic string
+	}{
+		// invalid cases
+		{
+			name:       "like a full topic ,no {schema}",
+			expression: "persistent://",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic",
+			expression: "persistent://{schema}",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic ,no {schema}",
+			expression: "persistent://public",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic ,no {schema}",
+			expression: "persistent://public_test-table",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic ,need '/' after 'test-table'",
+			expression: "persistent://public/_test-table",
+			wantErr:    "invalid topic expression",
+		},
+		//{
+		//	// if the {schema} is a not exist namespace in pulsar server, pulsar client will get an error,
+		//	// but cdc can not check it
+		//	expression:     "persistent://public/{schema}/_test-table",
+		//	expectedResult: false,
+		//},
+		{
+			name:       "like a full topic",
+			expression: "persistent_public/test__{table}",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic",
+			expression: "persistent://{schema}_{table}",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic, but more '/' ",
+			expression: "persistent://{schema}/{table}/test/name",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic, but more '/' ",
+			expression: "persistent://test/{table}/test/name/admin",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic, but less '/' ",
+			expression: "non-persistent://public/test_{schema}_{table}",
+			wantErr:    "invalid topic expression",
+		},
+		{
+			name:       "like a full topic, but less '/' ",
+			expression: "non-persistent://public/test {table}_123456aaaa",
+			wantErr:    "invalid topic expression",
+		},
+		// valid cases
+		{
+			name:          "simple topic ,no {schema}",
+			expression:    "public", // no {schema}
+			expectedTopic: "public",
+		},
+		{
+			name:          "simple topic ,no {schema}",
+			expression:    "_xyz",
+			expectedTopic: "_xyz",
+		},
+		{
+			name:          "simple topic ,no {schema}",
+			expression:    "123456",
+			expectedTopic: "123456",
+		},
+		{
+			name:          "simple topic ,no {schema}",
+			expression:    "ABCD",
+			expectedTopic: "ABCD",
+		},
+		{
+			name:          "like a full topic ,no {schema}",
+			expression:    "persistent:public_test-table",
+			expectedTopic: "persistent:public_test-table",
+		},
+		{
+			name:          "simple topic",
+			expression:    "{schema}",
+			expectedTopic: "schema",
+		},
+		{
+			name:          "simple topic",
+			expression:    "AZ_{schema}",
+			expectedTopic: "AZ_schema",
+		},
+		{
+			name:          "simple topic",
+			expression:    "{table}_{schema}",
+			expectedTopic: "table_schema",
+		},
+		{
+			name:          "simple topic",
+			expression:    "123_{schema}_non-persistenttest__{table})",
+			expectedTopic: "123_schema_non-persistenttest__table)",
+		},
+		{
+			name:          "simple topic",
+			expression:    "persistent_public_test_{schema}_{table}",
+			expectedTopic: "persistent_public_test_schema_table",
+		},
+		{
+			name:          "simple topic",
+			expression:    "persistent{schema}_{table}",
+			expectedTopic: "persistentschema_table",
+		},
+		{
+			name:          "full topic",
+			expression:    "persistent://public/default/{schema}_{table}",
+			expectedTopic: "persistent://public/default/schema_table",
+		},
+		{
+			name:          "full topic",
+			expression:    "persistent://public/default/2342-{schema}_abc234",
+			expectedTopic: "persistent://public/default/2342-schema_abc234",
+		},
+		{
+			name:          "full topic",
+			expression:    "persistent://{schema}/{schema}/2342-{schema}_abc234",
+			expectedTopic: "persistent://schema/schema/2342-schema_abc234",
+		},
+		{
+			name:          "full topic",
+			expression:    "persistent://{schema}/dev/2342-{schema}_abc234",
+			expectedTopic: "persistent://schema/dev/2342-schema_abc234",
+		},
+		{
+			name:          "full topic",
+			expression:    "non-persistent://public/default/test_{schema}_{table}_back_up",
+			expectedTopic: "non-persistent://public/default/test_schema_table_back_up",
+		},
+		{
+			name:          "full topic",
+			expression:    "123_{schema}_non-persistenttest__{table}",
+			expectedTopic: "123_schema_non-persistenttest__table",
+		},
+	}
+
+	for i, tc := range testTopicCases {
+		topicExpr := Expression(tc.expression)
+		err := topicExpr.validateForPulsar()
+		t.Logf("case %d: %s", i, tc.name)
+		if err != nil {
+			require.Contains(t, err.Error(), tc.wantErr, fmt.Sprintf("case:%s", tc.name))
+		} else {
+			require.Nil(t, err, fmt.Sprintf("case:%s", tc.name))
+			topicName := topicExpr.Substitute(schema, table)
+			require.Equal(t, topicName, tc.expectedTopic, fmt.Sprintf("case:%s", tc.name))
+		}
+	}
+}

--- a/downstreamadapter/sink/eventrouter/topic/expression_test.go
+++ b/downstreamadapter/sink/eventrouter/topic/expression_test.go
@@ -1,0 +1,312 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tiflow/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstituteTopicExpression(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		expression string
+		schema     string
+		table      string
+		wantErr    string
+		expected   string
+	}{
+		{
+			name:       "valid expression containing '{schema}', but with no prefix and suffix",
+			expression: "{schema}",
+			schema:     "abc",
+			table:      "",
+			expected:   "abc",
+		},
+		{
+			name:       "valid expression containing '{schema}', with prefix",
+			expression: "abc{schema}",
+			schema:     "def",
+			table:      "",
+			expected:   "abcdef",
+		},
+		{
+			name:       "valid expression containing '{schema}', with suffix",
+			expression: "{schema}def",
+			schema:     "hello",
+			table:      "",
+			expected:   "hellodef",
+		},
+		{
+			name:       "valid expression containing '{schema}', with both prefix and suffix",
+			expression: "abc{schema}def",
+			schema:     "hello",
+			table:      "",
+			expected:   "abchellodef",
+		},
+		{
+			expression: "abc{schema}",
+			name:       "valid expression containing '{schema}', schema is converted to lower case letters",
+			schema:     "DEF",
+			table:      "",
+			expected:   "abcDEF",
+		},
+		{
+			name:       "valid expression containing '{schema}' and special prefix, schema is converted to lower case letters",
+			expression: "abc._-def{schema}abc",
+			schema:     "HELLO",
+			table:      "",
+			expected:   "abc._-defHELLOabc",
+		},
+		{
+			name:       "valid expression containing '{schema}', the kafka disallowed characters in schema are replaced with underscore '_'",
+			expression: "abc_def{schema}",
+			schema:     "!@#$%^&*()_+.{}",
+			table:      "",
+			expected:   "abc_def____________.__",
+		},
+		{
+			name:       "valid expression containing '{schema}', the kafka disallowed characters in schema are replaced with underscore '_'",
+			expression: "abc{schema}def",
+			schema:     "你好",
+			table:      "",
+			expected:   "abc__def",
+		},
+		{
+			name:       "invalid expression containing '{schema}', the prefix has punctuation marks other than '.', '-' or '_'",
+			expression: "{{{{schema}",
+			schema:     "abc",
+			table:      "",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name:       "invalid expression containing '{schema}', the prefix has unicode characters other than [A-Za-z0-9]*",
+			expression: "你好{schema}",
+			schema:     "world",
+			table:      "",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name:       "invalid expression containing '{schema}', the suffix must be [A-Za-z0-9\\._\\-]*",
+			expression: "{schema}}}}}",
+			schema:     "abc",
+			table:      "",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name:       "invalid expression not containing '{schema}', with no prefix and suffix",
+			expression: "{xxx}",
+			schema:     "abc",
+			table:      "",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name:       "invalid expressions not containing '{schema}', with prefix",
+			expression: "abc{sch}",
+			schema:     "def",
+			table:      "",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" without prefix or suffix",
+			expression: "{schema}_{table}",
+			schema:     "hello",
+			table:      "world",
+			expected:   "hello_world",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" schema/table are converted to lower case letters",
+			expression: "{schema}_{table}",
+			schema:     "HELLO",
+			table:      "WORLD",
+			expected:   "HELLO_WORLD",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" the kafka disallowed characters in table are replaced",
+			expression: "{schema}_{table}",
+			schema:     "hello",
+			table:      "!@#$%^&*",
+			expected:   "hello_________",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" the kafka disallowed characters in schema are replaced",
+			expression: "{schema}_{table}",
+			schema:     "()_+.{}",
+			table:      "world",
+			expected:   "____.___world",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" with both prefix and suffix",
+			expression: "ab.-c_{schema}_{table}_de.-f",
+			schema:     "hello",
+			table:      "WORLD",
+			expected:   "ab.-c_hello_WORLD_de.-f",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" with customized middle delimited string",
+			expression: "abc_{schema}de._-{table}_fhi",
+			schema:     "hello",
+			table:      "world",
+			expected:   "abc_hellode._-world_fhi",
+		},
+		{
+			name: "valid expression containing '{schema}' and '{table}'," +
+				" the kafka disallowed characters in schema and table are replaced",
+			expression: "{schema}_{table}",
+			schema:     "你好",
+			table:      "世界",
+			expected:   "_____",
+		},
+		{
+			name:       "invalid expression not containing '{schema}' and '{table}'",
+			expression: "{sch}_{tab}",
+			schema:     "hello",
+			table:      "world",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name: "invalid expression containing '{schema}' and '{table}'," +
+				" the middle delimited string must be [A-Za-z0-9\\._\\-]*",
+			expression: "{schema}!@#$%^&*()+{}你好{table}",
+			schema:     "hello",
+			table:      "world",
+			wantErr:    "invalid topic expression",
+			expected:   "",
+		},
+		{
+			name:       "invalid topic name '.'",
+			expression: "{schema}",
+			schema:     ".",
+			table:      "",
+			expected:   "_",
+		},
+		{
+			name:       "invalid topic name '..'",
+			expression: "{schema}",
+			schema:     "..",
+			table:      "",
+			expected:   "__",
+		},
+	}
+
+	for _, tc := range cases {
+		topicExpr := Expression(tc.expression)
+		err := topicExpr.validate()
+		if tc.wantErr != "" {
+			require.Contains(t, err.Error(), tc.wantErr, fmt.Sprintf("case:%s", tc.name))
+		} else {
+			require.Nil(t, err, fmt.Sprintf("case:%s", tc.name))
+			topicName := topicExpr.Substitute(tc.schema, tc.table)
+			require.Equal(t, topicName, tc.expected, fmt.Sprintf("case:%s", tc.name))
+		}
+	}
+}
+
+func TestSchemaOptional(t *testing.T) {
+	t.Parallel()
+
+	expression := "prefix_{table}"
+	topicExpr := Expression(expression)
+	err := topicExpr.validate()
+	require.NoError(t, err)
+
+	schemaName := "test"
+	tableName := "table1"
+	topicName := topicExpr.Substitute(schemaName, tableName)
+	require.Equal(t, topicName, "prefix_table1")
+}
+
+func TestTableOptional(t *testing.T) {
+	t.Parallel()
+
+	expression := "prefix_{schema}"
+	topicExpr := Expression(expression)
+	err := topicExpr.validate()
+	require.NoError(t, err)
+
+	schemaName := "test"
+	tableName := "abc"
+	topicName := topicExpr.Substitute(schemaName, tableName)
+	require.Equal(t, topicName, "prefix_test")
+}
+
+func TestInvalidExpression(t *testing.T) {
+	t.Parallel()
+
+	invalidExpr := "%invalid{schema}"
+	topicExpr := Expression(invalidExpr)
+
+	err := topicExpr.validate()
+	require.ErrorIs(t, err, errors.ErrKafkaInvalidTopicExpression)
+	require.ErrorContains(t, err, invalidExpr)
+
+	err = topicExpr.validateForAvro()
+	require.ErrorIs(t, err, errors.ErrKafkaInvalidTopicExpression)
+	require.ErrorContains(t, err, "Avro")
+	require.ErrorContains(t, err, invalidExpr)
+}
+
+// cmd: go test -run='^$' -bench '^(BenchmarkSubstitute)$' github.com/pingcap/tiflow/cdc/sink/dispatcher/topic
+// goos: linux
+// goarch: amd64
+// pkg: github.com/pingcap/tiflow/cdc/sink/dispatcher
+// cpu: Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz
+// BenchmarkSubstitute/schema_substitution-40         	  199372	      6477 ns/op
+// BenchmarkSubstitute/schema_table_substitution-40   	  110752	     13637 ns/op
+func BenchmarkSubstitute(b *testing.B) {
+	cases := []struct {
+		name       string
+		expression string
+		schema     string
+		table      string
+	}{{
+		name:       "schema_substitution",
+		expression: "abc{schema}def",
+		schema:     "hello!@#$%^&*()_+.{}world",
+		table:      "",
+	}, {
+		name:       "schema_table_substitution",
+		expression: "{schema}_{table}",
+		schema:     "hello!@#$%^&*()_+.{}你好",
+		table:      "world!@#$%^&*()_+.{}世界",
+	}}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				topicExpr := Expression(tc.expression)
+				err := topicExpr.validate()
+				require.Nil(b, err)
+				_ = topicExpr.Substitute(tc.schema, tc.table)
+			}
+		})
+	}
+}

--- a/downstreamadapter/sink/eventrouter/topic/topic_test.go
+++ b/downstreamadapter/sink/eventrouter/topic/topic_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticTopicDispatcher(t *testing.T) {
+	p := newStaticTopic("cdctest")
+	require.Equal(t, p.Substitute("db1", "tbl1"), "cdctest")
+}
+
+func TestDynamicTopicDispatcherForSchema(t *testing.T) {
+	t.Parallel()
+
+	topicExpr := Expression("hello_{schema}_world")
+	err := topicExpr.validate()
+	require.NoError(t, err)
+
+	testCase := []struct {
+		schema      string
+		table       string
+		expectTopic string
+	}{
+		{
+			schema:      "test1",
+			table:       "tb1",
+			expectTopic: "hello_test1_world",
+		},
+		{
+			schema:      "test1",
+			table:       "tb2",
+			expectTopic: "hello_test1_world",
+		},
+		{
+			schema:      "test2",
+			table:       "tb1",
+			expectTopic: "hello_test2_world",
+		},
+		{
+			schema:      "test2",
+			table:       "tb2",
+			expectTopic: "hello_test2_world",
+		},
+	}
+
+	p := newDynamicTopicGenerator(topicExpr)
+	for _, tc := range testCase {
+		require.Equal(t, tc.expectTopic, p.Substitute(tc.schema, tc.table))
+	}
+}
+
+func TestDynamicTopicDispatcherForTable(t *testing.T) {
+	t.Parallel()
+
+	topicExpr := Expression("{schema}_{table}")
+	err := topicExpr.validate()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		schema        string
+		table         string
+		expectedTopic string
+	}{
+		{
+			schema:        "test1",
+			table:         "tb1",
+			expectedTopic: "test1_tb1",
+		},
+		{
+			schema:        "test1",
+			table:         "tb2",
+			expectedTopic: "test1_tb2",
+		},
+		{
+			schema:        "test2",
+			table:         "tb1",
+			expectedTopic: "test2_tb1",
+		},
+		{
+			schema:        "test2",
+			table:         "tb2",
+			expectedTopic: "test2_tb2",
+		},
+	}
+	p := newDynamicTopicGenerator(topicExpr)
+	for _, tc := range testCases {
+		require.Equal(t, tc.expectedTopic, p.Substitute(tc.schema, tc.table))
+	}
+}

--- a/tests/integration_tests/canal_json_basic/run.sh
+++ b/tests/integration_tests/canal_json_basic/run.sh
@@ -8,7 +8,7 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
-# use kafka-consumer with canal-json decoder to sync data from kafka to mysql
+# test MQ sink only in this case
 function run() {
 	if [ "$SINK_TYPE" != "kafka" ] && [ "$SINK_TYPE" != "pulsar" ]; then
 		return

--- a/tests/integration_tests/canal_json_content_compatible/run.sh
+++ b/tests/integration_tests/canal_json_content_compatible/run.sh
@@ -8,7 +8,7 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
-# use kafka-consumer with canal-json decoder to sync data from kafka to mysql
+# test MQ sink only in this case
 function run() {
 	if [ "$SINK_TYPE" != "kafka" ] && [ "$SINK_TYPE" != "pulsar" ]; then
 		return

--- a/tests/integration_tests/http_api/util/test_case.py
+++ b/tests/integration_tests/http_api/util/test_case.py
@@ -136,6 +136,27 @@ def create_changefeed(sink_uri):
     resp = rq.post(url, data=data, headers=headers)
     assert "ErrDispatcherFailed" in resp.text, f"{resp.text}"
 
+    url = BASE_URL1_V2+"/changefeeds?keyspace=keyspace1"
+    data = json.dumps({
+        "changefeed_id": "changefeed-test-v2",
+        "sink_uri": "pulsar://127.0.0.1:6650/http_api_?protocol=canal-json",
+        "replica_config": {
+            "sink": {
+                "dispatchers": [
+                    {
+                        "matcher": ["*.*"],
+                        "partition": "columns",
+                        "columns": ["a.b"],
+                        "topic": "persistent://public/default/http_api_{schema}_{table}",
+                    }
+                ]
+            }
+        }
+    })
+    headers = {"Content-Type": "application/json"}
+    resp = rq.post(url, data=data, headers=headers)
+    assert "ErrDispatcherFailed" in resp.text, f"{resp.text}"
+
     # create changefeed fail because glue schema config is invalid
     url = BASE_URL1_V2+"/changefeeds?keyspace=keyspace1"
     data = json.dumps({


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/ticdc/pull/1883

### What is changed and how it works?
- Pulsar Topic Validation: Introduced comprehensive validation logic and unit tests for Pulsar topic expressions to ensure correct formatting and prevent misconfigurations.
- Changefeed Configuration Fix: Corrected a bug in the getVerifiedTables function where the Pulsar scheme was incorrectly identified, ensuring proper eventrouter initialization.
- Enhanced Topic Expression Handling: Added new unit tests for general topic expression substitution, including handling of special characters and optional schema/table placeholders.
- Integration Test for Pulsar: Included a new integration test case to verify that invalid Pulsar topic expressions in changefeed configurations are correctly rejected by the API.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
