### PR TITLE
maintainer: add region count refresher to accelerate load tables (#3579)

### DIFF
--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -558,6 +558,9 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 		if c.Scheduler.RegionCountPerSpan != nil {
 			res.Scheduler.RegionCountPerSpan = c.Scheduler.RegionCountPerSpan
 		}
+		if c.Scheduler.RegionCountRefreshInterval != nil {
+			res.Scheduler.RegionCountRefreshInterval = c.Scheduler.RegionCountRefreshInterval
+		}
 		if c.Scheduler.WriteKeyThreshold != nil {
 			res.Scheduler.WriteKeyThreshold = c.Scheduler.WriteKeyThreshold
 		}
@@ -942,6 +945,9 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 		if cloned.Scheduler.RegionCountPerSpan != nil {
 			res.Scheduler.RegionCountPerSpan = cloned.Scheduler.RegionCountPerSpan
 		}
+		if cloned.Scheduler.RegionCountRefreshInterval != nil {
+			res.Scheduler.RegionCountRefreshInterval = cloned.Scheduler.RegionCountRefreshInterval
+		}
 		if cloned.Scheduler.WriteKeyThreshold != nil {
 			res.Scheduler.WriteKeyThreshold = cloned.Scheduler.WriteKeyThreshold
 		}
@@ -1182,6 +1188,8 @@ type ChangefeedSchedulerConfig struct {
 	RegionThreshold *int `json:"region_threshold,omitempty"`
 	// RegionCountPerSpan is the maximax region count for each span when first splitted by RegionCountSpliiter
 	RegionCountPerSpan *int `json:"region_count_per_span,omitempty"`
+	// RegionCountRefreshInterval controls how often we refresh span region count with PD.
+	RegionCountRefreshInterval *time.Duration `json:"region_count_refresh_interval,omitempty"`
 	// WriteKeyThreshold is the written keys threshold of splitting a table.
 	WriteKeyThreshold *int `json:"write_key_threshold,omitempty"`
 	// SchedulingTaskCountPerNode is the upper limit for scheduling tasks each node.

--- a/maintainer/barrier_event_test.go
+++ b/maintainer/barrier_event_test.go
@@ -41,7 +41,7 @@ func TestScheduleEvent(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "test1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 1}, 1)
 	event := NewBlockEvent(cfID, tableTriggerEventDispatcherID, spanController, operatorController, &heartbeatpb.State{
@@ -94,7 +94,7 @@ func TestResendAction(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 1}, 1)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 2}, 1)
@@ -199,7 +199,7 @@ func TestUpdateSchemaID(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 1}, 1)
 	require.Equal(t, 1, spanController.GetAbsentSize())

--- a/maintainer/barrier_test.go
+++ b/maintainer/barrier_test.go
@@ -43,7 +43,7 @@ func TestOneBlockEvent(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	startTs := uint64(10)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 1}, startTs)
@@ -175,7 +175,7 @@ func TestNormalBlock(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	var blockedDispatcherIDS []*heartbeatpb.DispatcherID
 	for id := 1; id < 4; id++ {
@@ -344,7 +344,7 @@ func TestNormalBlockWithTableTrigger(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	var blockedDispatcherIDS []*heartbeatpb.DispatcherID
 	for id := 1; id < 3; id++ {
@@ -492,7 +492,7 @@ func TestSchemaBlock(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 1}, 1)
@@ -668,7 +668,7 @@ func TestSyncPointBlock(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 1}, 1)
 	spanController.AddNewTable(commonEvent.Table{SchemaID: 1, TableID: 2}, 1)
@@ -836,7 +836,7 @@ func TestNonBlocked(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	barrier := NewBarrier(spanController, operatorController, false, nil, common.DefaultMode)
 
@@ -890,7 +890,7 @@ func TestUpdateCheckpointTs(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	barrier := NewBarrier(spanController, operatorController, false, nil, common.DefaultMode)
 	msgs := barrier.HandleStatus("node1", &heartbeatpb.BlockStatusRequest{
@@ -945,7 +945,7 @@ func TestHandleBlockBootstrapResponse(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 
 	var dispatcherIDs []*heartbeatpb.DispatcherID
@@ -1106,7 +1106,7 @@ func TestSyncPointBlockPerf(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 	barrier := NewBarrier(spanController, operatorController, true, nil, common.DefaultMode)
 	for id := 1; id < 1000; id++ {
@@ -1186,7 +1186,7 @@ func TestBarrierEventWithDispatcherReallocation(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 
 	tableID := int64(1)
@@ -1393,7 +1393,7 @@ func TestBarrierEventWithDispatcherScheduling(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	spanController := span.NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	spanController := span.NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	operatorController := operator.NewOperatorController(cfID, spanController, 1000, common.DefaultMode)
 
 	// Setup dispatcher A

--- a/maintainer/maintainer.go
+++ b/maintainer/maintainer.go
@@ -180,6 +180,8 @@ func NewMaintainer(cfID common.ChangeFeedID,
 		_, redoDDLSpan = newDDLSpan(keyspaceID, cfID, checkpointTs, selfNode, common.RedoMode)
 	}
 
+	refresher := replica.NewRegionCountRefresher(cfID, util.GetOrZero(info.Config.Scheduler.RegionCountRefreshInterval))
+
 	var (
 		keyspaceName = cfID.Keyspace()
 		name         = cfID.Name()
@@ -194,7 +196,7 @@ func NewMaintainer(cfID common.ChangeFeedID,
 		eventCh:           chann.NewAutoDrainChann[*Event](),
 		startCheckpointTs: checkpointTs,
 		controller: NewController(cfID, checkpointTs, taskScheduler,
-			info.Config, ddlSpan, redoDDLSpan, conf.AddTableBatchSize, time.Duration(conf.CheckBalanceInterval), keyspaceMeta, enableRedo),
+			info.Config, ddlSpan, redoDDLSpan, conf.AddTableBatchSize, time.Duration(conf.CheckBalanceInterval), refresher, keyspaceMeta, enableRedo),
 		mc:                    mc,
 		removed:               atomic.NewBool(false),
 		nodeManager:           nodeManager,
@@ -249,6 +251,11 @@ func NewMaintainer(cfID common.ChangeFeedID,
 	go m.calCheckpointTs(ctx)
 	if enableRedo {
 		go m.handleRedoMessage(ctx)
+	}
+
+	if util.GetOrZero(info.Config.Scheduler.EnableTableAcrossNodes) &&
+		util.GetOrZero(info.Config.Scheduler.RegionThreshold) > 0 {
+		go refresher.Run(ctx)
 	}
 
 	log.Info("changefeed maintainer is created",

--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -77,6 +77,7 @@ func NewController(changefeedID common.ChangeFeedID,
 	cfConfig *config.ReplicaConfig,
 	ddlSpan, redoDDLSpan *replica.SpanReplication,
 	batchSize int, balanceInterval time.Duration,
+	refresher *replica.RegionCountRefresher,
 	keyspaceMeta common.KeyspaceMeta,
 	enableRedo bool,
 ) *Controller {
@@ -96,14 +97,14 @@ func NewController(changefeedID common.ChangeFeedID,
 	if cfConfig != nil {
 		schedulerCfg = cfConfig.Scheduler
 	}
-	spanController := span.NewController(changefeedID, ddlSpan, splitter, schedulerCfg, keyspaceMeta.ID, common.DefaultMode)
+	spanController := span.NewController(changefeedID, ddlSpan, splitter, schedulerCfg, refresher, keyspaceMeta.ID, common.DefaultMode)
 
 	var (
 		redoSpanController *span.Controller
 		redoOC             *operator.Controller
 	)
 	if enableRedo {
-		redoSpanController = span.NewController(changefeedID, redoDDLSpan, splitter, schedulerCfg, keyspaceMeta.ID, common.RedoMode)
+		redoSpanController = span.NewController(changefeedID, redoDDLSpan, splitter, schedulerCfg, refresher, keyspaceMeta.ID, common.RedoMode)
 		redoOC = operator.NewOperatorController(changefeedID, redoSpanController, batchSize, common.RedoMode)
 	}
 	// Create operator controller using spanController

--- a/maintainer/maintainer_controller_test.go
+++ b/maintainer/maintainer_controller_test.go
@@ -72,7 +72,8 @@ func TestSchedule(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	controller := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 9, time.Minute, common.DefaultKeyspace, false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
+	controller := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 9, time.Minute, refresher, common.DefaultKeyspace, false)
 	for i := 0; i < 10; i++ {
 		controller.spanController.AddNewTable(commonEvent.Table{
 			SchemaID: 1,
@@ -109,6 +110,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableMoreThanNodeNum(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	s := NewController(cfID, 1, nil, &config.ReplicaConfig{
 		Scheduler: &config.ChangefeedSchedulerConfig{
 			EnableTableAcrossNodes: util.AddressOf(true),
@@ -117,7 +119,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableMoreThanNodeNum(t *testing.T) {
 			MinTrafficPercentage:   util.AddressOf(0.8),
 			MaxTrafficPercentage:   util.AddressOf(1.2),
 		},
-	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 
 	nodeID := node.ID("node1")
 	for i := 0; i < 100; i++ {
@@ -217,6 +219,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableLessThanNodeNum(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	s := NewController(cfID, 1, nil, &config.ReplicaConfig{
 		Scheduler: &config.ChangefeedSchedulerConfig{
 			EnableTableAcrossNodes: util.AddressOf(true),
@@ -225,7 +228,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableLessThanNodeNum(t *testing.T) {
 			MinTrafficPercentage:   util.AddressOf(0.8),
 			MaxTrafficPercentage:   util.AddressOf(1.2),
 		},
-	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 
 	regionCache := appcontext.GetService[*testutil.MockCache](appcontext.RegionCache)
 
@@ -338,6 +341,7 @@ func TestSplitBalanceGroupsWithNodeRemove(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	s := NewController(cfID, 1, nil, &config.ReplicaConfig{
 		Scheduler: &config.ChangefeedSchedulerConfig{
 			EnableTableAcrossNodes: util.AddressOf(true),
@@ -346,7 +350,7 @@ func TestSplitBalanceGroupsWithNodeRemove(t *testing.T) {
 			MinTrafficPercentage:   util.AddressOf(0.8),
 			MaxTrafficPercentage:   util.AddressOf(1.2),
 		},
-	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 
 	nodeIDList := []node.ID{"node1", "node2", "node3"}
 	for i := 0; i < 100; i++ {
@@ -437,16 +441,18 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 			CheckpointTs:    1,
 		}, "node1", false)
 
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	controller := NewController(cfID, 1, nil, &config.ReplicaConfig{
 		Scheduler: &config.ChangefeedSchedulerConfig{
-			EnableTableAcrossNodes: util.AddressOf(true),
-			WriteKeyThreshold:      util.AddressOf(1000),
-			RegionThreshold:        util.AddressOf(20),
-			BalanceScoreThreshold:  util.AddressOf(1),
-			MinTrafficPercentage:   util.AddressOf(0.8),
-			MaxTrafficPercentage:   util.AddressOf(1.2),
+			EnableTableAcrossNodes:     util.AddressOf(true),
+			WriteKeyThreshold:          util.AddressOf(1000),
+			RegionThreshold:            util.AddressOf(20),
+			RegionCountRefreshInterval: util.AddressOf(time.Minute),
+			BalanceScoreThreshold:      util.AddressOf(1),
+			MinTrafficPercentage:       util.AddressOf(0.8),
+			MaxTrafficPercentage:       util.AddressOf(1.2),
 		},
-	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 
 	nodeIDList := []node.ID{"node1", "node2", "node3"}
 	// make a group
@@ -1031,7 +1037,8 @@ func TestBalance(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	s := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
+	s := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 	for i := 0; i < 100; i++ {
 		sz := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		span := &heartbeatpb.TableSpan{TableID: sz.TableID, StartKey: sz.StartKey, EndKey: sz.EndKey}
@@ -1105,17 +1112,20 @@ func TestDefaultSpanIntoSplit(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
+
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	controller := NewController(cfID, 1, nil, &config.ReplicaConfig{
 		Scheduler: &config.ChangefeedSchedulerConfig{
 			EnableTableAcrossNodes:     util.AddressOf(true),
 			WriteKeyThreshold:          util.AddressOf(1000),
 			RegionThreshold:            util.AddressOf(8),
+			RegionCountRefreshInterval: util.AddressOf(time.Minute),
 			SchedulingTaskCountPerNode: util.AddressOf(10),
 			BalanceScoreThreshold:      util.AddressOf(1),
 			MinTrafficPercentage:       util.AddressOf(0.8),
 			MaxTrafficPercentage:       util.AddressOf(1.2),
 		},
-	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 	totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, 1)
 	span := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: totalSpan.StartKey, EndKey: totalSpan.EndKey}
 	dispatcherID := common.NewDispatcherID()
@@ -1256,7 +1266,8 @@ func TestStoppedWhenMoving(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
-	s := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
+	s := NewController(cfID, 1, nil, replicaConfig, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 	for i := 0; i < 2; i++ {
 		sz := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		span := &heartbeatpb.TableSpan{TableID: sz.TableID, StartKey: sz.StartKey, EndKey: sz.EndKey}
@@ -1307,8 +1318,9 @@ func TestFinishBootstrap(t *testing.T) {
 			ComponentStatus: heartbeatpb.ComponentState_Working,
 			CheckpointTs:    1,
 		}, "node1", false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	s := NewController(cfID, 1, &mockThreadPool{},
-		config.GetDefaultReplicaConfig(), ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+		config.GetDefaultReplicaConfig(), ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 	totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, 1)
 	span := &heartbeatpb.TableSpan{TableID: int64(1), StartKey: totalSpan.StartKey, EndKey: totalSpan.EndKey}
 	schemaStore := eventservice.NewMockSchemaStore()
@@ -1380,14 +1392,16 @@ func TestSplitTableWhenBootstrapFinished(t *testing.T) {
 		}, "node1", false)
 	defaultConfig := config.GetDefaultReplicaConfig().Clone()
 	defaultConfig.Scheduler = &config.ChangefeedSchedulerConfig{
-		EnableTableAcrossNodes: util.AddressOf(true),
-		RegionThreshold:        util.AddressOf(1),
-		RegionCountPerSpan:     util.AddressOf(1),
-		BalanceScoreThreshold:  util.AddressOf(1),
-		MinTrafficPercentage:   util.AddressOf(0.8),
-		MaxTrafficPercentage:   util.AddressOf(1.2),
+		EnableTableAcrossNodes:     util.AddressOf(true),
+		RegionThreshold:            util.AddressOf(1),
+		RegionCountPerSpan:         util.AddressOf(1),
+		RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
+		BalanceScoreThreshold:      util.AddressOf(1),
+		MinTrafficPercentage:       util.AddressOf(0.8),
+		MaxTrafficPercentage:       util.AddressOf(1.2),
 	}
-	s := NewController(cfID, 1, nil, defaultConfig, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
+	s := NewController(cfID, 1, nil, defaultConfig, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 	s.taskPool = &mockThreadPool{}
 	schemaStore := eventservice.NewMockSchemaStore()
 	schemaStore.SetTables(
@@ -1554,18 +1568,20 @@ func TestLargeTableInitialization(t *testing.T) {
 		}, "node1", false)
 
 	// Configure with the specified parameters
+	refresher := replica.NewRegionCountRefresher(cfID, time.Minute)
 	controller := NewController(cfID, 1, nil, &config.ReplicaConfig{
 		Scheduler: &config.ChangefeedSchedulerConfig{
 			EnableTableAcrossNodes:     util.AddressOf(true),
 			WriteKeyThreshold:          util.AddressOf(500),
 			RegionThreshold:            util.AddressOf(50),
 			RegionCountPerSpan:         util.AddressOf(10),
+			RegionCountRefreshInterval: util.AddressOf(time.Minute),
 			SchedulingTaskCountPerNode: util.AddressOf(2),
 			BalanceScoreThreshold:      util.AddressOf(1),
 			MinTrafficPercentage:       util.AddressOf(0.8),
 			MaxTrafficPercentage:       util.AddressOf(1.2),
 		},
-	}, ddlSpan, nil, 1000, 0, common.DefaultKeyspace, false)
+	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false)
 
 	// Create a large table with 10000 regions
 	totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(1))

--- a/maintainer/replica/checker.go
+++ b/maintainer/replica/checker.go
@@ -31,7 +31,9 @@ const (
 )
 
 func GetNewGroupChecker(
-	cfID common.ChangeFeedID, schedulerCfg *config.ChangefeedSchedulerConfig,
+	cfID common.ChangeFeedID,
+	schedulerCfg *config.ChangefeedSchedulerConfig,
+	refresher *RegionCountRefresher,
 ) func(replica.GroupID) replica.GroupChecker[common.DispatcherID, *SpanReplication] {
 	if schedulerCfg == nil || !util.GetOrZero(schedulerCfg.EnableTableAcrossNodes) {
 		return replica.NewEmptyChecker[common.DispatcherID, *SpanReplication]
@@ -40,9 +42,9 @@ func GetNewGroupChecker(
 		groupType := replica.GetGroupType(groupID)
 		switch groupType {
 		case replica.GroupDefault:
-			return NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+			return NewDefaultSpanSplitChecker(cfID, schedulerCfg, refresher)
 		case replica.GroupTable:
-			return NewSplitSpanChecker(cfID, groupID, schedulerCfg)
+			return NewSplitSpanChecker(cfID, groupID, schedulerCfg, refresher)
 		}
 		log.Panic("unknown group type", zap.String("changefeed", cfID.Name()), zap.Int8("groupType", int8(groupType)))
 		return nil

--- a/maintainer/replica/default_span_split_checker.go
+++ b/maintainer/replica/default_span_split_checker.go
@@ -18,24 +18,20 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/maintainer/split"
 	"github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/scheduler/replica"
 	"github.com/pingcap/ticdc/pkg/util"
-	"github.com/tikv/client-go/v2/tikv"
 	"go.uber.org/zap"
 )
 
 var (
 	trafficScoreThreshold = 3
 	regionScoreThreshold  = 3
-	regionCheckInterval   = time.Second * 120
 )
 
 // defaultSpanSplitChecker is used to check whether spans in the default group need to be split
@@ -64,33 +60,37 @@ type defaultSpanSplitChecker struct {
 	writeThreshold int
 
 	// regionThreshold defines the maximum number of regions allowed before split
-	regionThreshold int
-
-	regionCache split.RegionCache
+	regionThreshold        int
+	enableTableAcrossNodes bool
+	refresher              *RegionCountRefresher
 }
 
-func NewDefaultSpanSplitChecker(changefeedID common.ChangeFeedID, schedulerCfg *config.ChangefeedSchedulerConfig) *defaultSpanSplitChecker {
+func NewDefaultSpanSplitChecker(
+	changefeedID common.ChangeFeedID,
+	schedulerCfg *config.ChangefeedSchedulerConfig,
+	refresher *RegionCountRefresher,
+) *defaultSpanSplitChecker {
 	if schedulerCfg == nil {
 		log.Panic("scheduler config is nil, please check the config", zap.String("changefeed", changefeedID.Name()))
 	}
-	regionCache := appcontext.GetService[split.RegionCache](appcontext.RegionCache)
+
 	return &defaultSpanSplitChecker{
-		changefeedID:    changefeedID,
-		allTasks:        make(map[common.DispatcherID]*spanSplitStatus),
-		splitReadyTasks: make(map[common.DispatcherID]*spanSplitStatus),
-		writeThreshold:  util.GetOrZero(schedulerCfg.WriteKeyThreshold),
-		regionThreshold: util.GetOrZero(schedulerCfg.RegionThreshold),
-		regionCache:     regionCache,
+		changefeedID:           changefeedID,
+		allTasks:               make(map[common.DispatcherID]*spanSplitStatus),
+		splitReadyTasks:        make(map[common.DispatcherID]*spanSplitStatus),
+		writeThreshold:         util.GetOrZero(schedulerCfg.WriteKeyThreshold),
+		regionThreshold:        util.GetOrZero(schedulerCfg.RegionThreshold),
+		enableTableAcrossNodes: util.GetOrZero(schedulerCfg.EnableTableAcrossNodes),
+		refresher:              refresher,
 	}
 }
 
 // spanSplitStatus tracks the split status of a span in the default group
 type spanSplitStatus struct {
 	*SpanReplication
-	trafficScore    int
-	latestTraffic   float64
-	regionCount     int
-	regionCheckTime time.Time
+	trafficScore  int
+	latestTraffic float64
+	regionCount   int
 }
 
 func (s *defaultSpanSplitChecker) Name() string {
@@ -110,13 +110,19 @@ func (s *defaultSpanSplitChecker) AddReplica(replica *SpanReplication) {
 		trafficScore:    0,
 		regionCount:     0,
 		latestTraffic:   0,
-		regionCheckTime: time.Now().Add(-regionCheckInterval),
+	}
+	if s.enableTableAcrossNodes && s.regionThreshold > 0 {
+		s.refresher.addDispatcher(context.Background(), replica.ID, replica.Span)
 	}
 }
 
 func (s *defaultSpanSplitChecker) RemoveReplica(replica *SpanReplication) {
 	delete(s.allTasks, replica.ID)
 	delete(s.splitReadyTasks, replica.ID)
+
+	if s.enableTableAcrossNodes && s.regionThreshold > 0 {
+		s.refresher.removeDispatcher(replica.ID)
+	}
 }
 
 func (s *defaultSpanSplitChecker) UpdateStatus(replica *SpanReplication) {
@@ -139,20 +145,15 @@ func (s *defaultSpanSplitChecker) UpdateStatus(replica *SpanReplication) {
 		}
 	}
 
-	// check region count, because the change of region count is not frequent, so we can check less frequently
-	if time.Since(status.regionCheckTime) > regionCheckInterval {
-		regions, err := s.regionCache.LoadRegionsInKeyRange(tikv.NewBackoffer(context.Background(), 500), status.Span.StartKey, status.Span.EndKey)
-		if err != nil {
-			log.Warn("list regions failed, skip check region count",
-				zap.Stringer("changefeed", s.changefeedID),
-				zap.String("span", common.FormatTableSpan(status.Span)), zap.Error(err))
-		} else {
-			status.regionCount = len(regions)
-		}
-		status.regionCheckTime = time.Now()
+	log.Debug("default span split checker: update status", zap.Stringer("changefeed", s.changefeedID), zap.String("replica", replica.ID.String()), zap.Int("trafficScore", status.trafficScore), zap.Int("regionCount", status.regionCount))
+
+	if !s.enableTableAcrossNodes {
+		return
 	}
 
-	log.Debug("default span split checker: update status", zap.Stringer("changefeed", s.changefeedID), zap.String("replica", replica.ID.String()), zap.Int("trafficScore", status.trafficScore), zap.Int("regionCount", status.regionCount))
+	if s.regionThreshold > 0 {
+		status.regionCount = s.refresher.getRegionCount(replica.ID)
+	}
 
 	if status.trafficScore >= trafficScoreThreshold || (s.regionThreshold > 0 && status.regionCount >= s.regionThreshold) {
 		if _, ok := s.splitReadyTasks[status.ID]; !ok {

--- a/maintainer/replica/default_span_split_checker_test.go
+++ b/maintainer/replica/default_span_split_checker_test.go
@@ -34,17 +34,24 @@ func createTestSpanReplication(cfID common.ChangeFeedID, tableID int64) *SpanRep
 	return NewSpanReplication(cfID, common.NewDispatcherID(), 0, &totalSpan, 1, common.DefaultMode, true)
 }
 
+func newTestDefaultChecker(t *testing.T, cfID common.ChangeFeedID, schedulerCfg *config.ChangefeedSchedulerConfig) *defaultSpanSplitChecker {
+	refresher := NewRegionCountRefresher(cfID, util.GetOrZero(schedulerCfg.RegionCountRefreshInterval))
+	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg, refresher)
+	return checker
+}
+
 func TestDefaultSpanSplitChecker_AddReplica(t *testing.T) {
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(10),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(10),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
 	mockCache := testutil.NewMockRegionCache()
 	appcontext.SetService(appcontext.RegionCache, mockCache)
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	// Create a test replica
 	replica := createTestSpanReplication(cfID, 1)
@@ -70,11 +77,12 @@ func TestDefaultSpanSplitChecker_RemoveReplica(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(10),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(10),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	replica := createTestSpanReplication(cfID, 1)
 
@@ -91,13 +99,15 @@ func TestDefaultSpanSplitChecker_RemoveReplica(t *testing.T) {
 func TestDefaultSpanSplitChecker_UpdateStatus_TrafficCheck(t *testing.T) {
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(10),
+		EnableTableAcrossNodes:     util.AddressOf(true),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(10),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
 	testutil.SetUpTestServices()
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	replica := createTestSpanReplication(cfID, 1)
 
@@ -148,11 +158,13 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheck(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		EnableTableAcrossNodes:     util.AddressOf(true),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	replica := createTestSpanReplication(cfID, 1)
 
@@ -171,7 +183,6 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheck(t *testing.T) {
 	checker.AddReplica(replica)
 
 	spanStatus := checker.allTasks[replica.ID]
-	spanStatus.regionCheckTime = time.Now().Add(-2 * regionCheckInterval)
 
 	status := &heartbeatpb.TableSpanStatus{
 		ID:                 replica.ID.ToPB(),
@@ -186,11 +197,6 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheck(t *testing.T) {
 	spanStatus = checker.allTasks[replica.ID]
 	require.Equal(t, 6, spanStatus.regionCount)
 	require.Contains(t, checker.splitReadyTasks, replica.ID)
-
-	// Test region check time interval
-	checker.UpdateStatus(replica)
-	spanStatus = checker.allTasks[replica.ID]
-	require.Equal(t, 6, spanStatus.regionCount) // Should not change due to time interval
 }
 
 func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheckError(t *testing.T) {
@@ -198,15 +204,16 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheckError(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
 	// Mock region cache with error
 	mockCache := appcontext.GetService[*testutil.MockCache](appcontext.RegionCache)
 	mockCache.SetError(context.DeadlineExceeded)
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	replica := createTestSpanReplication(cfID, 1)
 
@@ -220,9 +227,10 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheckError(t *testing.T) {
 	}
 	replica.UpdateStatus(status)
 
-	// Test region check error handling
-	checker.UpdateStatus(replica)
 	spanStatus := checker.allTasks[replica.ID]
+
+	// Test region check error handling
+	spanStatus = checker.allTasks[replica.ID]
 	require.Equal(t, 0, spanStatus.regionCount) // Should remain 0 due to error
 }
 
@@ -231,11 +239,12 @@ func TestDefaultSpanSplitChecker_UpdateStatus_NonWorkingStatus(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	replica := createTestSpanReplication(cfID, 1)
 
@@ -260,13 +269,27 @@ func TestDefaultSpanSplitChecker_CheckRegionSplit(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		EnableTableAcrossNodes:     util.AddressOf(true),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	replica := createTestSpanReplication(cfID, 1)
+
+	// Mock regions
+	mockRegions := []*tikv.Region{
+		testutil.MockRegionWithID(1),
+		testutil.MockRegionWithID(2),
+		testutil.MockRegionWithID(3),
+		testutil.MockRegionWithID(4),
+		testutil.MockRegionWithID(5),
+		testutil.MockRegionWithID(6), // Above threshold
+	}
+	mockCache := appcontext.GetService[*testutil.MockCache](appcontext.RegionCache)
+	mockCache.SetRegions(fmt.Sprintf("%s-%s", replica.Span.StartKey, replica.Span.EndKey), mockRegions)
 
 	checker.AddReplica(replica)
 
@@ -281,7 +304,6 @@ func TestDefaultSpanSplitChecker_CheckRegionSplit(t *testing.T) {
 
 	// Set region count above threshold
 	spanStatus := checker.allTasks[replica.ID]
-	spanStatus.regionCheckTime = time.Now() // set region check time to now, to skip get region from query
 	spanStatus.regionCount = 10
 	checker.UpdateStatus(replica)
 
@@ -296,11 +318,12 @@ func TestDefaultSpanSplitChecker_Check_BatchLimit(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	// Add multiple replicas
 	for i := 0; i < 5; i++ {
@@ -331,11 +354,12 @@ func TestDefaultSpanSplitChecker_Check_EmptyResults(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	// Test empty results when no split ready tasks
 	results := checker.Check(10)
@@ -364,11 +388,12 @@ func TestDefaultSpanSplitChecker_Stat(t *testing.T) {
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
-		WriteKeyThreshold: util.AddressOf(1000),
-		RegionThreshold:   util.AddressOf(5),
+		WriteKeyThreshold:          util.AddressOf(1000),
+		RegionThreshold:            util.AddressOf(5),
+		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	checker := NewDefaultSpanSplitChecker(cfID, schedulerCfg)
+	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
 	// Test empty stat
 	stat := checker.Stat()

--- a/maintainer/replica/region_count_refresher.go
+++ b/maintainer/replica/region_count_refresher.go
@@ -1,0 +1,119 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replica
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/maintainer/split"
+	"github.com/pingcap/ticdc/pkg/common"
+	appcontext "github.com/pingcap/ticdc/pkg/common/context"
+	"github.com/tikv/client-go/v2/tikv"
+	"go.uber.org/zap"
+)
+
+type RegionCountRefresher struct {
+	regionCache  split.RegionCache
+	interval     time.Duration
+	changefeedID common.ChangeFeedID
+
+	traced sync.Map // map[common.DispatcherID]*heartbeatpb.TableSpan
+	counts sync.Map // map[common.DispatcherID]int
+}
+
+func NewRegionCountRefresher(changefeedID common.ChangeFeedID, interval time.Duration) *RegionCountRefresher {
+	return &RegionCountRefresher{
+		regionCache:  appcontext.GetService[split.RegionCache](appcontext.RegionCache),
+		interval:     interval,
+		changefeedID: changefeedID,
+	}
+}
+
+func (r *RegionCountRefresher) addDispatcher(ctx context.Context, id common.DispatcherID, span *heartbeatpb.TableSpan) {
+	r.traced.Store(id, span)
+	backoff := tikv.NewBackoffer(ctx, 2000)
+	regions, err := r.regionCache.LoadRegionsInKeyRange(backoff, span.StartKey, span.EndKey)
+	if err != nil {
+		log.Warn("load regions failed, just continue",
+			zap.Stringer("changefeedID", r.changefeedID),
+			zap.Stringer("dispatcherID", id),
+			zap.String("span", common.FormatTableSpan(span)),
+			zap.Error(err))
+	}
+	r.counts.Store(id, len(regions))
+}
+
+func (r *RegionCountRefresher) removeDispatcher(id common.DispatcherID) {
+	r.traced.Delete(id)
+	r.counts.Delete(id)
+}
+
+func (r *RegionCountRefresher) getRegionCount(id common.DispatcherID) int {
+	value, ok := r.counts.Load(id)
+	if !ok {
+		return 0
+	}
+	return value.(int)
+}
+
+func (r *RegionCountRefresher) Run(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("region count refresher exited", zap.Stringer("changefeedID", r.changefeedID))
+			return
+		case <-ticker.C:
+			r.queryRegionCount(ctx)
+		}
+	}
+}
+
+func (r *RegionCountRefresher) queryRegionCount(ctx context.Context) {
+	backoff := tikv.NewBackoffer(ctx, 2000)
+
+	var tableCount int
+	start := time.Now()
+	r.traced.Range(func(key, value any) bool {
+		tableCount++
+		dispatcherID := key.(common.DispatcherID)
+		span := value.(*heartbeatpb.TableSpan)
+		regions, err := r.regionCache.LoadRegionsInKeyRange(
+			backoff,
+			span.StartKey,
+			span.EndKey,
+		)
+		if err != nil {
+			log.Warn("load regions failed, just continue",
+				zap.Stringer("changefeedID", r.changefeedID),
+				zap.Stringer("dispatcherID", dispatcherID),
+				zap.String("span", common.FormatTableSpan(span)),
+				zap.Error(err))
+			return true
+		}
+		r.counts.Store(dispatcherID, len(regions))
+		return true
+	})
+
+	if tableCount > 0 {
+		log.Info("refresh region count for all tables",
+			zap.Stringer("changefeedID", r.changefeedID),
+			zap.Int("tableCount", tableCount), zap.Duration("duration", time.Since(start)))
+	}
+}

--- a/maintainer/replica/split_span_checker.go
+++ b/maintainer/replica/split_span_checker.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pingcap/ticdc/server/watcher"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/oracle"
-	"github.com/tikv/client-go/v2/tikv"
 	"go.uber.org/zap"
 )
 
@@ -155,10 +154,10 @@ type SplitSpanChecker struct {
 	mergeThreshold  int
 	mergeCheckCount int
 
-	regionCache split.RegionCache
 	nodeManager *watcher.NodeManager
 	pdClock     pdutil.Clock
 
+	refresher              *RegionCountRefresher
 	splitSpanCheckDuration prometheus.Observer
 }
 
@@ -170,15 +169,18 @@ type splitSpanStatus struct {
 	// idx = 0 is the latest traffic
 	lastThreeTraffic []float64
 
-	regionCount     int
-	regionCheckTime time.Time
+	regionCount int
 }
 
-func NewSplitSpanChecker(changefeedID common.ChangeFeedID, groupID replica.GroupID, schedulerCfg *config.ChangefeedSchedulerConfig) *SplitSpanChecker {
+func NewSplitSpanChecker(
+	changefeedID common.ChangeFeedID,
+	groupID replica.GroupID,
+	schedulerCfg *config.ChangefeedSchedulerConfig,
+	refresher *RegionCountRefresher,
+) *SplitSpanChecker {
 	if schedulerCfg == nil {
 		log.Panic("scheduler config is nil, please check the config", zap.String("changefeed", changefeedID.Name()))
 	}
-	regionCache := appcontext.GetService[split.RegionCache](appcontext.RegionCache)
 	return &SplitSpanChecker{
 		changefeedID:           changefeedID,
 		groupID:                groupID,
@@ -188,27 +190,35 @@ func NewSplitSpanChecker(changefeedID common.ChangeFeedID, groupID replica.Group
 		balanceScoreThreshold:  util.GetOrZero(schedulerCfg.BalanceScoreThreshold),
 		minTrafficPercentage:   util.GetOrZero(schedulerCfg.MinTrafficPercentage),
 		maxTrafficPercentage:   util.GetOrZero(schedulerCfg.MaxTrafficPercentage),
-		regionCache:            regionCache,
 		mergeThreshold:         mergeThreshold,
 		mergeCheckCount:        0,
 		nodeManager:            appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName),
 		pdClock:                appcontext.GetService[pdutil.Clock](appcontext.DefaultPDClock),
 		splitSpanCheckDuration: metrics.SplitSpanCheckDuration.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name(), replica.GetGroupName(groupID)),
+
+		refresher: refresher,
 	}
 }
 
 func (s *SplitSpanChecker) AddReplica(replica *SpanReplication) {
 	s.allTasks[replica.ID] = &splitSpanStatus{
 		SpanReplication:  replica,
-		regionCheckTime:  time.Now().Add(-regionCheckInterval), // Ensure the first time update status will calculate the region count
 		regionCount:      0,
 		trafficScore:     0,
 		lastThreeTraffic: make([]float64, 3),
+	}
+
+	if s.regionThreshold > 0 {
+		s.refresher.addDispatcher(context.Background(), replica.ID, replica.Span)
 	}
 }
 
 func (s *SplitSpanChecker) RemoveReplica(replica *SpanReplication) {
 	delete(s.allTasks, replica.ID)
+
+	if s.regionThreshold > 0 {
+		s.refresher.removeDispatcher(replica.ID)
+	}
 }
 
 func (s *SplitSpanChecker) UpdateStatus(replica *SpanReplication) {
@@ -244,18 +254,7 @@ func (s *SplitSpanChecker) UpdateStatus(replica *SpanReplication) {
 	}
 
 	if s.regionThreshold > 0 {
-		// check region count, because the change of region count is not frequent, so we can check less frequently
-		if time.Since(status.regionCheckTime) > regionCheckInterval {
-			regions, err := s.regionCache.LoadRegionsInKeyRange(tikv.NewBackoffer(context.Background(), 500), status.Span.StartKey, status.Span.EndKey)
-			if err != nil {
-				log.Warn("list regions failed, skip check region count",
-					zap.Stringer("changefeed", s.changefeedID),
-					zap.String("span", common.FormatTableSpan(status.Span)), zap.Error(err))
-			} else {
-				status.regionCount = len(regions)
-				status.regionCheckTime = time.Now()
-			}
-		}
+		status.regionCount = s.refresher.getRegionCount(replica.ID)
 	}
 
 	s.balanceCondition.statusUpdated = true
@@ -266,7 +265,6 @@ func (s *SplitSpanChecker) UpdateStatus(replica *SpanReplication) {
 		zap.Any("replica", replica.ID),
 		zap.Any("status", status.GetStatus()),
 		zap.Int("status.regionCount", status.regionCount),
-		zap.Any("status.regionCheckTime", status.regionCheckTime),
 		zap.Int("status.trafficScore", status.trafficScore),
 		zap.Any("status.lastThreeTraffic", status.lastThreeTraffic),
 	)
@@ -286,7 +284,7 @@ type SplitSpanCheckResult struct {
 	TargetNode node.ID
 }
 
-func (s *SplitSpanChecker) checkAllTaskAvailable() bool {
+func (s *SplitSpanChecker) checkAllTaskAvailableLocked() bool {
 	for _, task := range s.allTasks {
 		for _, traffic := range task.lastThreeTraffic {
 			if traffic == 0 {
@@ -314,7 +312,7 @@ func (s *SplitSpanChecker) Check(batch int) replica.GroupCheckResult {
 		zap.Any("batch", batch))
 	results := make([]SplitSpanCheckResult, 0)
 
-	if !s.checkAllTaskAvailable() {
+	if !s.checkAllTaskAvailableLocked() {
 		log.Debug("some task is not available, skip check",
 			zap.String("changefeed", s.changefeedID.String()),
 			zap.Int64("group", int64(s.groupID)),
@@ -1269,6 +1267,5 @@ func (s *SplitSpanChecker) Name() string {
 func SetEasyThresholdForTest() {
 	minTrafficBalanceThreshold = 1
 	maxLagThreshold = 120
-	regionCheckInterval = time.Second * 10
 	mergeThreshold = 1
 }

--- a/maintainer/span/span_controller_test.go
+++ b/maintainer/span/span_controller_test.go
@@ -40,7 +40,7 @@ func TestNewController(t *testing.T) {
 			CheckpointTs:    1,
 		}, "node1", false)
 	appcontext.SetService(watcher.NodeManagerName, watcher.NewNodeManager(nil, nil))
-	controller := NewController(cfID, ddlSpan, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
+	controller := NewController(cfID, ddlSpan, nil, nil, nil, common.DefaultKeyspaceID, common.DefaultMode)
 	require.NotNil(t, controller)
 	require.Equal(t, cfID, controller.changefeedID)
 	require.False(t, controller.enableTableAcrossNodes)
@@ -61,6 +61,7 @@ func TestController_AddNewTable(t *testing.T) {
 		changefeedID,
 		ddlSpan,
 		nil, // splitter
+		nil,
 		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
@@ -98,6 +99,7 @@ func TestController_GetTaskByID(t *testing.T) {
 		changefeedID,
 		ddlSpan,
 		nil, // splitter
+		nil,
 		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
@@ -153,6 +155,7 @@ func TestController_GetTasksByTableID(t *testing.T) {
 		ddlSpan,
 		nil, // splitter
 		nil,
+		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
 	)
@@ -189,6 +192,7 @@ func TestController_GetTasksBySchemaID(t *testing.T) {
 		changefeedID,
 		ddlSpan,
 		nil, // splitter
+		nil,
 		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
@@ -231,6 +235,7 @@ func TestController_UpdateSchemaID(t *testing.T) {
 		ddlSpan,
 		nil, // splitter
 		nil,
+		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
 	)
@@ -272,6 +277,7 @@ func TestController_Statistics(t *testing.T) {
 		changefeedID,
 		ddlSpan,
 		nil, // splitter
+		nil,
 		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
@@ -433,6 +439,7 @@ func newControllerWithCheckerForTest(t *testing.T) *Controller {
 		ddlSpan,
 		nil,
 		&config.ChangefeedSchedulerConfig{EnableTableAcrossNodes: util.AddressOf(true)},
+		nil,
 		common.DefaultKeyspaceID,
 		common.DefaultMode,
 	)

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -98,6 +98,7 @@ var defaultReplicaConfig = &ReplicaConfig{
 		WriteKeyThreshold:          util.AddressOf(0),
 		SchedulingTaskCountPerNode: util.AddressOf(20),  // TODO: choose a btter value
 		RegionCountPerSpan:         util.AddressOf(100), // TODO: choose a btter value
+		RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 		EnableSplittableCheck:      util.AddressOf(false),
 		ForceSplit:                 util.AddressOf(false),
 		BalanceScoreThreshold:      util.AddressOf(20),

--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -16,6 +16,7 @@ package config
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				BalanceScoreThreshold:      util.AddressOf(20),
@@ -51,6 +53,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				BalanceScoreThreshold:      util.AddressOf(20),
@@ -67,6 +70,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				BalanceScoreThreshold:      util.AddressOf(20),
@@ -83,6 +87,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				BalanceScoreThreshold:      util.AddressOf(20),
@@ -99,6 +104,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				BalanceScoreThreshold:      util.AddressOf(20),
@@ -115,6 +121,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				BalanceScoreThreshold:      util.AddressOf(20),
@@ -131,6 +138,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				EnableSplittableCheck:      util.AddressOf(true), // User sets to true
@@ -147,6 +155,7 @@ func TestReplicaConfig_EnableSplittableCheck_AutoAdjust(t *testing.T) {
 				EnableTableAcrossNodes:     util.AddressOf(true),
 				RegionThreshold:            util.AddressOf(100000),
 				RegionCountPerSpan:         util.AddressOf(100),
+				RegionCountRefreshInterval: util.AddressOf(5 * time.Minute),
 				WriteKeyThreshold:          util.AddressOf(1000),
 				SchedulingTaskCountPerNode: util.AddressOf(20),
 				EnableSplittableCheck:      util.AddressOf(false), // User sets to false

--- a/pkg/config/scheduler_config.go
+++ b/pkg/config/scheduler_config.go
@@ -38,6 +38,8 @@ type ChangefeedSchedulerConfig struct {
 	RegionThreshold *int `toml:"region-threshold" json:"region-threshold,omitempty"`
 	// RegionCountPerSpan is the maximax region count for each span when first splitted by RegionCountSpliiter
 	RegionCountPerSpan *int `toml:"region-count-per-span" json:"region-count-per-span,omitempty"`
+	// RegionCountRefreshInterval controls how often we refresh span region count with PD.
+	RegionCountRefreshInterval *time.Duration `toml:"region-count-refresh-interval" json:"region-count-refresh-interval,omitempty"`
 	// WriteKeyThreshold is the written keys threshold of splitting a table.
 	WriteKeyThreshold *int `toml:"write-key-threshold" json:"write-key-threshold,omitempty"`
 	// SchedulingTaskCountPerNode is the upper limit for scheduling tasks each node.
@@ -74,6 +76,9 @@ func (c *ChangefeedSchedulerConfig) FillMissingWithDefaults(defaultCfg *Changefe
 	}
 	if util.GetOrZero(c.RegionCountPerSpan) <= 0 {
 		c.RegionCountPerSpan = defaultCfg.RegionCountPerSpan
+	}
+	if c.RegionCountRefreshInterval == nil || *c.RegionCountRefreshInterval <= 0 {
+		c.RegionCountRefreshInterval = defaultCfg.RegionCountRefreshInterval
 	}
 	if util.GetOrZero(c.WriteKeyThreshold) < 0 {
 		c.WriteKeyThreshold = defaultCfg.WriteKeyThreshold
@@ -117,6 +122,9 @@ func (c *ChangefeedSchedulerConfig) ValidateAndAdjust(sinkURI *url.URL) error {
 	}
 	if util.GetOrZero(c.RegionCountPerSpan) <= 0 {
 		return errors.New("region-count-per-span must be larger than 0")
+	}
+	if c.RegionCountRefreshInterval == nil || *c.RegionCountRefreshInterval <= 0 {
+		return errors.New("region-count-refresh-interval must be larger than 0")
 	}
 
 	if util.GetOrZero(c.BalanceScoreThreshold) <= 0 {

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -44,13 +44,13 @@ mysql_groups=(
 	# G06
 	'ddl_for_split_tables_with_random_merge_and_split'
 	# G07
-	'consistent_compatibility consistent_partition_table consistent_replicate_gbk consistent_replicate_ddl consistent_replicate_basic'
+	'consistent_compatibility consistent_partition_table consistent_replicate_gbk consistent_replicate_basic'
 	# G08
 	'default_value http_proxies bank ddl_for_split_tables_random_schedule'
 	# G09
 	'availability resolve_lock merge_table drop_many_tables ddl_for_split_tables'
 	# G10
-	'consistent_replicate_nfs consistent_replicate_storage_file consistent_replicate_storage_file_large_value consistent_replicate_storage_s3'
+	'consistent_replicate_nfs consistent_replicate_storage_s3'
 	# G11
 	'multi_changefeeds ddl_wait ddl_reentrant force_replicate_table multi_source'
 	# G12

--- a/tests/integration_tests/update_changefeed_check_config/run.sh
+++ b/tests/integration_tests/update_changefeed_check_config/run.sh
@@ -58,6 +58,7 @@ function run() {
 		"max_traffic_percentage": 1.25,
 		"min_traffic_percentage": 0.8,
 		"region_count_per_span": 100,
+		"region_count_refresh_interval": 300000000000,
 		"region_threshold": 10000,
 		"scheduling_task_count_per_node": 20,
 		"write_key_threshold": 0,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3633, ref #3579

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
