### PR TITLE
sink: Add schema/table routing support for mysql and redo sinks

### DIFF
--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -308,6 +308,8 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				IndexName:      rule.IndexName,
 				Columns:        rule.Columns,
 				TopicRule:      rule.TopicRule,
+				SchemaRule:     rule.SchemaRule,
+				TableRule:      rule.TableRule,
 			})
 		}
 		var columnSelectors []*config.ColumnSelector
@@ -658,6 +660,8 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				IndexName:     rule.IndexName,
 				Columns:       rule.Columns,
 				TopicRule:     rule.TopicRule,
+				SchemaRule:    rule.SchemaRule,
+				TableRule:     rule.TableRule,
 			})
 		}
 		var columnSelectors []*ColumnSelector
@@ -1147,6 +1151,12 @@ type DispatchRule struct {
 	IndexName     string   `json:"index,omitempty"`
 	Columns       []string `json:"columns,omitempty"`
 	TopicRule     string   `json:"topic,omitempty"`
+	// SchemaRule is an expression for the target schema name.
+	// Supports {schema} and {table} placeholders.
+	SchemaRule string `json:"schema,omitempty"`
+	// TableRule is an expression for the target table name.
+	// Supports {schema} and {table} placeholders.
+	TableRule string `json:"table,omitempty"`
 }
 
 // ColumnSelector represents a column selector for a table.

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -136,7 +136,7 @@ func newWriter(ctx context.Context, o *option) *writer {
 		SinkURI:      o.downstreamURI,
 		SinkConfig:   o.sinkConfig,
 	}
-	w.mysqlSink, err = sink.New(ctx, cfg, changefeedID)
+	w.mysqlSink, err = sink.New(ctx, cfg, changefeedID, nil)
 	if err != nil {
 		log.Panic("cannot create the mysql sink", zap.Error(err))
 	}

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -127,7 +127,7 @@ func newWriter(ctx context.Context, o *option) *writer {
 		SinkURI:      o.downstreamURI,
 		SinkConfig:   o.replicaConfig.Sink,
 	}
-	w.mysqlSink, err = sink.New(ctx, cfg, changefeedID)
+	w.mysqlSink, err = sink.New(ctx, cfg, changefeedID, nil)
 	if err != nil {
 		log.Panic("cannot create the mysql sink", zap.Error(err))
 	}

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -130,7 +130,7 @@ func newConsumer(ctx context.Context) (*consumer, error) {
 		SinkURI:    downstreamURIStr,
 		SinkConfig: replicaConfig.Sink,
 	}
-	sink, err := sink.New(stdCtx, cfg, commonType.NewChangeFeedIDWithName(defaultChangefeedName, commonType.DefaultKeyspaceNamme))
+	sink, err := sink.New(stdCtx, cfg, commonType.NewChangeFeedIDWithName(defaultChangefeedName, commonType.DefaultKeyspaceNamme), nil)
 	if err != nil {
 		log.Error("failed to create sink", zap.Error(err))
 		return nil, err

--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -28,6 +28,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/sink/util"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -51,6 +52,9 @@ type DispatcherService interface {
 	GetCheckpointTs() uint64
 	HandleEvents(events []DispatcherEvent, wakeCallback func()) (block bool)
 	IsOutputRawChangeEvent() bool
+	// GetRouter returns the router for schema/table name routing.
+	// May return nil if no routing rules are configured.
+	GetRouter() *util.Router
 }
 
 // Dispatcher defines the interface for event dispatchers that are responsible for receiving events

--- a/downstreamadapter/dispatcher/event_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/event_dispatcher_test.go
@@ -80,6 +80,7 @@ func newDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) *Eve
 		}, // syncPointConfig
 		&defaultAtomicity,
 		false, // enableSplittableCheck
+		nil,   // router
 		make(chan TableSpanStatusWithSeq, 128),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 128),
 		make(chan error, 1),
@@ -815,6 +816,7 @@ func TestDispatcherSplittableCheck(t *testing.T) {
 		},
 		&defaultAtomicity,
 		true, // enableSplittableCheck = true
+		nil,  // router
 		make(chan TableSpanStatusWithSeq, 128),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 128),
 		make(chan error, 1),
@@ -924,6 +926,7 @@ func TestDispatcher_SkipDMLAsStartTs_FilterCorrectly(t *testing.T) {
 		},
 		&defaultAtomicity,
 		false,
+		nil, // router
 		make(chan TableSpanStatusWithSeq, 128),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 128),
 		make(chan error, 1),
@@ -1003,6 +1006,7 @@ func TestDispatcher_SkipDMLAsStartTs_Disabled(t *testing.T) {
 		},
 		&defaultAtomicity,
 		false,
+		nil, // router
 		make(chan TableSpanStatusWithSeq, 128),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 128),
 		make(chan error, 1),

--- a/downstreamadapter/dispatcher/redo_dispatcher_test.go
+++ b/downstreamadapter/dispatcher/redo_dispatcher_test.go
@@ -46,6 +46,7 @@ func newRedoDispatcherForTest(sink sink.Sink, tableSpan *heartbeatpb.TableSpan) 
 		nil, // redo dispatcher doesn't need syncPointConfig
 		&defaultAtomicity,
 		false, // enableSplittableCheck
+		nil,   // router
 		make(chan TableSpanStatusWithSeq, 128),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 128),
 		make(chan error, 1),

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
+	sinkutil "github.com/pingcap/ticdc/pkg/sink/util"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/utils/threadpool"
 	"github.com/prometheus/client_golang/prometheus"
@@ -206,8 +207,25 @@ func NewDispatcherManager(
 		}
 	}
 
+	// Create router for schema/table name routing.
+	// The router is shared between:
+	// 1. The Sink - for rewriting DDL queries (e.g., CREATE TABLE source.t -> CREATE TABLE target.t)
+	// 2. The Dispatchers (via SharedInfo) - for setting TargetSchema/TargetTable on TableInfo,
+	//    which is then used by DML SQL generation to write to the correct target table.
+	// This ensures both DDL and DML operations use consistent routing rules.
+	var router *sinkutil.Router
 	var err error
-	manager.sink, err = sink.New(ctx, manager.config, manager.changefeedID)
+	if manager.config.SinkConfig != nil && len(manager.config.SinkConfig.DispatchRules) > 0 {
+		router, err = sinkutil.NewRouterFromDispatchRules(
+			manager.config.CaseSensitive,
+			manager.config.SinkConfig.DispatchRules,
+		)
+		if err != nil {
+			return nil, 0, errors.Trace(err)
+		}
+	}
+
+	manager.sink, err = sink.New(ctx, manager.config, manager.changefeedID, router)
 	if err != nil {
 		return nil, 0, errors.Trace(err)
 	}
@@ -232,6 +250,7 @@ func NewDispatcherManager(
 		syncPointConfig,
 		manager.config.SinkConfig.TxnAtomicity,
 		manager.config.EnableSplittableCheck,
+		router,
 		make(chan dispatcher.TableSpanStatusWithSeq, 8192),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 1024*1024),
 		make(chan error, 1),

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -45,7 +45,9 @@ func initRedoComponet(
 	}
 	manager.RedoEnable = true
 	manager.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()
-	manager.redoSink = redo.New(ctx, changefeedID, startTs, manager.config.Consistent)
+	// Pass the router to the redo sink so DDL queries are rewritten with routing
+	// before being written to the redo log. This ensures replay writes to correct target tables.
+	manager.redoSink = redo.New(ctx, changefeedID, startTs, manager.config.Consistent, manager.sharedInfo.GetRouter())
 	manager.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
 
 	totalQuota := manager.sinkQuota

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -55,6 +55,7 @@ func createTestDispatcher(t *testing.T, manager *DispatcherManager, id common.Di
 		nil,
 		&defaultAtomicity,
 		false,
+		nil, // router
 		make(chan dispatcher.TableSpanStatusWithSeq, 1),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 1),
 		make(chan error, 1),
@@ -113,6 +114,7 @@ func createTestManager(t *testing.T) *DispatcherManager {
 		nil,   // syncPointConfig
 		&defaultAtomicity,
 		false,
+		nil, // router
 		make(chan dispatcher.TableSpanStatusWithSeq, 8192),
 		make(chan *heartbeatpb.TableSpanBlockStatus, 1024*1024),
 		make(chan error, 1),

--- a/downstreamadapter/eventcollector/event_collector_test.go
+++ b/downstreamadapter/eventcollector/event_collector_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/pkg/node"
+	sinkutil "github.com/pingcap/ticdc/pkg/sink/util"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -114,6 +115,10 @@ func (m *mockEventDispatcher) GetBlockEventStatus() *heartbeatpb.State {
 
 func (m *mockEventDispatcher) IsOutputRawChangeEvent() bool {
 	return false
+}
+
+func (m *mockEventDispatcher) GetRouter() *sinkutil.Router {
+	return nil
 }
 
 func newMessage(id node.ID, msg messaging.IOTypeT) *messaging.TargetMessage {

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/sink/mysql"
+	"github.com/pingcap/ticdc/pkg/sink/util"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -56,6 +57,10 @@ type Sink struct {
 	isNormal   *atomic.Bool
 	maxTxnRows int
 	bdrMode    bool
+
+	// router is used to route source schema/table names to target schema/table names.
+	// May be nil if no routing rules are configured.
+	router *util.Router
 }
 
 // Verify is used to verify the sink uri and config is valid
@@ -79,12 +84,13 @@ func New(
 	changefeedID common.ChangeFeedID,
 	config *config.ChangefeedConfig,
 	sinkURI *url.URL,
+	router *util.Router,
 ) (*Sink, error) {
 	cfg, db, err := mysql.NewMysqlConfigAndDB(ctx, changefeedID, sinkURI, config)
 	if err != nil {
 		return nil, err
 	}
-	return NewMySQLSink(ctx, changefeedID, cfg, db, config.BDRMode), nil
+	return NewMySQLSink(ctx, changefeedID, cfg, db, config.BDRMode, router), nil
 }
 
 func NewMySQLSink(
@@ -93,6 +99,7 @@ func NewMySQLSink(
 	cfg *mysql.Config,
 	db *sql.DB,
 	bdrMode bool,
+	router *util.Router,
 ) *Sink {
 	stat := metrics.NewStatistics(changefeedID, "TxnSink")
 	result := &Sink{
@@ -110,6 +117,7 @@ func NewMySQLSink(
 		isNormal:   atomic.NewBool(true),
 		maxTxnRows: cfg.MaxTxnRow,
 		bdrMode:    bdrMode,
+		router:     router,
 	}
 	for i := 0; i < len(result.dmlWriter); i++ {
 		result.dmlWriter[i] = mysql.NewWriter(ctx, i, db, cfg, changefeedID, stat)
@@ -240,6 +248,12 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 		if s.bdrMode && ddl.BDRMode != string(ast.BDRRolePrimary) {
 			break
 		}
+		// Rewrite DDL query if routing is configured
+		if s.router != nil {
+			if err = s.rewriteDDLQueryWithRouting(ddl); err != nil {
+				return errors.Trace(err)
+			}
+		}
 		err = s.ddlWriter.FlushDDLEvent(ddl)
 	case commonEvent.TypeSyncPointEvent:
 		err = s.ddlWriter.FlushSyncPointEvent(event.(*commonEvent.SyncPointEvent))
@@ -254,6 +268,30 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 		return errors.Trace(err)
 	}
 	event.PostFlush()
+	return nil
+}
+
+// rewriteDDLQueryWithRouting rewrites the DDL query by applying routing rules
+// to transform source table names to target table names.
+// Returns an error if DDL rewriting fails, as silent fallback could lead to data going to wrong tables.
+//
+// IMPORTANT: This function mutates ddl.Query in place. It is safe because:
+// 1. This is only called once per DDL event at the start of WriteBlockEvent
+// 2. Internal retries in FlushDDLEvent/execDDLWithMaxRetries reuse the already-rewritten query
+// 3. If WriteBlockEvent fails, the dispatcher reports an error and does not retry with the same event
+// If the retry behavior changes in the future, consider adding an idempotency check (e.g., a flag
+// on DDLEvent to track whether routing has been applied).
+func (s *Sink) rewriteDDLQueryWithRouting(ddl *commonEvent.DDLEvent) error {
+	result, err := util.RewriteDDLQueryWithRouting(s.router, ddl, s.changefeedID.String())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if result.WasRewritten {
+		ddl.Query = result.NewQuery
+		ddl.TargetSchemaName = result.TargetSchemaName
+	}
+
 	return nil
 }
 

--- a/downstreamadapter/sink/redo/sink_test.go
+++ b/downstreamadapter/sink/redo/sink_test.go
@@ -26,6 +26,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/redo"
+	sinkutil "github.com/pingcap/ticdc/pkg/sink/util"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -124,7 +125,7 @@ func TestRedoSinkInProcessor(t *testing.T) {
 			UseFileBackend:        util.AddressOf(useFileBackend),
 		}
 		startTs := uint64(100)
-		dmlMgr := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme), startTs, cfg)
+		dmlMgr := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme), startTs, cfg, nil)
 		defer dmlMgr.Close(false)
 
 		var eg errgroup.Group
@@ -214,7 +215,7 @@ func TestRedoSinkError(t *testing.T) {
 		EncodingWorkerNum:     util.AddressOf(workerNumberForTest),
 		FlushWorkerNum:        util.AddressOf(workerNumberForTest),
 	}
-	logMgr := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme), 0, cfg)
+	logMgr := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme), 0, cfg, nil)
 	defer logMgr.Close(false)
 
 	var eg errgroup.Group
@@ -273,7 +274,7 @@ func runBenchTest(b *testing.B, storage string, useFileBackend bool) {
 		FlushWorkerNum:        util.AddressOf(redo.DefaultFlushWorkerNum),
 		UseFileBackend:        util.AddressOf(useFileBackend),
 	}
-	dmlMgr := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme), 0, cfg)
+	dmlMgr := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme), 0, cfg, nil)
 	defer dmlMgr.Close(false)
 
 	var eg errgroup.Group
@@ -329,4 +330,66 @@ func runBenchTest(b *testing.B, storage string, useFileBackend bool) {
 	cancel()
 
 	require.ErrorIs(b, eg.Wait(), context.Canceled)
+}
+
+// TestRedoSinkDDLRoutingDelegation tests that the redo sink's rewriteDDLQueryWithRouting
+// method properly delegates to the shared RewriteDDLQueryWithRouting function.
+// Comprehensive tests for the core DDL routing logic are in pkg/sink/util/ddl_routing_test.go.
+func TestRedoSinkDDLRoutingDelegation(t *testing.T) {
+	t.Parallel()
+
+	// Test with routing configured
+	router, err := sinkutil.NewRouter(false, []sinkutil.RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  sinkutil.TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+
+	changefeedID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceNamme)
+	s := &Sink{
+		changefeedID: changefeedID,
+		router:       router,
+	}
+
+	// Test that routing is applied and query is modified
+	ddlEvent := &commonEvent.DDLEvent{
+		Query: "CREATE TABLE `source_db`.`test_table` (id INT PRIMARY KEY)",
+		TableInfo: &common.TableInfo{
+			TableName: common.TableName{Schema: "source_db", Table: "test_table"},
+		},
+	}
+
+	err = s.rewriteDDLQueryWithRouting(ddlEvent)
+	require.NoError(t, err)
+	require.Contains(t, ddlEvent.Query, "target_db", "Query should be rewritten with target schema")
+	require.NotContains(t, ddlEvent.Query, "source_db", "Query should not contain source schema")
+
+	// Test with nil router - should be a no-op
+	sNoRouter := &Sink{
+		changefeedID: changefeedID,
+		router:       nil,
+	}
+
+	ddlEvent2 := &commonEvent.DDLEvent{
+		Query: "CREATE TABLE `source_db`.`test_table` (id INT PRIMARY KEY)",
+		TableInfo: &common.TableInfo{
+			TableName: common.TableName{Schema: "source_db", Table: "test_table"},
+		},
+	}
+
+	originalQuery := ddlEvent2.Query
+	err = sNoRouter.rewriteDDLQueryWithRouting(ddlEvent2)
+	require.NoError(t, err)
+	require.Equal(t, originalQuery, ddlEvent2.Query, "Query should not be modified when router is nil")
+
+	// Test with empty query - should be a no-op
+	ddlEvent3 := &commonEvent.DDLEvent{
+		Query: "",
+	}
+	err = s.rewriteDDLQueryWithRouting(ddlEvent3)
+	require.NoError(t, err)
+	require.Equal(t, "", ddlEvent3.Query)
 }

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -26,6 +26,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/sink/util"
 )
 
 type Sink interface {
@@ -41,7 +42,7 @@ type Sink interface {
 	Run(ctx context.Context) error
 }
 
-func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) (Sink, error) {
+func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID, router *util.Router) (Sink, error) {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	if err != nil {
 		return nil, errors.WrapError(errors.ErrSinkURIInvalid, err)
@@ -49,7 +50,7 @@ func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.
 	scheme := config.GetScheme(sinkURI)
 	switch scheme {
 	case config.MySQLScheme, config.MySQLSSLScheme, config.TiDBScheme, config.TiDBSSLScheme:
-		return mysql.New(ctx, changefeedID, cfg, sinkURI)
+		return mysql.New(ctx, changefeedID, cfg, sinkURI, router)
 	case config.KafkaScheme, config.KafkaSSLScheme:
 		return kafka.New(ctx, changefeedID, sinkURI, cfg.SinkConfig)
 	case config.PulsarScheme, config.PulsarSSLScheme, config.PulsarHTTPScheme, config.PulsarHTTPSScheme:

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -463,7 +463,10 @@ func (ra *RedoApplier) Apply(egCtx context.Context) (err error) {
 		SinkConfig: &config.SinkConfig{},
 	}
 	if ra.mysqlSink == nil {
-		ra.mysqlSink, err = mysql.New(egCtx, ra.rd.GetChangefeedID(), replicaConfig, sinkURI)
+		// Pass nil for router because redo logs already contain routed schema/table names.
+		// Routing was applied when events were written to redo logs, so we don't need
+		// to apply routing again during replay.
+		ra.mysqlSink, err = mysql.New(egCtx, ra.rd.GetChangefeedID(), replicaConfig, sinkURI, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/applier/redo_test.go
+++ b/pkg/applier/redo_test.go
@@ -376,7 +376,7 @@ func TestApply(t *testing.T) {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	require.NoError(t, err)
 	mysqlCfg.Apply(sinkURI, cfg.ChangefeedID, cfg)
-	ap.mysqlSink = dmysql.NewMySQLSink(ctx, cfg.ChangefeedID, mysqlCfg, db, false)
+	ap.mysqlSink = dmysql.NewMySQLSink(ctx, cfg.ChangefeedID, mysqlCfg, db, false, nil)
 	ap.needRecoveryInfo = false
 	err = ap.Apply(ctx)
 	require.Nil(t, err)
@@ -584,7 +584,7 @@ func TestApplyBigTxn(t *testing.T) {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	require.NoError(t, err)
 	mysqlCfg.Apply(sinkURI, cfg.ChangefeedID, cfg)
-	ap.mysqlSink = dmysql.NewMySQLSink(ctx, cfg.ChangefeedID, mysqlCfg, db, false)
+	ap.mysqlSink = dmysql.NewMySQLSink(ctx, cfg.ChangefeedID, mysqlCfg, db, false, nil)
 	ap.needRecoveryInfo = false
 	err = ap.Apply(ctx)
 	require.Nil(t, err)

--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -41,6 +41,10 @@ type DDLEvent struct {
 	SchemaID   int64  `json:"schema_id"`
 	SchemaName string `json:"schema_name"`
 	TableName  string `json:"table_name"`
+	// TargetSchemaName is the routed schema name when sink routing is configured.
+	// When set, GetDDLSchemaName() returns this value instead of SchemaName.
+	// This field is not serialized as it's only used during sink execution.
+	TargetSchemaName string `json:"-"`
 	// the following two fields are just used for RenameTable,
 	// they are the old schema/table name of the table
 	ExtraSchemaName string            `json:"extra_schema_name"`
@@ -255,6 +259,17 @@ func (e *DDLEvent) GetDDLQuery() string {
 	return e.Query
 }
 
+func (e *DDLEvent) GetDDLSchemaName() string {
+	if e == nil {
+		return ""
+	}
+	// Return the target schema name if routing is configured
+	if e.TargetSchemaName != "" {
+		return e.TargetSchemaName
+	}
+	return e.SchemaName
+}
+
 func (e *DDLEvent) GetDDLType() model.ActionType {
 	return model.ActionType(e.Type)
 }
@@ -396,6 +411,39 @@ func (t *DDLEvent) GetSize() int64 {
 
 func (t *DDLEvent) IsPaused() bool {
 	return false
+}
+
+// CloneForRouting creates a shallow copy of the DDLEvent that can safely be mutated
+// for routing purposes without affecting the original event. This is necessary because
+// DDLEvents may be shared between multiple dispatchers (e.g., EventDispatcher and
+// RedoDispatcher) and mutating the original would cause race conditions.
+//
+// The clone shares most fields with the original (they are read-only after creation),
+// but the following fields are prepared for independent mutation:
+// - Query: will be rewritten with routed schema/table names
+// - TargetSchemaName: will be set by routing
+// - TableInfo: will be replaced with routed version (via CloneWithRouting)
+// - MultipleTableInfos: each element will be replaced with routed version
+//
+// PostTxnFlushed callbacks are shared between the original and clone since sinks
+// call PostFlush() on the event for checkpoint/progress tracking.
+func (d *DDLEvent) CloneForRouting() *DDLEvent {
+	if d == nil {
+		return nil
+	}
+
+	// Create shallow copy - this copies all fields including the PostTxnFlushed
+	// slice header, so callbacks are shared (which is correct behavior)
+	clone := *d
+
+	// MultipleTableInfos needs a new slice so each dispatcher can independently
+	// apply routing to its elements without affecting others
+	if d.MultipleTableInfos != nil {
+		clone.MultipleTableInfos = make([]*common.TableInfo, len(d.MultipleTableInfos))
+		copy(clone.MultipleTableInfos, d.MultipleTableInfos)
+	}
+
+	return &clone
 }
 
 func (t *DDLEvent) Len() int32 {

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -239,6 +239,26 @@ func (b *BatchDMLEvent) encodeV1() ([]byte, error) {
 // AssembleRows assembles the Rows from the RawRows.
 // It also sets the TableInfo and clears the RawRows.
 func (b *BatchDMLEvent) AssembleRows(tableInfo *common.TableInfo) {
+	if tableInfo == nil {
+		log.Panic("DMLEvent: TableInfo is nil")
+		return
+	}
+
+	// Verify schema version compatibility before replacing TableInfo
+	if b.TableInfo != nil && b.TableInfo.GetUpdateTS() != tableInfo.GetUpdateTS() {
+		log.Panic("DMLEvent: TableInfoVersion mismatch",
+			zap.Uint64("dmlEventTableInfoVersion", b.TableInfo.GetUpdateTS()),
+			zap.Uint64("tableInfoVersion", tableInfo.GetUpdateTS()))
+		return
+	}
+
+	// Always update TableInfo and DMLEvents' TableInfo to the passed tableInfo,
+	// because it may have routing applied (TargetSchema/TargetTable set).
+	// This must happen before the early return to ensure routing is applied.
+	b.TableInfo = tableInfo
+	for _, dml := range b.DMLEvents {
+		dml.TableInfo = tableInfo
+	}
 	defer func() {
 		b.TableInfo.InitPrivateFields()
 	}()
@@ -247,27 +267,17 @@ func (b *BatchDMLEvent) AssembleRows(tableInfo *common.TableInfo) {
 	if b.Rows != nil {
 		return
 	}
-	if tableInfo == nil {
-		log.Panic("DMLEvent: TableInfo is nil")
-		return
-	}
 
 	if len(b.RawRows) == 0 {
 		log.Panic("DMLEvent: RawRows is empty")
 		return
 	}
 
-	if b.TableInfo != nil && b.TableInfo.GetUpdateTS() != tableInfo.GetUpdateTS() {
-		log.Panic("DMLEvent: TableInfoVersion mismatch", zap.Uint64("dmlEventTableInfoVersion", b.TableInfo.GetUpdateTS()), zap.Uint64("tableInfoVersion", tableInfo.GetUpdateTS()))
-		return
-	}
 	decoder := chunk.NewCodec(tableInfo.GetFieldSlice())
 	b.Rows, _ = decoder.Decode(b.RawRows)
-	b.TableInfo = tableInfo
 	b.RawRows = nil
 	for _, dml := range b.DMLEvents {
 		dml.Rows = b.Rows
-		dml.TableInfo = b.TableInfo
 	}
 }
 

--- a/pkg/common/table_info_test.go
+++ b/pkg/common/table_info_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneWithRouting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil TableInfo", func(t *testing.T) {
+		var ti *TableInfo
+		cloned := ti.CloneWithRouting("target_schema", "target_table")
+		require.Nil(t, cloned)
+	})
+
+	t.Run("basic cloning with routing", func(t *testing.T) {
+		original := &TableInfo{
+			TableName: TableName{
+				Schema:  "source_db",
+				Table:   "source_table",
+				TableID: 123,
+			},
+			Charset:          "utf8mb4",
+			Collate:          "utf8mb4_bin",
+			Comment:          "test table",
+			HasPKOrNotNullUK: true,
+			UpdateTS:         1000,
+		}
+
+		cloned := original.CloneWithRouting("target_db", "target_table")
+
+		// Verify cloned has routing applied
+		require.Equal(t, "source_db", cloned.TableName.Schema)
+		require.Equal(t, "source_table", cloned.TableName.Table)
+		require.Equal(t, "target_db", cloned.TableName.TargetSchema)
+		require.Equal(t, "target_table", cloned.TableName.TargetTable)
+		require.Equal(t, int64(123), cloned.TableName.TableID)
+
+		// Verify other fields are copied
+		require.Equal(t, "utf8mb4", cloned.Charset)
+		require.Equal(t, "utf8mb4_bin", cloned.Collate)
+		require.Equal(t, "test table", cloned.Comment)
+		require.Equal(t, true, cloned.HasPKOrNotNullUK)
+		require.Equal(t, uint64(1000), cloned.UpdateTS)
+
+		// Verify original is NOT modified
+		require.Equal(t, "", original.TableName.TargetSchema)
+		require.Equal(t, "", original.TableName.TargetTable)
+	})
+
+	t.Run("cloning does not affect original preSQLs", func(t *testing.T) {
+		original := &TableInfo{
+			TableName: TableName{
+				Schema:  "source_db",
+				Table:   "source_table",
+				TableID: 123,
+			},
+		}
+
+		// Clone with different routing
+		cloned1 := original.CloneWithRouting("db1", "table1")
+		cloned2 := original.CloneWithRouting("db2", "table2")
+
+		// Each clone should have its own routing
+		require.Equal(t, "db1", cloned1.TableName.TargetSchema)
+		require.Equal(t, "table1", cloned1.TableName.TargetTable)
+		require.Equal(t, "db2", cloned2.TableName.TargetSchema)
+		require.Equal(t, "table2", cloned2.TableName.TargetTable)
+
+		// Original should be unchanged
+		require.Equal(t, "", original.TableName.TargetSchema)
+		require.Equal(t, "", original.TableName.TargetTable)
+
+		// Clones should be independent
+		require.NotSame(t, cloned1, cloned2)
+	})
+}

--- a/pkg/common/table_name.go
+++ b/pkg/common/table_name.go
@@ -26,6 +26,12 @@ type TableName struct {
 	// TableID is the logic table ID
 	TableID     int64 `toml:"tbl-id" msg:"tbl-id"`
 	IsPartition bool  `toml:"is-partition" msg:"is-partition"`
+	// TargetSchema is the target schema name for routing.
+	// If empty, Schema is used as the target.
+	TargetSchema string `toml:"target-db-name" msg:"target-db-name"`
+	// TargetTable is the target table name for routing.
+	// If empty, Table is used as the target.
+	TargetTable string `toml:"target-tbl-name" msg:"target-tbl-name"`
 }
 
 // String implements fmt.Stringer interface.
@@ -36,4 +42,32 @@ func (t TableName) String() string {
 // QuoteString returns quoted full table name
 func (t TableName) QuoteString() string {
 	return QuoteSchema(t.Schema, t.Table)
+}
+
+// GetTargetSchema returns the target schema name for routing.
+// If TargetSchema is empty, returns Schema.
+func (t *TableName) GetTargetSchema() string {
+	if t.TargetSchema != "" {
+		return t.TargetSchema
+	}
+	return t.Schema
+}
+
+// GetTargetTable returns the target table name for routing.
+// If TargetTable is empty, returns Table.
+func (t *TableName) GetTargetTable() string {
+	if t.TargetTable != "" {
+		return t.TargetTable
+	}
+	return t.Table
+}
+
+// TargetString returns the target schema.table string for routing.
+func (t TableName) TargetString() string {
+	return fmt.Sprintf("%s.%s", t.GetTargetSchema(), t.GetTargetTable())
+}
+
+// QuoteTargetString returns quoted full target table name for routing.
+func (t TableName) QuoteTargetString() string {
+	return QuoteSchema(t.GetTargetSchema(), t.GetTargetTable())
 }

--- a/pkg/common/table_name_gen.go
+++ b/pkg/common/table_name_gen.go
@@ -48,6 +48,18 @@ func (z *TableName) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "IsPartition")
 				return
 			}
+		case "target-db-name":
+			z.TargetSchema, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "TargetSchema")
+				return
+			}
+		case "target-tbl-name":
+			z.TargetTable, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "TargetTable")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -61,9 +73,9 @@ func (z *TableName) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *TableName) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
+	// map header, size 6
 	// write "db-name"
-	err = en.Append(0x84, 0xa7, 0x64, 0x62, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	err = en.Append(0x86, 0xa7, 0x64, 0x62, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
 	if err != nil {
 		return
 	}
@@ -102,15 +114,35 @@ func (z *TableName) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "IsPartition")
 		return
 	}
+	// write "target-db-name"
+	err = en.Append(0xae, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x2d, 0x64, 0x62, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.TargetSchema)
+	if err != nil {
+		err = msgp.WrapError(err, "TargetSchema")
+		return
+	}
+	// write "target-tbl-name"
+	err = en.Append(0xaf, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x2d, 0x74, 0x62, 0x6c, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.TargetTable)
+	if err != nil {
+		err = msgp.WrapError(err, "TargetTable")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *TableName) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 6
 	// string "db-name"
-	o = append(o, 0x84, 0xa7, 0x64, 0x62, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	o = append(o, 0x86, 0xa7, 0x64, 0x62, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.Schema)
 	// string "tbl-name"
 	o = append(o, 0xa8, 0x74, 0x62, 0x6c, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
@@ -121,6 +153,12 @@ func (z *TableName) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "is-partition"
 	o = append(o, 0xac, 0x69, 0x73, 0x2d, 0x70, 0x61, 0x72, 0x74, 0x69, 0x74, 0x69, 0x6f, 0x6e)
 	o = msgp.AppendBool(o, z.IsPartition)
+	// string "target-db-name"
+	o = append(o, 0xae, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x2d, 0x64, 0x62, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.TargetSchema)
+	// string "target-tbl-name"
+	o = append(o, 0xaf, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x2d, 0x74, 0x62, 0x6c, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.TargetTable)
 	return
 }
 
@@ -166,6 +204,18 @@ func (z *TableName) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "IsPartition")
 				return
 			}
+		case "target-db-name":
+			z.TargetSchema, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TargetSchema")
+				return
+			}
+		case "target-tbl-name":
+			z.TargetTable, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TargetTable")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -180,6 +230,6 @@ func (z *TableName) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *TableName) Msgsize() (s int) {
-	s = 1 + 8 + msgp.StringPrefixSize + len(z.Schema) + 9 + msgp.StringPrefixSize + len(z.Table) + 7 + msgp.Int64Size + 13 + msgp.BoolSize
+	s = 1 + 8 + msgp.StringPrefixSize + len(z.Schema) + 9 + msgp.StringPrefixSize + len(z.Table) + 7 + msgp.Int64Size + 13 + msgp.BoolSize + 15 + msgp.StringPrefixSize + len(z.TargetSchema) + 16 + msgp.StringPrefixSize + len(z.TargetTable)
 	return
 }

--- a/pkg/config/changefeed.go
+++ b/pkg/config/changefeed.go
@@ -484,7 +484,15 @@ func (info *ChangeFeedInfo) rmMQOnlyFields() {
 	log.Info("since the downstream is not a MQ, remove MQ only fields",
 		zap.String("keyspace", info.ChangefeedID.Keyspace()),
 		zap.String("changefeed", info.ChangefeedID.Name()))
-	info.Config.Sink.DispatchRules = nil
+	// Don't nil out DispatchRules entirely - it may contain routing rules (SchemaRule/TableRule)
+	// that are valid for all sink types. Instead, remove only MQ-specific fields from each rule.
+	for _, rule := range info.Config.Sink.DispatchRules {
+		rule.DispatcherRule = ""
+		rule.PartitionRule = ""
+		rule.IndexName = ""
+		rule.Columns = nil
+		rule.TopicRule = ""
+	}
 	info.Config.Sink.SchemaRegistry = nil
 	info.Config.Sink.EncoderConcurrency = nil
 	info.Config.Sink.OnlyOutputUpdatedColumns = nil

--- a/pkg/sink/mysql/helper.go
+++ b/pkg/sink/mysql/helper.go
@@ -386,7 +386,7 @@ func CreateMysqlDBConn(dsnStr string) (*sql.DB, error) {
 }
 
 func needSwitchDB(event *commonEvent.DDLEvent) bool {
-	if len(event.GetSchemaName()) == 0 {
+	if len(event.GetDDLSchemaName()) == 0 {
 		return false
 	}
 	if event.GetDDLType() == timodel.ActionCreateSchema || event.GetDDLType() == timodel.ActionDropSchema {

--- a/pkg/sink/mysql/mysql_writer_ddl.go
+++ b/pkg/sink/mysql/mysql_writer_ddl.go
@@ -84,7 +84,7 @@ func (w *Writer) execDDL(event *commonEvent.DDLEvent) error {
 	}
 
 	if shouldSwitchDB {
-		_, err = tx.ExecContext(ctx, "USE "+common.QuoteName(event.GetSchemaName())+";")
+		_, err = tx.ExecContext(ctx, "USE "+common.QuoteName(event.GetDDLSchemaName())+";")
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
 				log.Error("Failed to rollback", zap.Error(err))

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -176,7 +176,7 @@ func buildInsert(
 // sql: `DELETE FROM `test`.`t` WHERE x = ? AND y >= ? LIMIT 1`
 func buildDelete(tableInfo *common.TableInfo, row commonEvent.RowChange) (string, []interface{}) {
 	var builder strings.Builder
-	quoteTable := tableInfo.TableName.QuoteString()
+	quoteTable := tableInfo.TableName.QuoteTargetString()
 	builder.WriteString("DELETE FROM ")
 	builder.WriteString(quoteTable)
 	builder.WriteString(" WHERE ")

--- a/pkg/sink/sqlmodel/multi_row.go
+++ b/pkg/sink/sqlmodel/multi_row.go
@@ -87,7 +87,7 @@ func GenDeleteSQL(changes ...*RowChange) (string, []interface{}) {
 	var buf strings.Builder
 	buf.Grow(1024)
 	buf.WriteString("DELETE FROM ")
-	buf.WriteString(first.targetTable.QuoteString())
+	buf.WriteString(first.targetTable.QuoteTargetString())
 	buf.WriteString(" WHERE (")
 
 	allArgs := make([]interface{}, 0, len(changes)*CommonIndexColumnsCount)
@@ -117,7 +117,7 @@ func GenUpdateSQL(changes ...*RowChange) (string, []any) {
 	// Generate UPDATE `db`.`table` SET
 	first := changes[0]
 	buf.WriteString("UPDATE ")
-	buf.WriteString(first.targetTable.QuoteString())
+	buf.WriteString(first.targetTable.QuoteTargetString())
 	buf.WriteString(" SET ")
 
 	// Pre-generate essential sub statements used after WHEN, WHERE.
@@ -241,7 +241,7 @@ func GenInsertSQL(tp DMLType, changes ...*RowChange) (string, []interface{}) {
 	} else {
 		buf.WriteString("INSERT INTO ")
 	}
-	buf.WriteString(first.targetTable.QuoteString())
+	buf.WriteString(first.targetTable.QuoteTargetString())
 	buf.WriteString(" (")
 	columnNum := 0
 	var skipColIdx []int

--- a/pkg/sink/sqlmodel/multi_row_test.go
+++ b/pkg/sink/sqlmodel/multi_row_test.go
@@ -1,0 +1,334 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlmodel
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/stretchr/testify/require"
+)
+
+// getTestTableInfoForMultiRow creates a simple TableInfo for testing using EventTestHelper
+func getTestTableInfoForMultiRow(t *testing.T, schema, table string) *common.TableInfo {
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use " + schema)
+	createTableSQL := "create table " + table + " (id int primary key, name varchar(32));"
+	job := helper.DDL2Job(createTableSQL)
+	require.NotNil(t, job)
+
+	// Create a dummy event to get the TableInfo
+	insertDataSQL := "insert into " + table + " values (1, 'dummy');"
+	event := helper.DML2Event(schema, table, insertDataSQL)
+	require.NotNil(t, event)
+
+	return event.TableInfo
+}
+
+// TestGenInsertSQLWithRouting tests that GenInsertSQL uses target schema/table
+// when routing is configured via TableInfo.CloneWithRouting().
+func TestGenInsertSQLWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	// Create 5 row changes to properly test multi-row batch insert
+	row1 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(1), "alice"}, routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(2), "bob"}, routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(3), "charlie"}, routedTableInfo, nil, nil)
+	row4 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(4), "david"}, routedTableInfo, nil, nil)
+	row5 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(5), "eve"}, routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3, row4, row5}
+
+	// Test INSERT
+	sql, args := GenInsertSQL(DMLInsert, rows...)
+	require.Contains(t, sql, "INSERT INTO `target_db`.`target_table`", "INSERT should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "INSERT should not contain source schema.table")
+	// Verify all 5 rows' values are in args (2 columns * 5 rows = 10 args)
+	require.Len(t, args, 10)
+	expectedArgs := []interface{}{
+		int64(1), "alice",
+		int64(2), "bob",
+		int64(3), "charlie",
+		int64(4), "david",
+		int64(5), "eve",
+	}
+	require.Equal(t, expectedArgs, args, "INSERT args should contain all row values in order")
+
+	// Test REPLACE
+	sql, args = GenInsertSQL(DMLReplace, rows...)
+	require.Contains(t, sql, "REPLACE INTO `target_db`.`target_table`", "REPLACE should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "REPLACE should not contain source schema.table")
+	require.Len(t, args, 10)
+	require.Equal(t, expectedArgs, args, "REPLACE args should contain all row values in order")
+
+	// Test INSERT ON DUPLICATE KEY UPDATE
+	sql, args = GenInsertSQL(DMLInsertOnDuplicateUpdate, rows...)
+	require.Contains(t, sql, "INSERT INTO `target_db`.`target_table`", "INSERT ON DUP should use target schema and table")
+	require.Contains(t, sql, "ON DUPLICATE KEY UPDATE", "Should have ON DUPLICATE KEY UPDATE clause")
+	require.NotContains(t, sql, "`test`.`t`", "INSERT ON DUP should not contain source schema.table")
+	require.Len(t, args, 10)
+	require.Equal(t, expectedArgs, args, "INSERT ON DUP args should contain all row values in order")
+}
+
+// TestGenDeleteSQLWithRouting tests that GenDeleteSQL uses target schema/table
+func TestGenDeleteSQLWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	// Create 4 row changes for delete (preValues only)
+	row1 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1), "alice"}, nil, routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(2), "bob"}, nil, routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(3), "charlie"}, nil, routedTableInfo, nil, nil)
+	row4 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(4), "david"}, nil, routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3, row4}
+
+	sql, args := GenDeleteSQL(rows...)
+	require.Contains(t, sql, "DELETE FROM `target_db`.`target_table`", "DELETE should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "DELETE should not contain source schema.table")
+	// DELETE uses WHERE with primary key (id column only for this table)
+	// 4 rows * 1 PK column = 4 args
+	require.Len(t, args, 4)
+	expectedArgs := []interface{}{int64(1), int64(2), int64(3), int64(4)}
+	require.Equal(t, expectedArgs, args, "DELETE args should contain PK values for all rows")
+	// Verify OR clauses for multi-row delete
+	require.Contains(t, sql, "OR", "Multi-row DELETE should have OR clauses")
+}
+
+// TestGenUpdateSQLWithRouting tests that GenUpdateSQL uses target schema/table
+func TestGenUpdateSQLWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	// Create 3 row changes for update (both preValues and postValues)
+	row1 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1), "alice_old"},
+		[]interface{}{int64(1), "alice_new"},
+		routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(2), "bob_old"},
+		[]interface{}{int64(2), "bob_new"},
+		routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(3), "charlie_old"},
+		[]interface{}{int64(3), "charlie_new"},
+		routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3}
+
+	sql, args := GenUpdateSQL(rows...)
+	require.Contains(t, sql, "UPDATE `target_db`.`target_table`", "UPDATE should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "UPDATE should not contain source schema.table")
+	// UPDATE uses CASE WHEN for multi-row updates
+	require.Contains(t, sql, "CASE", "Multi-row UPDATE should use CASE expression")
+	require.Contains(t, sql, "WHEN", "Multi-row UPDATE should use WHEN clauses")
+	require.Contains(t, sql, "OR", "Multi-row UPDATE WHERE should have OR clauses")
+	// Args should contain values for all rows
+	// Multi-row UPDATE args: for each column: [WHEN pk=? THEN new_val] repeated for each row, then WHERE pk values
+	// 2 columns (id, name) * 3 rows * (1 pk + 1 new_val) + 3 WHERE pk values = 2*3*2 + 3 = 15
+	require.Len(t, args, 15, "Multi-row UPDATE should have correct number of args")
+	// Verify args contain expected new values
+	require.Contains(t, args, "alice_new")
+	require.Contains(t, args, "bob_new")
+	require.Contains(t, args, "charlie_new")
+}
+
+// TestGenInsertSQLWithSchemaOnlyRouting tests routing where only schema changes
+func TestGenInsertSQLWithSchemaOnlyRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "users")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("prod", "users")
+
+	// Create 3 row changes
+	row1 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(100), "user1"}, routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(200), "user2"}, routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(300), "user3"}, routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3}
+
+	sql, args := GenInsertSQL(DMLInsert, rows...)
+	require.Contains(t, sql, "`prod`.`users`", "Should use target schema with original table name")
+	require.NotContains(t, sql, "`test`.`users`", "Should not contain source schema")
+	require.Len(t, args, 6)
+	expectedArgs := []interface{}{int64(100), "user1", int64(200), "user2", int64(300), "user3"}
+	require.Equal(t, expectedArgs, args)
+}
+
+// TestGenInsertSQLWithTableOnlyRouting tests routing where only table name changes
+func TestGenInsertSQLWithTableOnlyRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "old_table")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("test", "new_table")
+
+	// Create 3 row changes
+	row1 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(10), "data1"}, routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(20), "data2"}, routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(30), "data3"}, routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3}
+
+	sql, args := GenInsertSQL(DMLInsert, rows...)
+	require.Contains(t, sql, "`test`.`new_table`", "Should use original schema with target table name")
+	require.NotContains(t, sql, "old_table", "Should not contain source table name")
+	require.Len(t, args, 6)
+	expectedArgs := []interface{}{int64(10), "data1", int64(20), "data2", int64(30), "data3"}
+	require.Equal(t, expectedArgs, args)
+}
+
+// TestGenDeleteSQLWithSchemaOnlyRouting tests DELETE with schema-only routing
+func TestGenDeleteSQLWithSchemaOnlyRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "orders")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "orders")
+
+	// Create 4 row changes for delete
+	row1 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1001), "order1"}, nil, routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1002), "order2"}, nil, routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1003), "order3"}, nil, routedTableInfo, nil, nil)
+	row4 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1004), "order4"}, nil, routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3, row4}
+
+	sql, args := GenDeleteSQL(rows...)
+	require.Contains(t, sql, "`target_db`.`orders`", "Should use target schema with original table name")
+	require.NotContains(t, sql, "`test`.`orders`", "Should not contain source schema.table")
+	require.Len(t, args, 4)
+	expectedArgs := []interface{}{int64(1001), int64(1002), int64(1003), int64(1004)}
+	require.Equal(t, expectedArgs, args)
+}
+
+// TestGenUpdateSQLWithTableOnlyRouting tests UPDATE with table-only routing
+func TestGenUpdateSQLWithTableOnlyRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "old_products")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("test", "new_products")
+
+	// Create 3 row changes for update
+	row1 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(1), "old_name1"},
+		[]interface{}{int64(1), "new_name1"},
+		routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(2), "old_name2"},
+		[]interface{}{int64(2), "new_name2"},
+		routedTableInfo, nil, nil)
+	row3 := NewRowChange(&routedTableInfo.TableName, nil,
+		[]interface{}{int64(3), "old_name3"},
+		[]interface{}{int64(3), "new_name3"},
+		routedTableInfo, nil, nil)
+
+	rows := []*RowChange{row1, row2, row3}
+
+	sql, args := GenUpdateSQL(rows...)
+	require.Contains(t, sql, "`test`.`new_products`", "Should use original schema with target table name")
+	require.NotContains(t, sql, "old_products", "Should not contain source table name")
+	// 2 columns * 3 rows * 2 (pk + new_val) + 3 WHERE pk values = 15
+	require.Len(t, args, 15, "Multi-row UPDATE should have correct number of args")
+	require.Contains(t, args, "new_name1")
+	require.Contains(t, args, "new_name2")
+	require.Contains(t, args, "new_name3")
+}
+
+// TestGenMultiRowSQLWithoutRouting verifies that when no routing is configured,
+// source schema/table names are used.
+func TestGenMultiRowSQLWithoutRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "t")
+
+	// Test INSERT without routing - 3 rows
+	row1 := NewRowChange(&sourceTableInfo.TableName, nil, nil,
+		[]interface{}{int64(1), "val1"}, sourceTableInfo, nil, nil)
+	row2 := NewRowChange(&sourceTableInfo.TableName, nil, nil,
+		[]interface{}{int64(2), "val2"}, sourceTableInfo, nil, nil)
+	row3 := NewRowChange(&sourceTableInfo.TableName, nil, nil,
+		[]interface{}{int64(3), "val3"}, sourceTableInfo, nil, nil)
+
+	insertRows := []*RowChange{row1, row2, row3}
+	sql, args := GenInsertSQL(DMLInsert, insertRows...)
+	require.Contains(t, sql, "`test`.`t`", "Should use source schema and table")
+	require.Len(t, args, 6)
+	expectedArgs := []interface{}{int64(1), "val1", int64(2), "val2", int64(3), "val3"}
+	require.Equal(t, expectedArgs, args)
+
+	// Test DELETE without routing - 3 rows
+	delRow1 := NewRowChange(&sourceTableInfo.TableName, nil,
+		[]interface{}{int64(1), "val1"}, nil, sourceTableInfo, nil, nil)
+	delRow2 := NewRowChange(&sourceTableInfo.TableName, nil,
+		[]interface{}{int64(2), "val2"}, nil, sourceTableInfo, nil, nil)
+	delRow3 := NewRowChange(&sourceTableInfo.TableName, nil,
+		[]interface{}{int64(3), "val3"}, nil, sourceTableInfo, nil, nil)
+
+	deleteRows := []*RowChange{delRow1, delRow2, delRow3}
+	sql, args = GenDeleteSQL(deleteRows...)
+	require.Contains(t, sql, "`test`.`t`", "Should use source schema and table")
+	require.Len(t, args, 3)
+	expectedDeleteArgs := []interface{}{int64(1), int64(2), int64(3)}
+	require.Equal(t, expectedDeleteArgs, args)
+
+	// Test UPDATE without routing - 3 rows
+	updRow1 := NewRowChange(&sourceTableInfo.TableName, nil,
+		[]interface{}{int64(1), "old1"},
+		[]interface{}{int64(1), "new1"},
+		sourceTableInfo, nil, nil)
+	updRow2 := NewRowChange(&sourceTableInfo.TableName, nil,
+		[]interface{}{int64(2), "old2"},
+		[]interface{}{int64(2), "new2"},
+		sourceTableInfo, nil, nil)
+	updRow3 := NewRowChange(&sourceTableInfo.TableName, nil,
+		[]interface{}{int64(3), "old3"},
+		[]interface{}{int64(3), "new3"},
+		sourceTableInfo, nil, nil)
+
+	updateRows := []*RowChange{updRow1, updRow2, updRow3}
+	sql, args = GenUpdateSQL(updateRows...)
+	require.Contains(t, sql, "`test`.`t`", "Should use source schema and table")
+	require.Len(t, args, 15, "Multi-row UPDATE should have correct number of args")
+	require.Contains(t, args, "new1")
+	require.Contains(t, args, "new2")
+	require.Contains(t, args, "new3")
+}
+
+// TestSameTypeTargetAndColumnsWithRouting tests that SameTypeTargetAndColumns
+// works correctly when routing is configured.
+func TestSameTypeTargetAndColumnsWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfoForMultiRow(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	row1 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(1), "alice"}, routedTableInfo, nil, nil)
+	row2 := NewRowChange(&routedTableInfo.TableName, nil, nil,
+		[]interface{}{int64(2), "bob"}, routedTableInfo, nil, nil)
+
+	// Same source table, same type - should be compatible
+	require.True(t, SameTypeTargetAndColumns(row1, row2),
+		"Rows with same source table and type should be compatible")
+}

--- a/pkg/sink/sqlmodel/row_change.go
+++ b/pkg/sink/sqlmodel/row_change.go
@@ -171,7 +171,7 @@ func (r *RowChange) String() string {
 
 // TargetTableID returns a ID string for target table.
 func (r *RowChange) TargetTableID() string {
-	return r.targetTable.QuoteString()
+	return r.targetTable.QuoteTargetString()
 }
 
 // ColumnCount returns the number of columns of this RowChange.
@@ -277,7 +277,7 @@ func (r *RowChange) genDeleteSQL() (string, []interface{}) {
 	var buf strings.Builder
 	buf.Grow(1024)
 	buf.WriteString("DELETE FROM ")
-	buf.WriteString(r.targetTable.QuoteString())
+	buf.WriteString(r.targetTable.QuoteTargetString())
 	buf.WriteString(" WHERE ")
 	whereArgs := r.genWhere(&buf)
 	buf.WriteString(" LIMIT 1")
@@ -296,7 +296,7 @@ func (r *RowChange) genUpdateSQL() (string, []interface{}) {
 	var buf strings.Builder
 	buf.Grow(2048)
 	buf.WriteString("UPDATE ")
-	buf.WriteString(r.targetTable.QuoteString())
+	buf.WriteString(r.targetTable.QuoteTargetString())
 	buf.WriteString(" SET ")
 
 	// Build target generated columns lower names set to accelerate following check

--- a/pkg/sink/sqlmodel/row_change_test.go
+++ b/pkg/sink/sqlmodel/row_change_test.go
@@ -1,0 +1,288 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlmodel
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/stretchr/testify/require"
+)
+
+// getTestTableInfo creates a simple TableInfo for testing using EventTestHelper
+func getTestTableInfo(t *testing.T, schema, table string) *common.TableInfo {
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use " + schema)
+	createTableSQL := "create table " + table + " (id int primary key, name varchar(32));"
+	job := helper.DDL2Job(createTableSQL)
+	require.NotNil(t, job)
+
+	// Create a dummy event to get the TableInfo
+	insertDataSQL := "insert into " + table + " values (1, 'dummy');"
+	event := helper.DML2Event(schema, table, insertDataSQL)
+	require.NotNil(t, event)
+
+	return event.TableInfo
+}
+
+// TestGenSQLInsertWithRouting tests that GenSQL for INSERT uses target schema/table
+// when routing is configured via TableInfo.CloneWithRouting().
+func TestGenSQLInsertWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "t")
+
+	// Clone TableInfo with routing: test.t -> target_db.target_table
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	row := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		nil, // preValues (nil for INSERT)
+		[]interface{}{int64(1), "test_value"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, args := row.GenSQL(DMLInsert)
+	require.Contains(t, sql, "`target_db`.`target_table`", "INSERT should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "INSERT should not contain source schema.table")
+	require.Len(t, args, 2)
+
+	// Test REPLACE
+	sql, args = row.GenSQL(DMLReplace)
+	require.Contains(t, sql, "`target_db`.`target_table`", "REPLACE should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "REPLACE should not contain source schema.table")
+	require.Len(t, args, 2)
+}
+
+// TestGenSQLDeleteWithRouting tests that GenSQL for DELETE uses target schema/table
+func TestGenSQLDeleteWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	row := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "test_value"}, // preValues
+		nil,                                   // postValues (nil for DELETE)
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, args := row.GenSQL(DMLDelete)
+	require.Contains(t, sql, "DELETE FROM `target_db`.`target_table`", "DELETE should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "DELETE should not contain source schema.table")
+	require.Greater(t, len(args), 0)
+}
+
+// TestGenSQLUpdateWithRouting tests that GenSQL for UPDATE uses target schema/table
+func TestGenSQLUpdateWithRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	row := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "old_value"},
+		[]interface{}{int64(1), "new_value"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, args := row.GenSQL(DMLUpdate)
+	require.Contains(t, sql, "UPDATE `target_db`.`target_table`", "UPDATE should use target schema and table")
+	require.NotContains(t, sql, "`test`.`t`", "UPDATE should not contain source schema.table")
+	require.Len(t, args, 3, "UPDATE should have 3 args: new id, new name, old id (WHERE)")
+	// Args: SET id=?, name=? WHERE id=?
+	require.Equal(t, []interface{}{int64(1), "new_value", int64(1)}, args)
+}
+
+// TestGenSQLWithSchemaOnlyRouting tests routing where only schema changes
+func TestGenSQLWithSchemaOnlyRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "users")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("prod", "users")
+
+	// Test INSERT
+	insertRow := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		nil,
+		[]interface{}{int64(1), "alice"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, _ := insertRow.GenSQL(DMLInsert)
+	require.Contains(t, sql, "`prod`.`users`", "Should use target schema with original table name")
+	require.NotContains(t, sql, "`test`.`users`", "Should not contain source schema")
+
+	// Test DELETE
+	deleteRow := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "alice"},
+		nil,
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, _ = deleteRow.GenSQL(DMLDelete)
+	require.Contains(t, sql, "`prod`.`users`", "Should use target schema with original table name")
+	require.NotContains(t, sql, "`test`.`users`", "Should not contain source schema")
+
+	// Test UPDATE
+	updateRow := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "alice"},
+		[]interface{}{int64(1), "bob"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, args := updateRow.GenSQL(DMLUpdate)
+	require.Contains(t, sql, "`prod`.`users`", "Should use target schema with original table name")
+	require.NotContains(t, sql, "`test`.`users`", "Should not contain source schema")
+	require.Len(t, args, 3)
+	require.Equal(t, []interface{}{int64(1), "bob", int64(1)}, args)
+}
+
+// TestGenSQLWithTableOnlyRouting tests routing where only table name changes
+func TestGenSQLWithTableOnlyRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "old_table")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("test", "new_table")
+
+	// Test INSERT
+	insertRow := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		nil,
+		[]interface{}{int64(1), "data"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, _ := insertRow.GenSQL(DMLInsert)
+	require.Contains(t, sql, "`test`.`new_table`", "Should use original schema with target table name")
+	require.NotContains(t, sql, "old_table", "Should not contain source table name")
+
+	// Test DELETE
+	deleteRow := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "data"},
+		nil,
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, _ = deleteRow.GenSQL(DMLDelete)
+	require.Contains(t, sql, "`test`.`new_table`", "Should use original schema with target table name")
+	require.NotContains(t, sql, "old_table", "Should not contain source table name")
+
+	// Test UPDATE
+	updateRow := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "old_data"},
+		[]interface{}{int64(1), "new_data"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, args := updateRow.GenSQL(DMLUpdate)
+	require.Contains(t, sql, "`test`.`new_table`", "Should use original schema with target table name")
+	require.NotContains(t, sql, "old_table", "Should not contain source table name")
+	require.Len(t, args, 3)
+	require.Equal(t, []interface{}{int64(1), "new_data", int64(1)}, args)
+}
+
+// TestGenSQLWithoutRouting verifies that when no routing is configured,
+// source schema/table names are used.
+func TestGenSQLWithoutRouting(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "t")
+
+	// Test INSERT without routing
+	insertRow := NewRowChange(
+		&sourceTableInfo.TableName,
+		nil,
+		nil,
+		[]interface{}{int64(1), "test"},
+		sourceTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, _ := insertRow.GenSQL(DMLInsert)
+	require.Contains(t, sql, "`test`.`t`", "Should use source schema and table")
+
+	// Test DELETE
+	deleteRow := NewRowChange(
+		&sourceTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "test"},
+		nil,
+		sourceTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, _ = deleteRow.GenSQL(DMLDelete)
+	require.Contains(t, sql, "`test`.`t`", "Should use source schema and table")
+
+	// Test UPDATE
+	updateRow := NewRowChange(
+		&sourceTableInfo.TableName,
+		nil,
+		[]interface{}{int64(1), "old"},
+		[]interface{}{int64(1), "new"},
+		sourceTableInfo,
+		nil,
+		nil,
+	)
+
+	sql, args := updateRow.GenSQL(DMLUpdate)
+	require.Contains(t, sql, "`test`.`t`", "Should use source schema and table")
+	require.Len(t, args, 3)
+	require.Equal(t, []interface{}{int64(1), "new", int64(1)}, args)
+}
+
+// TestTargetTableID verifies that TargetTableID returns the correct quoted target string
+func TestTargetTableID(t *testing.T) {
+	sourceTableInfo := getTestTableInfo(t, "test", "t")
+	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
+
+	row := NewRowChange(
+		&routedTableInfo.TableName,
+		nil,
+		nil,
+		[]interface{}{int64(1), "test"},
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	require.Equal(t, "`target_db`.`target_table`", row.TargetTableID())
+}

--- a/pkg/sink/util/ddl_routing.go
+++ b/pkg/sink/util/ddl_routing.go
@@ -1,0 +1,135 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/pingcap/log"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/util/filter"
+	"go.uber.org/zap"
+)
+
+// DDLRoutingResult contains the result of DDL routing rewriting.
+type DDLRoutingResult struct {
+	// NewQuery is the rewritten DDL query with target table names.
+	NewQuery string
+	// TargetSchemaName is the target schema to use for the USE statement (if needed).
+	// This is set to the first target table's schema.
+	TargetSchemaName string
+	// WasRewritten indicates whether the query was actually rewritten (had routing applied).
+	WasRewritten bool
+}
+
+// RewriteDDLQueryWithRouting rewrites a DDL query by applying routing rules
+// to transform source table names to target table names.
+//
+// This function is used by both MySQL and Redo sinks to ensure DDL statements
+// use the correct target table names when sink routing is configured.
+//
+// Parameters:
+//   - router: The Router instance containing routing rules. May be nil.
+//   - ddl: The DDL event containing the query to rewrite.
+//   - changefeedID: The changefeed ID for logging purposes.
+//
+// Returns:
+//   - *DDLRoutingResult: Contains the rewritten query and metadata.
+//   - error: Returns an error if DDL parsing or rewriting fails. Silent fallback
+//     is not acceptable as it could lead to data going to wrong tables.
+//
+// IMPORTANT: This function does NOT mutate ddl.Query. Callers are responsible
+// for applying the returned NewQuery to the DDL event if WasRewritten is true.
+func RewriteDDLQueryWithRouting(router *Router, ddl *commonEvent.DDLEvent, changefeedID string) (*DDLRoutingResult, error) {
+	result := &DDLRoutingResult{
+		NewQuery:     ddl.Query,
+		WasRewritten: false,
+	}
+
+	// Early returns for no-op cases
+	if router == nil || ddl.Query == "" {
+		return result, nil
+	}
+
+	// Get the default schema for parsing. If TableInfo is nil (e.g., for
+	// database-level DDLs like CREATE DATABASE), FetchDDLTables will extract
+	// the schema name directly from the DDL statement itself.
+	defaultSchema := ""
+	if ddl.TableInfo != nil {
+		defaultSchema = ddl.TableInfo.GetSchemaName()
+	}
+
+	// Parse the DDL query using TiDB parser
+	p := parser.New()
+	stmt, err := p.ParseOneStmt(ddl.Query, "", "")
+	if err != nil {
+		return nil, errors.Errorf("failed to parse DDL query for routing: %v (query: %s)", err, ddl.Query)
+	}
+
+	// Fetch source tables from the DDL
+	sourceTables, err := FetchDDLTables(defaultSchema, stmt)
+	if err != nil {
+		return nil, errors.Errorf("failed to fetch tables from DDL for routing: %v (query: %s)", err, ddl.Query)
+	}
+
+	if len(sourceTables) == 0 {
+		return result, nil
+	}
+
+	// Build target tables by applying routing rules
+	targetTables := make([]*filter.Table, 0, len(sourceTables))
+	hasRouting := false
+	for _, srcTable := range sourceTables {
+		targetSchema, targetTable := router.Route(srcTable.Schema, srcTable.Name)
+		if targetSchema != srcTable.Schema || targetTable != srcTable.Name {
+			hasRouting = true
+		}
+		targetTables = append(targetTables, &filter.Table{
+			Schema: targetSchema,
+			Name:   targetTable,
+		})
+	}
+
+	if !hasRouting {
+		return result, nil
+	}
+
+	// Rewrite the DDL with target tables
+	newQuery, err := RenameDDLTable(stmt, targetTables)
+	if err != nil {
+		return nil, errors.Errorf("failed to rewrite DDL query with routing: %v (query: %s)", err, ddl.Query)
+	}
+
+	if newQuery != ddl.Query {
+		log.Info("DDL query rewritten with routing",
+			zap.String("changefeed", changefeedID),
+			zap.String("originalQuery", ddl.Query),
+			zap.String("newQuery", newQuery))
+		result.NewQuery = newQuery
+		result.WasRewritten = true
+	}
+
+	// Set the target schema for the USE command when executing the DDL.
+	// We use the first target table's schema because:
+	// 1. For single-table DDLs, this is the correct target schema
+	// 2. For multi-table DDLs (e.g., RENAME TABLE), all table references in the
+	//    rewritten query are fully qualified, so the USE command just needs to
+	//    switch to any database the user has access to - the first target schema
+	//    is guaranteed to be accessible since routing was configured for it.
+	if len(targetTables) > 0 {
+		result.TargetSchemaName = targetTables[0].Schema
+	}
+
+	return result, nil
+}

--- a/pkg/sink/util/ddl_routing_test.go
+++ b/pkg/sink/util/ddl_routing_test.go
@@ -1,0 +1,693 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRewriteDDLQueryWithNilRouter tests that DDL queries pass through unchanged when no router is configured.
+func TestRewriteDDLQueryWithNilRouter(t *testing.T) {
+	t.Parallel()
+
+	ddlEvent := &commonEvent.DDLEvent{
+		Query: "CREATE TABLE `source_db`.`test_table` (id INT PRIMARY KEY)",
+		TableInfo: &common.TableInfo{
+			TableName: common.TableName{Schema: "source_db", Table: "test_table"},
+		},
+	}
+
+	originalQuery := ddlEvent.Query
+	result, err := RewriteDDLQueryWithRouting(nil, ddlEvent, "test-changefeed")
+	require.NoError(t, err)
+	require.False(t, result.WasRewritten, "Query should not be rewritten when router is nil")
+	require.Equal(t, originalQuery, result.NewQuery, "Query should not be modified when router is nil")
+}
+
+// TestRewriteDDLQueryWithEmptyQuery tests that empty queries are handled correctly.
+func TestRewriteDDLQueryWithEmptyQuery(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+
+	ddlEvent := &commonEvent.DDLEvent{
+		Query: "",
+	}
+
+	result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+	require.NoError(t, err)
+	require.False(t, result.WasRewritten)
+	require.Equal(t, "", result.NewQuery)
+}
+
+// TestRewriteDDLQueryWithBasicRouting tests that DDL queries are rewritten when routing is configured.
+func TestRewriteDDLQueryWithBasicRouting(t *testing.T) {
+	t.Parallel()
+
+	// Create a router with a routing rule: source_db.* -> target_db.*
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Test case 1: DDL with routing applied
+	ddlEvent := &commonEvent.DDLEvent{
+		Query: "CREATE TABLE `source_db`.`test_table` (id INT PRIMARY KEY)",
+		TableInfo: &common.TableInfo{
+			TableName: common.TableName{Schema: "source_db", Table: "test_table"},
+		},
+	}
+
+	result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+	require.NoError(t, err)
+	require.True(t, result.WasRewritten)
+	require.Contains(t, result.NewQuery, "target_db")
+	require.Contains(t, result.NewQuery, "test_table")
+	require.NotContains(t, result.NewQuery, "source_db")
+	require.Equal(t, "target_db", result.TargetSchemaName)
+
+	// Test case 2: DDL without routing (no matching rule)
+	ddlEvent2 := &commonEvent.DDLEvent{
+		Query: "CREATE TABLE `other_db`.`other_table` (id INT PRIMARY KEY)",
+		TableInfo: &common.TableInfo{
+			TableName: common.TableName{Schema: "other_db", Table: "other_table"},
+		},
+	}
+
+	originalQuery := ddlEvent2.Query
+	result2, err := RewriteDDLQueryWithRouting(router, ddlEvent2, "test-changefeed")
+	require.NoError(t, err)
+	require.False(t, result2.WasRewritten, "Query should not be rewritten when no routing rule matches")
+	require.Equal(t, originalQuery, result2.NewQuery, "Query should not be modified when no routing rule matches")
+}
+
+// TestRewriteDDLQueryWithSchemaAndTableRouting tests routing where BOTH schema AND table change.
+// Example: source_db.test_table -> target_db.test_table_routed
+func TestRewriteDDLQueryWithSchemaAndTableRouting(t *testing.T) {
+	t.Parallel()
+
+	// Create a router with full routing: source_db.test_table -> target_db.test_table_routed
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.test_table"},
+			SchemaRule: "target_db",
+			TableRule:  "test_table_routed",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		name          string
+		query         string
+		schema        string
+		table         string
+		expectedQuery string
+	}{
+		{
+			name:          "CREATE TABLE",
+			query:         "CREATE TABLE `source_db`.`test_table` (id INT PRIMARY KEY)",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table_routed`",
+		},
+		{
+			name:          "DROP TABLE",
+			query:         "DROP TABLE `source_db`.`test_table`",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table_routed`",
+		},
+		{
+			name:          "TRUNCATE TABLE",
+			query:         "TRUNCATE TABLE `source_db`.`test_table`",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table_routed`",
+		},
+		{
+			name:          "ALTER TABLE ADD COLUMN",
+			query:         "ALTER TABLE `source_db`.`test_table` ADD COLUMN name VARCHAR(255)",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table_routed`",
+		},
+		{
+			name:          "CREATE INDEX",
+			query:         "CREATE INDEX idx_name ON `source_db`.`test_table`(name)",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table_routed`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddlEvent := &commonEvent.DDLEvent{
+				Query: tt.query,
+				TableInfo: &common.TableInfo{
+					TableName: common.TableName{Schema: tt.schema, Table: tt.table},
+				},
+			}
+
+			result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+			require.NoError(t, err)
+			require.True(t, result.WasRewritten)
+			require.Contains(t, result.NewQuery, tt.expectedQuery, "Query should contain routed schema and table")
+			require.NotContains(t, result.NewQuery, "source_db", "Query should not contain source schema")
+			require.NotContains(t, result.NewQuery, "test_table`", "Query should not contain source table (checking with backtick to avoid matching test_table_routed)")
+			require.Equal(t, "target_db", result.TargetSchemaName)
+		})
+	}
+}
+
+// TestRewriteDDLQueryWithSchemaOnlyRouting tests routing where ONLY the schema changes.
+// The table name stays the same via TableRule="{table}".
+// Example: source_db.test_table -> target_db.test_table
+func TestRewriteDDLQueryWithSchemaOnlyRouting(t *testing.T) {
+	t.Parallel()
+
+	// Create a router that only routes the schema: source_db.* -> target_db.*
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		name          string
+		query         string
+		schema        string
+		table         string
+		expectedQuery string
+	}{
+		{
+			name:          "CREATE TABLE users",
+			query:         "CREATE TABLE `source_db`.`users` (id INT PRIMARY KEY)",
+			schema:        "source_db",
+			table:         "users",
+			expectedQuery: "`target_db`.`users`",
+		},
+		{
+			name:          "CREATE TABLE IF NOT EXISTS",
+			query:         "CREATE TABLE IF NOT EXISTS `source_db`.`test_table` (id INT PRIMARY KEY)",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table`",
+		},
+		{
+			name:          "DROP TABLE",
+			query:         "DROP TABLE `source_db`.`test_table`",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table`",
+		},
+		{
+			name:          "TRUNCATE TABLE",
+			query:         "TRUNCATE TABLE `source_db`.`test_table`",
+			schema:        "source_db",
+			table:         "test_table",
+			expectedQuery: "`target_db`.`test_table`",
+		},
+		{
+			name:          "ALTER TABLE products",
+			query:         "ALTER TABLE `source_db`.`products` ADD COLUMN price DECIMAL(10,2)",
+			schema:        "source_db",
+			table:         "products",
+			expectedQuery: "`target_db`.`products`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddlEvent := &commonEvent.DDLEvent{
+				Query: tt.query,
+				TableInfo: &common.TableInfo{
+					TableName: common.TableName{Schema: tt.schema, Table: tt.table},
+				},
+			}
+
+			result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+			require.NoError(t, err)
+			require.True(t, result.WasRewritten)
+			require.Contains(t, result.NewQuery, tt.expectedQuery, "Query should contain routed schema with original table")
+			require.NotContains(t, result.NewQuery, "source_db", "Query should not contain source schema")
+			require.Equal(t, "target_db", result.TargetSchemaName)
+		})
+	}
+}
+
+// TestRewriteDDLQueryWithTableOnlyRouting tests routing where ONLY the table name changes.
+// The schema stays the same via SchemaRule="{schema}".
+// Example: source_db.test_table -> source_db.test_table_routed
+func TestRewriteDDLQueryWithTableOnlyRouting(t *testing.T) {
+	t.Parallel()
+
+	// Create a router that only routes the table name: mydb.old_table -> mydb.new_table
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"mydb.old_table"},
+			SchemaRule: SchemaPlaceholder, // Keep schema unchanged
+			TableRule:  "new_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		name          string
+		query         string
+		schema        string
+		table         string
+		expectedQuery string
+	}{
+		{
+			name:          "CREATE TABLE",
+			query:         "CREATE TABLE `mydb`.`old_table` (id INT PRIMARY KEY)",
+			schema:        "mydb",
+			table:         "old_table",
+			expectedQuery: "`mydb`.`new_table`",
+		},
+		{
+			name:          "DROP TABLE",
+			query:         "DROP TABLE `mydb`.`old_table`",
+			schema:        "mydb",
+			table:         "old_table",
+			expectedQuery: "`mydb`.`new_table`",
+		},
+		{
+			name:          "TRUNCATE TABLE",
+			query:         "TRUNCATE TABLE `mydb`.`old_table`",
+			schema:        "mydb",
+			table:         "old_table",
+			expectedQuery: "`mydb`.`new_table`",
+		},
+		{
+			name:          "ALTER TABLE",
+			query:         "ALTER TABLE `mydb`.`old_table` ADD COLUMN status VARCHAR(50)",
+			schema:        "mydb",
+			table:         "old_table",
+			expectedQuery: "`mydb`.`new_table`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddlEvent := &commonEvent.DDLEvent{
+				Query: tt.query,
+				TableInfo: &common.TableInfo{
+					TableName: common.TableName{Schema: tt.schema, Table: tt.table},
+				},
+			}
+
+			result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+			require.NoError(t, err)
+			require.True(t, result.WasRewritten)
+			require.Contains(t, result.NewQuery, tt.expectedQuery, "Query should contain original schema with routed table")
+			require.NotContains(t, result.NewQuery, "old_table", "Query should not contain source table")
+			require.Equal(t, "mydb", result.TargetSchemaName)
+		})
+	}
+}
+
+// TestRewriteDDLQueryWithMultiTableOrdering tests that FetchDDLTables and RenameDDLTable maintain correct ordering
+// when DDLs reference multiple tables (e.g., RENAME TABLE, CREATE TABLE LIKE).
+// This ensures that tables are rewritten in the correct order when some are mapped and some are not.
+func TestRewriteDDLQueryWithMultiTableOrdering(t *testing.T) {
+	t.Parallel()
+
+	// Create a router where one schema is mapped and one is not
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"mapped_source_db.*"},
+			SchemaRule: "mapped_target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		name          string
+		query         string
+		schema        string
+		table         string
+		expectedQuery string
+		description   string
+	}{
+		{
+			name:          "DROP TABLE - mapped schema",
+			query:         "DROP TABLE `mapped_source_db`.`t1`",
+			schema:        "mapped_source_db",
+			table:         "t1",
+			expectedQuery: "DROP TABLE `mapped_target_db`.`t1`",
+			description:   "Tests DROP TABLE with mapped schema",
+		},
+		{
+			name:          "DROP TABLE - unmapped schema",
+			query:         "DROP TABLE `unmapped_db`.`t1`",
+			schema:        "unmapped_db",
+			table:         "t1",
+			expectedQuery: "DROP TABLE `unmapped_db`.`t1`",
+			description:   "Tests DROP TABLE with unmapped schema (identity mapping)",
+		},
+		{
+			name:          "RENAME TABLE - mapped old, mapped new",
+			query:         "RENAME TABLE `mapped_source_db`.`old_table` TO `mapped_source_db`.`new_table`",
+			schema:        "mapped_source_db",
+			table:         "old_table",
+			expectedQuery: "RENAME TABLE `mapped_target_db`.`old_table` TO `mapped_target_db`.`new_table`",
+			description:   "Tests RENAME TABLE where both old and new schemas are mapped (same schema)",
+		},
+		{
+			name:          "RENAME TABLE - mapped old, unmapped new",
+			query:         "RENAME TABLE `mapped_source_db`.`old_table` TO `unmapped_db`.`new_table`",
+			schema:        "mapped_source_db",
+			table:         "old_table",
+			expectedQuery: "RENAME TABLE `mapped_target_db`.`old_table` TO `unmapped_db`.`new_table`",
+			description:   "Tests RENAME TABLE ordering: old table is mapped, new table is unmapped",
+		},
+		{
+			name:          "RENAME TABLE - unmapped old, mapped new",
+			query:         "RENAME TABLE `unmapped_db`.`old_table` TO `mapped_source_db`.`new_table`",
+			schema:        "unmapped_db",
+			table:         "old_table",
+			expectedQuery: "RENAME TABLE `unmapped_db`.`old_table` TO `mapped_target_db`.`new_table`",
+			description:   "Tests RENAME TABLE ordering: old table is unmapped, new table is mapped",
+		},
+		{
+			name:          "CREATE TABLE LIKE - mapped source, unmapped template",
+			query:         "CREATE TABLE `mapped_source_db`.`new_table` LIKE `unmapped_db`.`template_table`",
+			schema:        "mapped_source_db",
+			table:         "new_table",
+			expectedQuery: "CREATE TABLE `mapped_target_db`.`new_table` LIKE `unmapped_db`.`template_table`",
+			description:   "Tests CREATE LIKE ordering: new table is mapped, template is unmapped",
+		},
+		{
+			name:          "CREATE TABLE LIKE - unmapped source, mapped template",
+			query:         "CREATE TABLE `unmapped_db`.`new_table` LIKE `mapped_source_db`.`template_table`",
+			schema:        "unmapped_db",
+			table:         "new_table",
+			expectedQuery: "CREATE TABLE `unmapped_db`.`new_table` LIKE `mapped_target_db`.`template_table`",
+			description:   "Tests CREATE LIKE ordering: new table is unmapped, template is mapped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddlEvent := &commonEvent.DDLEvent{
+				Query: tt.query,
+				TableInfo: &common.TableInfo{
+					TableName: common.TableName{Schema: tt.schema, Table: tt.table},
+				},
+			}
+
+			result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedQuery, result.NewQuery,
+				"ORDERING TEST FAILED for %s\n%s\nExpected: %s\nActual:   %s",
+				tt.name, tt.description, tt.expectedQuery, result.NewQuery)
+		})
+	}
+}
+
+// TestRewriteDDLQueryWithComplexMultiTableRouting tests complex multi-table routing scenarios
+func TestRewriteDDLQueryWithComplexMultiTableRouting(t *testing.T) {
+	t.Parallel()
+
+	// Test with full routing (schema + table name changes)
+	tableRouter, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.source_table"},
+			SchemaRule: "target_db",
+			TableRule:  "target_table_routed",
+		},
+		{
+			Matcher:    []string{"source_db.old_table"},
+			SchemaRule: "target_db",
+			TableRule:  "old_table_routed",
+		},
+		{
+			Matcher:    []string{"source_db.new_table"},
+			SchemaRule: "target_db",
+			TableRule:  "new_table_routed",
+		},
+		{
+			Matcher:    []string{"source_db.template_table"},
+			SchemaRule: "target_db",
+			TableRule:  "template_table_routed",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tableRouter)
+
+	tableRoutingTests := []struct {
+		name          string
+		query         string
+		schema        string
+		table         string
+		expectedQuery string
+		description   string
+	}{
+		{
+			name:          "DROP TABLE - with table routing",
+			query:         "DROP TABLE `source_db`.`source_table`",
+			schema:        "source_db",
+			table:         "source_table",
+			expectedQuery: "DROP TABLE `target_db`.`target_table_routed`",
+			description:   "Tests DROP TABLE with both schema and table routing",
+		},
+		{
+			name:          "TRUNCATE TABLE - with table routing",
+			query:         "TRUNCATE TABLE `source_db`.`source_table`",
+			schema:        "source_db",
+			table:         "source_table",
+			expectedQuery: "TRUNCATE TABLE `target_db`.`target_table_routed`",
+			description:   "Tests TRUNCATE TABLE with both schema and table routing",
+		},
+		{
+			name:          "CREATE TABLE - with table routing",
+			query:         "CREATE TABLE `source_db`.`source_table` (id INT PRIMARY KEY)",
+			schema:        "source_db",
+			table:         "source_table",
+			expectedQuery: "CREATE TABLE `target_db`.`target_table_routed` (`id` INT PRIMARY KEY)",
+			description:   "Tests CREATE TABLE with both schema and table routing",
+		},
+		{
+			name:          "RENAME TABLE - with table routing",
+			query:         "RENAME TABLE `source_db`.`old_table` TO `source_db`.`new_table`",
+			schema:        "source_db",
+			table:         "old_table",
+			expectedQuery: "RENAME TABLE `target_db`.`old_table_routed` TO `target_db`.`new_table_routed`",
+			description:   "Tests RENAME TABLE with both schema and table routing on both old and new tables",
+		},
+		{
+			name:          "CREATE TABLE LIKE - with table routing",
+			query:         "CREATE TABLE `source_db`.`new_table` LIKE `source_db`.`template_table`",
+			schema:        "source_db",
+			table:         "new_table",
+			expectedQuery: "CREATE TABLE `target_db`.`new_table_routed` LIKE `target_db`.`template_table_routed`",
+			description:   "Tests CREATE TABLE LIKE with both schema and table routing on both new and template tables",
+		},
+	}
+
+	for _, tt := range tableRoutingTests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddlEvent := &commonEvent.DDLEvent{
+				Query: tt.query,
+				TableInfo: &common.TableInfo{
+					TableName: common.TableName{Schema: tt.schema, Table: tt.table},
+				},
+			}
+
+			result, err := RewriteDDLQueryWithRouting(tableRouter, ddlEvent, "test-changefeed")
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedQuery, result.NewQuery,
+				"TABLE ROUTING TEST FAILED for %s\n%s\nExpected: %s\nActual:   %s",
+				tt.name, tt.description, tt.expectedQuery, result.NewQuery)
+		})
+	}
+}
+
+// TestRewriteDDLQueryWithConsolidatedRouting tests scenarios where multiple schemas are consolidated
+func TestRewriteDDLQueryWithConsolidatedRouting(t *testing.T) {
+	t.Parallel()
+
+	// Test scenario with multiple schemas consolidated to a single target
+	// Scenario: db1.* -> consolidated, db2.* -> consolidated
+	consolidatedRouter, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"db1.*"},
+			SchemaRule: "consolidated",
+			TableRule:  TablePlaceholder,
+		},
+		{
+			Matcher:    []string{"db2.*"},
+			SchemaRule: "consolidated",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("CREATE TABLE LIKE - multiple schemas consolidated to single target", func(t *testing.T) {
+		// CREATE TABLE db1.t1 LIKE db2.t2
+		// Both schemas map to the same target
+		ddlEvent := &commonEvent.DDLEvent{
+			Query: "CREATE TABLE `db1`.`t1` LIKE `db2`.`t2`",
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "db1", Table: "t1"},
+			},
+		}
+
+		result, err := RewriteDDLQueryWithRouting(consolidatedRouter, ddlEvent, "test-changefeed")
+		require.NoError(t, err)
+
+		expectedQuery := "CREATE TABLE `consolidated`.`t1` LIKE `consolidated`.`t2`"
+		require.Equal(t, expectedQuery, result.NewQuery,
+			"Multiple schemas consolidated to single target should route both tables to same target")
+	})
+
+	// Test scenarios with multiple schemas mapped to different targets
+	// Scenario: db1.* -> target1, db2.* -> target2
+	multiSchemaRouter, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"db1.*"},
+			SchemaRule: "target1",
+			TableRule:  TablePlaceholder,
+		},
+		{
+			Matcher:    []string{"db2.*"},
+			SchemaRule: "target2",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("CREATE TABLE LIKE - same table name different schemas routed differently", func(t *testing.T) {
+		// CREATE TABLE db1.users LIKE db2.users
+		// Both schemas are mapped but to different targets
+		// This is a critical test case: same table name but different routing per schema
+		ddlEvent := &commonEvent.DDLEvent{
+			Query: "CREATE TABLE `db1`.`users` LIKE `db2`.`users`",
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "db1", Table: "users"},
+			},
+		}
+
+		result, err := RewriteDDLQueryWithRouting(multiSchemaRouter, ddlEvent, "test-changefeed")
+		require.NoError(t, err)
+
+		expectedQuery := "CREATE TABLE `target1`.`users` LIKE `target2`.`users`"
+		require.Equal(t, expectedQuery, result.NewQuery,
+			"Same table name in different schemas should route to their respective targets")
+		require.True(t, result.WasRewritten, "Query should be marked as rewritten")
+		require.Equal(t, "target1", result.TargetSchemaName, "TargetSchemaName should be set to first target schema")
+	})
+
+	t.Run("RENAME TABLE - different schemas with same table name routed differently", func(t *testing.T) {
+		// RENAME TABLE db1.users TO db2.users
+		// Moving a table from one schema to another, both with routing
+		ddlEvent := &commonEvent.DDLEvent{
+			Query: "RENAME TABLE `db1`.`users` TO `db2`.`users`",
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "db1", Table: "users"},
+			},
+		}
+
+		result, err := RewriteDDLQueryWithRouting(multiSchemaRouter, ddlEvent, "test-changefeed")
+		require.NoError(t, err)
+
+		expectedQuery := "RENAME TABLE `target1`.`users` TO `target2`.`users`"
+		require.Equal(t, expectedQuery, result.NewQuery,
+			"RENAME TABLE should apply different routing to each schema")
+		require.True(t, result.WasRewritten)
+		require.Equal(t, "target1", result.TargetSchemaName)
+	})
+}
+
+// TestRewriteDDLQueryWithErrors tests error handling for malformed DDLs
+func TestRewriteDDLQueryWithErrors(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("Invalid SQL syntax", func(t *testing.T) {
+		ddlEvent := &commonEvent.DDLEvent{
+			Query: "CREATE TABLE this is not valid SQL",
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "source_db", Table: "test_table"},
+			},
+		}
+
+		result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+		require.Error(t, err, "Should return error for invalid SQL syntax")
+		require.Nil(t, result, "Result should be nil on error")
+		require.Contains(t, err.Error(), "failed to parse DDL query", "Error should mention parsing failure")
+	})
+
+	t.Run("SQL with syntax error in table name", func(t *testing.T) {
+		ddlEvent := &commonEvent.DDLEvent{
+			Query: "CREATE TABLE `source_db`.`unclosed (id INT)",
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "source_db", Table: "unclosed"},
+			},
+		}
+
+		result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+		require.Error(t, err, "Should return error for syntax error")
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "failed to parse DDL query", "Error should mention parsing failure")
+	})
+
+	t.Run("Empty TableInfo with database-level DDL that cannot be parsed", func(t *testing.T) {
+		// This simulates a case where we can't extract tables from the DDL
+		// but since it's database-level, it should still work (no tables to route)
+		ddlEvent := &commonEvent.DDLEvent{
+			Query:     "CREATE DATABASE `new_db`",
+			TableInfo: nil, // Database-level DDL has no TableInfo
+		}
+
+		result, err := RewriteDDLQueryWithRouting(router, ddlEvent, "test-changefeed")
+		require.NoError(t, err, "Database-level DDL with no tables should not error")
+		require.False(t, result.WasRewritten, "Database DDL should not be rewritten")
+		require.Equal(t, ddlEvent.Query, result.NewQuery, "Query should remain unchanged")
+	})
+}

--- a/pkg/sink/util/ddl_table_utils.go
+++ b/pkg/sink/util/ddl_table_utils.go
@@ -1,0 +1,167 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/format"
+	"github.com/pingcap/tidb/pkg/util/filter"
+)
+
+func genTableName(schema string, table string) *filter.Table {
+	return &filter.Table{Schema: schema, Name: table}
+}
+
+// tableNameExtractor extracts table names from DDL AST nodes.
+// ref: https://github.com/pingcap/tidb/blob/09feccb529be2830944e11f5fed474020f50370f/server/sql_info_fetcher.go#L46
+type tableNameExtractor struct {
+	curDB string
+	names []*filter.Table
+}
+
+func (tne *tableNameExtractor) Enter(in ast.Node) (ast.Node, bool) {
+	if _, ok := in.(*ast.ReferenceDef); ok {
+		return in, true
+	}
+	if t, ok := in.(*ast.TableName); ok {
+		tb := &filter.Table{Schema: t.Schema.O, Name: t.Name.O}
+		if tb.Schema == "" {
+			tb.Schema = tne.curDB
+		}
+		tne.names = append(tne.names, tb)
+		return in, true
+	}
+	return in, false
+}
+
+func (tne *tableNameExtractor) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
+// FetchDDLTables returns tables in DDL statement.
+// Because we use visitor pattern, first tableName is always upper-most table in AST.
+// Specifically:
+//   - for `CREATE TABLE ... LIKE` DDL, result contains [sourceTable, sourceRefTable]
+//   - for RENAME TABLE DDL, result contains [old1, new1, old2, new2, old3, new3, ...] because of TiDB parser
+//   - for other DDL, order of tableName is the node visit order.
+func FetchDDLTables(schema string, stmt ast.StmtNode) ([]*filter.Table, error) {
+	switch stmt.(type) {
+	case ast.DDLNode:
+	default:
+		return nil, fmt.Errorf("unknown DDL type: %T", stmt)
+	}
+
+	// Special cases: schema related SQLs don't have tableName
+	switch v := stmt.(type) {
+	case *ast.AlterDatabaseStmt:
+		dbName := v.Name.O
+		if dbName == "" {
+			dbName = schema
+		}
+		return []*filter.Table{{Schema: dbName, Name: ""}}, nil
+	case *ast.CreateDatabaseStmt:
+		return []*filter.Table{{Schema: v.Name.O, Name: ""}}, nil
+	case *ast.DropDatabaseStmt:
+		return []*filter.Table{{Schema: v.Name.O, Name: ""}}, nil
+	}
+
+	e := &tableNameExtractor{
+		curDB: schema,
+		names: make([]*filter.Table, 0),
+	}
+	stmt.Accept(e)
+
+	return e.names, nil
+}
+
+// tableRenameVisitor renames tables in DDL AST nodes.
+type tableRenameVisitor struct {
+	targetNames []*filter.Table
+	i           int
+	hasErr      bool
+}
+
+func (v *tableRenameVisitor) Enter(in ast.Node) (ast.Node, bool) {
+	if v.hasErr {
+		return in, true
+	}
+	if _, ok := in.(*ast.ReferenceDef); ok {
+		return in, true
+	}
+	if t, ok := in.(*ast.TableName); ok {
+		if v.i >= len(v.targetNames) {
+			v.hasErr = true
+			return in, true
+		}
+		t.Schema = ast.NewCIStr(v.targetNames[v.i].Schema)
+		t.Name = ast.NewCIStr(v.targetNames[v.i].Name)
+		v.i++
+		return in, true
+	}
+	return in, false
+}
+
+func (v *tableRenameVisitor) Leave(in ast.Node) (ast.Node, bool) {
+	if v.hasErr {
+		return in, false
+	}
+	return in, true
+}
+
+// RenameDDLTable renames tables in DDL by given `targetTables`.
+// Argument `targetTables` should have the same structure as the return value of FetchDDLTables.
+// Returned DDL is formatted like StringSingleQuotes, KeyWordUppercase and NameBackQuotes.
+func RenameDDLTable(stmt ast.StmtNode, targetTables []*filter.Table) (string, error) {
+	switch stmt.(type) {
+	case ast.DDLNode:
+	default:
+		return "", fmt.Errorf("unknown DDL type: %T", stmt)
+	}
+
+	switch v := stmt.(type) {
+	case *ast.AlterDatabaseStmt:
+		v.Name = ast.NewCIStr(targetTables[0].Schema)
+	case *ast.CreateDatabaseStmt:
+		v.Name = ast.NewCIStr(targetTables[0].Schema)
+	case *ast.DropDatabaseStmt:
+		v.Name = ast.NewCIStr(targetTables[0].Schema)
+	default:
+		visitor := &tableRenameVisitor{
+			targetNames: targetTables,
+		}
+		stmt.Accept(visitor)
+		if visitor.hasErr {
+			return "", fmt.Errorf("failed to rewrite DDL: not enough target tables for statement, got %d tables", len(targetTables))
+		}
+		// Check if all target tables were consumed - extra targets indicate a configuration mismatch
+		if visitor.i < len(targetTables) {
+			return "", fmt.Errorf("failed to rewrite DDL: %d target tables provided but only %d were used in statement", len(targetTables), visitor.i)
+		}
+	}
+
+	var b []byte
+	bf := bytes.NewBuffer(b)
+	err := stmt.Restore(&format.RestoreCtx{
+		Flags: format.DefaultRestoreFlags | format.RestoreTiDBSpecialComment | format.RestoreStringWithoutDefaultCharset,
+		In:    bf,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to restore DDL AST: %w", err)
+	}
+
+	return bf.String(), nil
+}

--- a/pkg/sink/util/ddl_table_utils_test.go
+++ b/pkg/sink/util/ddl_table_utils_test.go
@@ -1,0 +1,452 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/util/filter"
+	"github.com/stretchr/testify/require"
+)
+
+type testCase struct {
+	sql                string
+	expectedSQLs       []string
+	expectedTableNames [][]*filter.Table
+	targetTableNames   [][]*filter.Table
+	targetSQLs         []string
+}
+
+var testCases = []testCase{
+	// Test case with foreign key - foreign key references should NOT be renamed
+	{
+		"create table `t1` (`id` int, `student_id` int, primary key (`id`), foreign key (`student_id`) references `t2`(`id`))",
+		[]string{"CREATE TABLE `t1` (`id` INT,`student_id` INT,PRIMARY KEY(`id`),CONSTRAINT FOREIGN KEY (`student_id`) REFERENCES `t2`(`id`))"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "t1")}},
+		[]string{"CREATE TABLE `xtest`.`t1` (`id` INT,`student_id` INT,PRIMARY KEY(`id`),CONSTRAINT FOREIGN KEY (`student_id`) REFERENCES `t2`(`id`))"},
+	},
+	// CREATE SCHEMA/DATABASE
+	{
+		"create schema `s1`",
+		[]string{"CREATE DATABASE `s1`"},
+		[][]*filter.Table{{genTableName("s1", "")}},
+		[][]*filter.Table{{genTableName("xs1", "")}},
+		[]string{"CREATE DATABASE `xs1`"},
+	},
+	{
+		"create schema if not exists `s1`",
+		[]string{"CREATE DATABASE IF NOT EXISTS `s1`"},
+		[][]*filter.Table{{genTableName("s1", "")}},
+		[][]*filter.Table{{genTableName("xs1", "")}},
+		[]string{"CREATE DATABASE IF NOT EXISTS `xs1`"},
+	},
+	// DROP SCHEMA/DATABASE
+	{
+		"drop schema `s1`",
+		[]string{"DROP DATABASE `s1`"},
+		[][]*filter.Table{{genTableName("s1", "")}},
+		[][]*filter.Table{{genTableName("xs1", "")}},
+		[]string{"DROP DATABASE `xs1`"},
+	},
+	{
+		"drop schema if exists `s1`",
+		[]string{"DROP DATABASE IF EXISTS `s1`"},
+		[][]*filter.Table{{genTableName("s1", "")}},
+		[][]*filter.Table{{genTableName("xs1", "")}},
+		[]string{"DROP DATABASE IF EXISTS `xs1`"},
+	},
+	// ALTER DATABASE without explicit name - cannot rename since AST doesn't store database name
+	{
+		"alter database collate utf8mb4_general_ci",
+		[]string{"ALTER DATABASE COLLATE = utf8mb4_general_ci"},
+		[][]*filter.Table{{genTableName("test", "")}},
+		[][]*filter.Table{{genTableName("xtest", "")}},
+		// Note: When no database name is in original SQL, RenameDDLTable cannot add it
+		// because the AST parser tracks whether name was present
+		[]string{"ALTER DATABASE COLLATE = utf8mb4_general_ci"},
+	},
+	// DROP TABLE - single table
+	{
+		"drop table `Ss1`.`tT1`",
+		[]string{"DROP TABLE `Ss1`.`tT1`"},
+		[][]*filter.Table{{genTableName("Ss1", "tT1")}},
+		[][]*filter.Table{{genTableName("xSs1", "xtT1")}},
+		[]string{"DROP TABLE `xSs1`.`xtT1`"},
+	},
+	// DROP TABLE - multiple tables (requires SplitDDL to split, so we test without splitting)
+	{
+		"drop table `s1`.`t1`, `s2`.`t2`",
+		[]string{"DROP TABLE `s1`.`t1`, `s2`.`t2`"},
+		[][]*filter.Table{{genTableName("s1", "t1"), genTableName("s2", "t2")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1"), genTableName("xs2", "xt2")}},
+		[]string{"DROP TABLE `xs1`.`xt1`, `xs2`.`xt2`"},
+	},
+	{
+		"drop table `s1`.`t1`, `s2`.`t2`, `xx`",
+		[]string{"DROP TABLE `s1`.`t1`, `s2`.`t2`, `xx`"},
+		[][]*filter.Table{{genTableName("s1", "t1"), genTableName("s2", "t2"), genTableName("test", "xx")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1"), genTableName("xs2", "xt2"), genTableName("xtest", "xxx")}},
+		[]string{"DROP TABLE `xs1`.`xt1`, `xs2`.`xt2`, `xtest`.`xxx`"},
+	},
+	// CREATE TABLE
+	{
+		"create table `s1`.`t1` (id int)",
+		[]string{"CREATE TABLE `s1`.`t1` (`id` INT)"},
+		[][]*filter.Table{{genTableName("s1", "t1")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1")}},
+		[]string{"CREATE TABLE `xs1`.`xt1` (`id` INT)"},
+	},
+	{
+		"create table `t1` (id int)",
+		[]string{"CREATE TABLE `t1` (`id` INT)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"CREATE TABLE `xtest`.`xt1` (`id` INT)"},
+	},
+	{
+		"create table `s1` (c int default '0')",
+		[]string{"CREATE TABLE `s1` (`c` INT DEFAULT '0')"},
+		[][]*filter.Table{{genTableName("test", "s1")}},
+		[][]*filter.Table{{genTableName("xtest", "xs1")}},
+		[]string{"CREATE TABLE `xtest`.`xs1` (`c` INT DEFAULT '0')"},
+	},
+	// CREATE TABLE LIKE
+	{
+		"create table `t1` like `t2`",
+		[]string{"CREATE TABLE `t1` LIKE `t2`"},
+		[][]*filter.Table{{genTableName("test", "t1"), genTableName("test", "t2")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1"), genTableName("xtest", "xt2")}},
+		[]string{"CREATE TABLE `xtest`.`xt1` LIKE `xtest`.`xt2`"},
+	},
+	{
+		"create table `s1`.`t1` like `t2`",
+		[]string{"CREATE TABLE `s1`.`t1` LIKE `t2`"},
+		[][]*filter.Table{{genTableName("s1", "t1"), genTableName("test", "t2")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1"), genTableName("xtest", "xt2")}},
+		[]string{"CREATE TABLE `xs1`.`xt1` LIKE `xtest`.`xt2`"},
+	},
+	{
+		"create table `t1` like `xx`.`t2`",
+		[]string{"CREATE TABLE `t1` LIKE `xx`.`t2`"},
+		[][]*filter.Table{{genTableName("test", "t1"), genTableName("xx", "t2")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1"), genTableName("xxx", "xt2")}},
+		[]string{"CREATE TABLE `xtest`.`xt1` LIKE `xxx`.`xt2`"},
+	},
+	// TRUNCATE TABLE
+	{
+		"truncate table `t1`",
+		[]string{"TRUNCATE TABLE `t1`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"TRUNCATE TABLE `xtest`.`xt1`"},
+	},
+	{
+		"truncate table `s1`.`t1`",
+		[]string{"TRUNCATE TABLE `s1`.`t1`"},
+		[][]*filter.Table{{genTableName("s1", "t1")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1")}},
+		[]string{"TRUNCATE TABLE `xs1`.`xt1`"},
+	},
+	// RENAME TABLE - single
+	{
+		"rename table `s1`.`t1` to `s2`.`t2`",
+		[]string{"RENAME TABLE `s1`.`t1` TO `s2`.`t2`"},
+		[][]*filter.Table{{genTableName("s1", "t1"), genTableName("s2", "t2")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1"), genTableName("xs2", "xt2")}},
+		[]string{"RENAME TABLE `xs1`.`xt1` TO `xs2`.`xt2`"},
+	},
+	// RENAME TABLE - multiple (no splitting)
+	{
+		"rename table `t1` to `t2`, `s1`.`t1` to `t2`",
+		[]string{"RENAME TABLE `t1` TO `t2`, `s1`.`t1` TO `t2`"},
+		[][]*filter.Table{{genTableName("test", "t1"), genTableName("test", "t2"), genTableName("s1", "t1"), genTableName("test", "t2")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1"), genTableName("xtest", "xt2"), genTableName("xs1", "xt1"), genTableName("xtest", "xt2")}},
+		[]string{"RENAME TABLE `xtest`.`xt1` TO `xtest`.`xt2`, `xs1`.`xt1` TO `xtest`.`xt2`"},
+	},
+	// DROP INDEX
+	{
+		"drop index i1 on `s1`.`t1`",
+		[]string{"DROP INDEX `i1` ON `s1`.`t1`"},
+		[][]*filter.Table{{genTableName("s1", "t1")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1")}},
+		[]string{"DROP INDEX `i1` ON `xs1`.`xt1`"},
+	},
+	{
+		"drop index i1 on `t1`",
+		[]string{"DROP INDEX `i1` ON `t1`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"DROP INDEX `i1` ON `xtest`.`xt1`"},
+	},
+	// CREATE INDEX
+	{
+		"create index i1 on `t1`(`c1`)",
+		[]string{"CREATE INDEX `i1` ON `t1` (`c1`)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"CREATE INDEX `i1` ON `xtest`.`xt1` (`c1`)"},
+	},
+	{
+		"create index i1 on `s1`.`t1`(`c1`)",
+		[]string{"CREATE INDEX `i1` ON `s1`.`t1` (`c1`)"},
+		[][]*filter.Table{{genTableName("s1", "t1")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1")}},
+		[]string{"CREATE INDEX `i1` ON `xs1`.`xt1` (`c1`)"},
+	},
+	// ALTER TABLE - multiple specs (no splitting, test as single statement)
+	{
+		"alter table `t1` add column c1 int, drop column c2",
+		[]string{"ALTER TABLE `t1` ADD COLUMN `c1` INT, DROP COLUMN `c2`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` ADD COLUMN `c1` INT, DROP COLUMN `c2`"},
+	},
+	{
+		"alter table `s1`.`t1` add column c1 int, rename to `t2`, drop column c2",
+		[]string{"ALTER TABLE `s1`.`t1` ADD COLUMN `c1` INT, RENAME AS `t2`, DROP COLUMN `c2`"},
+		[][]*filter.Table{{genTableName("s1", "t1"), genTableName("test", "t2")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1"), genTableName("xtest", "xt2")}},
+		[]string{"ALTER TABLE `xs1`.`xt1` ADD COLUMN `c1` INT, RENAME AS `xtest`.`xt2`, DROP COLUMN `c2`"},
+	},
+	{
+		"alter table `s1`.`t1` add column c1 int, rename to `xx`.`t2`, drop column c2",
+		[]string{"ALTER TABLE `s1`.`t1` ADD COLUMN `c1` INT, RENAME AS `xx`.`t2`, DROP COLUMN `c2`"},
+		[][]*filter.Table{{genTableName("s1", "t1"), genTableName("xx", "t2")}},
+		[][]*filter.Table{{genTableName("xs1", "xt1"), genTableName("xxx", "xt2")}},
+		[]string{"ALTER TABLE `xs1`.`xt1` ADD COLUMN `c1` INT, RENAME AS `xxx`.`xt2`, DROP COLUMN `c2`"},
+	},
+	// ALTER TABLE with IF NOT EXISTS / IF EXISTS
+	// Note: TiDB parser converts these to TiDB-specific comment syntax (/*T! ... */)
+	{
+		"alter table `t1` add column if not exists c1 int",
+		[]string{"ALTER TABLE `t1` ADD COLUMN IF NOT EXISTS `c1` INT"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` ADD COLUMN /*T! IF NOT EXISTS  */`c1` INT"},
+	},
+	{
+		"alter table `t1` add index if not exists (a) using btree comment 'a'",
+		[]string{"ALTER TABLE `t1` ADD INDEX IF NOT EXISTS(`a`) USING BTREE COMMENT 'a'"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` ADD INDEX/*T!  IF NOT EXISTS */(`a`) USING BTREE COMMENT 'a'"},
+	},
+	{
+		"alter table `t1` add constraint fk_t2_id foreign key if not exists (t2_id) references t2(id)",
+		[]string{"ALTER TABLE `t1` ADD CONSTRAINT `fk_t2_id` FOREIGN KEY IF NOT EXISTS (`t2_id`) REFERENCES `t2`(`id`)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` ADD CONSTRAINT `fk_t2_id` FOREIGN KEY /*T! IF NOT EXISTS  */(`t2_id`) REFERENCES `t2`(`id`)"},
+	},
+	{
+		"create index if not exists i1 on `t1`(`c1`)",
+		[]string{"CREATE INDEX IF NOT EXISTS `i1` ON `t1` (`c1`)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"CREATE INDEX /*T! IF NOT EXISTS  */`i1` ON `xtest`.`xt1` (`c1`)"},
+	},
+	{
+		"alter table `t1` add partition if not exists ( partition p2 values less than maxvalue)",
+		[]string{"ALTER TABLE `t1` ADD PARTITION IF NOT EXISTS (PARTITION `p2` VALUES LESS THAN (MAXVALUE))"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` ADD PARTITION/*T!  IF NOT EXISTS */ (PARTITION `p2` VALUES LESS THAN (MAXVALUE))"},
+	},
+	{
+		"alter table `t1` drop column if exists c2",
+		[]string{"ALTER TABLE `t1` DROP COLUMN IF EXISTS `c2`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` DROP COLUMN /*T! IF EXISTS  */`c2`"},
+	},
+	{
+		"alter table `t1` change column if exists a b varchar(255)",
+		[]string{"ALTER TABLE `t1` CHANGE COLUMN IF EXISTS `a` `b` VARCHAR(255)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` CHANGE COLUMN /*T! IF EXISTS  */`a` `b` VARCHAR(255)"},
+	},
+	{
+		"alter table `t1` modify column if exists a varchar(255)",
+		[]string{"ALTER TABLE `t1` MODIFY COLUMN IF EXISTS `a` VARCHAR(255)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` MODIFY COLUMN /*T! IF EXISTS  */`a` VARCHAR(255)"},
+	},
+	{
+		"alter table `t1` drop index if exists i1",
+		[]string{"ALTER TABLE `t1` DROP INDEX IF EXISTS `i1`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` DROP INDEX /*T! IF EXISTS  */`i1`"},
+	},
+	{
+		"alter table `t1` drop foreign key fk_t2_id",
+		[]string{"ALTER TABLE `t1` DROP FOREIGN KEY `fk_t2_id`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` DROP FOREIGN KEY `fk_t2_id`"},
+	},
+	{
+		"alter table `t1` drop partition if exists p2",
+		[]string{"ALTER TABLE `t1` DROP PARTITION IF EXISTS `p2`"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` DROP PARTITION /*T! IF EXISTS  */`p2`"},
+	},
+	// ALTER TABLE PARTITION BY
+	{
+		"alter table `t1` partition by hash(a)",
+		[]string{"ALTER TABLE `t1` PARTITION BY HASH (`a`) PARTITIONS 1"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` PARTITION BY HASH (`a`) PARTITIONS 1"},
+	},
+	{
+		"alter table `t1` partition by key(a)",
+		[]string{"ALTER TABLE `t1` PARTITION BY KEY (`a`) PARTITIONS 1"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` PARTITION BY KEY (`a`) PARTITIONS 1"},
+	},
+	{
+		"alter table `t1` partition by range(a) (partition x values less than (75))",
+		[]string{"ALTER TABLE `t1` PARTITION BY RANGE (`a`) (PARTITION `x` VALUES LESS THAN (75))"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` PARTITION BY RANGE (`a`) (PARTITION `x` VALUES LESS THAN (75))"},
+	},
+	{
+		"alter table `t1` partition by list columns (a, b) (partition x values in ((10, 20)))",
+		[]string{"ALTER TABLE `t1` PARTITION BY LIST COLUMNS (`a`,`b`) (PARTITION `x` VALUES IN ((10, 20)))"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` PARTITION BY LIST COLUMNS (`a`,`b`) (PARTITION `x` VALUES IN ((10, 20)))"},
+	},
+	{
+		"alter table `t1` partition by list (a) (partition x default)",
+		[]string{"ALTER TABLE `t1` PARTITION BY LIST (`a`) (PARTITION `x` DEFAULT)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` PARTITION BY LIST (`a`) (PARTITION `x` DEFAULT)"},
+	},
+	{
+		"alter table `t1` partition by system_time (partition x history, partition y current)",
+		[]string{"ALTER TABLE `t1` PARTITION BY SYSTEM_TIME (PARTITION `x` HISTORY,PARTITION `y` CURRENT)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "xt1")}},
+		[]string{"ALTER TABLE `xtest`.`xt1` PARTITION BY SYSTEM_TIME (PARTITION `x` HISTORY,PARTITION `y` CURRENT)"},
+	},
+	// ALTER DATABASE with explicit name
+	{
+		"alter database `test` charset utf8mb4",
+		[]string{"ALTER DATABASE `test` CHARACTER SET = utf8mb4"},
+		[][]*filter.Table{{genTableName("test", "")}},
+		[][]*filter.Table{{genTableName("xtest", "")}},
+		[]string{"ALTER DATABASE `xtest` CHARACTER SET = utf8mb4"},
+	},
+	// ALTER TABLE ADD COLUMN with multiple columns (no splitting)
+	{
+		"alter table `t1` add column (c1 int, c2 int)",
+		[]string{"ALTER TABLE `t1` ADD COLUMN (`c1` INT, `c2` INT)"},
+		[][]*filter.Table{{genTableName("test", "t1")}},
+		[][]*filter.Table{{genTableName("xtest", "t1")}},
+		[]string{"ALTER TABLE `xtest`.`t1` ADD COLUMN (`c1` INT, `c2` INT)"},
+	},
+}
+
+var nonDDLs = []string{
+	"GRANT CREATE TABLESPACE ON *.* TO `root`@`%` WITH GRANT OPTION",
+}
+
+func TestParser(t *testing.T) {
+	t.Parallel()
+	p := parser.New()
+
+	for _, ca := range testCases {
+		sql := ca.sql
+		stmts, _, err := p.Parse(sql, "", "")
+		require.NoError(t, err)
+		require.Len(t, stmts, 1)
+	}
+
+	for _, sql := range nonDDLs {
+		stmts, _, err := p.Parse(sql, "", "")
+		require.NoError(t, err)
+		require.Len(t, stmts, 1)
+	}
+
+	unsupportedSQLs := []string{
+		"alter table bar ADD SPATIAL INDEX (`g`)",
+	}
+
+	for _, sql := range unsupportedSQLs {
+		_, _, err := p.Parse(sql, "", "")
+		require.NotNil(t, err)
+	}
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+	p := parser.New()
+
+	// DML will report ErrUnknownTypeDDL
+	dml := "INSERT INTO `t1` VALUES (1)"
+
+	stmts, _, err := p.Parse(dml, "", "")
+	require.NoError(t, err)
+	_, err = FetchDDLTables("test", stmts[0])
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown DDL type")
+
+	_, err = RenameDDLTable(stmts[0], nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown DDL type")
+
+	// tableRenameVisitor with less `targetNames` won't panic
+	ddl := "create table `s1`.`t1` (id int)"
+	stmts, _, err = p.Parse(ddl, "", "")
+	require.NoError(t, err)
+	_, err = RenameDDLTable(stmts[0], nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not enough target tables")
+}
+
+// TestResolveDDL tests FetchDDLTables and RenameDDLTable
+func TestResolveDDL(t *testing.T) {
+	t.Parallel()
+	p := parser.New()
+
+	for _, ca := range testCases {
+		stmts, _, err := p.Parse(ca.sql, "", "")
+		require.NoError(t, err)
+		require.Len(t, stmts, 1)
+
+		// Test FetchDDLTables
+		tableNames, err := FetchDDLTables("test", stmts[0])
+		require.NoError(t, err)
+		require.Equal(t, ca.expectedTableNames[0], tableNames, "FetchDDLTables failed for: %s", ca.sql)
+
+		// Re-parse for RenameDDLTable since it modifies AST in place
+		stmts, _, err = p.Parse(ca.sql, "", "")
+		require.NoError(t, err)
+
+		// Test RenameDDLTable
+		targetSQL, err := RenameDDLTable(stmts[0], ca.targetTableNames[0])
+		require.NoError(t, err)
+		require.Equal(t, ca.targetSQLs[0], targetSQL, "RenameDDLTable failed for: %s", ca.sql)
+	}
+}

--- a/pkg/sink/util/router.go
+++ b/pkg/sink/util/router.go
@@ -1,0 +1,170 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/pkg/config"
+	tfilter "github.com/pingcap/tidb/pkg/util/table-filter"
+	"go.uber.org/zap"
+)
+
+// Routing expression placeholders that can be used in SchemaRule and TableRule.
+const (
+	// SchemaPlaceholder is replaced with the source schema name in routing expressions.
+	SchemaPlaceholder = "{schema}"
+	// TablePlaceholder is replaced with the source table name in routing expressions.
+	TablePlaceholder = "{table}"
+)
+
+// Router routes source schema/table names to target schema/table names.
+type Router struct {
+	rules []*routingRule
+}
+
+// routingRule represents a single routing rule.
+type routingRule struct {
+	filter     tfilter.Filter
+	schemaExpr string
+	tableExpr  string
+}
+
+// RoutingRuleConfig represents configuration for a single routing rule.
+type RoutingRuleConfig struct {
+	// Matcher is a filter pattern like "db1.*" or "db1.table1"
+	Matcher []string `toml:"matcher" json:"matcher"`
+	// SchemaRule is an expression for the target schema, e.g., "{schema}" or "target_db"
+	SchemaRule string `toml:"schema" json:"schema"`
+	// TableRule is an expression for the target table, e.g., "{table}" or "target_table"
+	TableRule string `toml:"table" json:"table"`
+}
+
+// NewRouter creates a new Router from a list of routing rule configurations.
+// Returns nil if no rules are provided.
+func NewRouter(caseSensitive bool, rules []RoutingRuleConfig) (*Router, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
+	routingRules := make([]*routingRule, 0, len(rules))
+
+	for _, ruleConfig := range rules {
+		if ruleConfig.SchemaRule == "" && ruleConfig.TableRule == "" {
+			continue
+		}
+
+		if err := config.ValidateRoutingExpression(ruleConfig.SchemaRule); err != nil {
+			return nil, fmt.Errorf("invalid schema rule %q: %w", ruleConfig.SchemaRule, err)
+		}
+		if err := config.ValidateRoutingExpression(ruleConfig.TableRule); err != nil {
+			return nil, fmt.Errorf("invalid table rule %q: %w", ruleConfig.TableRule, err)
+		}
+
+		f, err := tfilter.Parse(ruleConfig.Matcher)
+		if err != nil {
+			return nil, fmt.Errorf("invalid matcher %v: %w", ruleConfig.Matcher, err)
+		}
+		if !caseSensitive {
+			f = tfilter.CaseInsensitive(f)
+		}
+
+		routingRules = append(routingRules, &routingRule{
+			filter:     f,
+			schemaExpr: ruleConfig.SchemaRule,
+			tableExpr:  ruleConfig.TableRule,
+		})
+	}
+
+	if len(routingRules) == 0 {
+		return nil, nil
+	}
+
+	return &Router{rules: routingRules}, nil
+}
+
+// Route returns the target schema and table names for the given source schema/table.
+// If no rule matches, returns the source schema and table unchanged.
+func (r *Router) Route(sourceSchema, sourceTable string) (targetSchema, targetTable string) {
+	if r == nil || len(r.rules) == 0 {
+		return sourceSchema, sourceTable
+	}
+
+	rule := r.matchRule(sourceSchema, sourceTable)
+	if rule == nil {
+		return sourceSchema, sourceTable
+	}
+
+	targetSchema = substituteExpression(rule.schemaExpr, sourceSchema, sourceTable, sourceSchema)
+	targetTable = substituteExpression(rule.tableExpr, sourceSchema, sourceTable, sourceTable)
+
+	log.Debug("sink routing applied",
+		zap.String("sourceSchema", sourceSchema),
+		zap.String("sourceTable", sourceTable),
+		zap.String("targetSchema", targetSchema),
+		zap.String("targetTable", targetTable),
+	)
+
+	return targetSchema, targetTable
+}
+
+// matchRule finds the first rule that matches the given schema/table.
+func (r *Router) matchRule(schema, table string) *routingRule {
+	for _, rule := range r.rules {
+		if rule.filter.MatchTable(schema, table) {
+			return rule
+		}
+	}
+	return nil
+}
+
+// substituteExpression replaces {schema} and {table} placeholders with actual values.
+// If expr is empty, returns defaultValue (typically sourceSchema for schema expressions,
+// sourceTable for table expressions).
+func substituteExpression(expr, sourceSchema, sourceTable, defaultValue string) string {
+	if expr == "" {
+		return defaultValue
+	}
+
+	result := expr
+	result = strings.ReplaceAll(result, SchemaPlaceholder, sourceSchema)
+	result = strings.ReplaceAll(result, TablePlaceholder, sourceTable)
+	return result
+}
+
+// NewRouterFromDispatchRules creates a new Router from dispatch rule configurations.
+// This is a convenience function that extracts routing rules from DispatchRule configs.
+func NewRouterFromDispatchRules(caseSensitive bool, rules []*config.DispatchRule) (*Router, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
+	routingConfigs := make([]RoutingRuleConfig, 0, len(rules))
+	for _, rule := range rules {
+		// Skip rules without routing configuration
+		if rule.SchemaRule == "" && rule.TableRule == "" {
+			continue
+		}
+
+		routingConfigs = append(routingConfigs, RoutingRuleConfig{
+			Matcher:    rule.Matcher,
+			SchemaRule: rule.SchemaRule,
+			TableRule:  rule.TableRule,
+		})
+	}
+
+	return NewRouter(caseSensitive, routingConfigs)
+}

--- a/pkg/sink/util/router_test.go
+++ b/pkg/sink/util/router_test.go
@@ -1,0 +1,858 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRoutingExpression(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expr    string
+		wantErr bool
+	}{
+		// Valid expressions
+		{"", false},
+		{SchemaPlaceholder, false},
+		{TablePlaceholder, false},
+		{"prefix_" + SchemaPlaceholder, false},
+		{SchemaPlaceholder + "_suffix", false},
+		{"prefix_" + SchemaPlaceholder + "_suffix", false},
+		{SchemaPlaceholder + "_" + TablePlaceholder, false},
+		{"static_name", false},
+		{"db_" + SchemaPlaceholder + "_" + TablePlaceholder + "_v2", false},
+
+		// Invalid expressions
+		{"{invalid}", true},
+		{"{Schema}", true}, // case sensitive
+		{"{TABLE}", true},  // case sensitive
+		{"{db}", true},
+		{"{", true},
+		{"}", true},
+		{"{schema", true},
+		{"schema}", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			err := config.ValidateRoutingExpression(tt.expr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSubstituteExpression(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expr         string
+		sourceSchema string
+		sourceTable  string
+		defaultValue string
+		expected     string
+	}{
+		{SchemaPlaceholder, "mydb", "mytable", "mydb", "mydb"},
+		{TablePlaceholder, "mydb", "mytable", "mytable", "mytable"},
+		{SchemaPlaceholder + "_" + TablePlaceholder, "mydb", "mytable", "mydb", "mydb_mytable"},
+		{"prefix_" + SchemaPlaceholder, "mydb", "mytable", "mydb", "prefix_mydb"},
+		{TablePlaceholder + "_suffix", "mydb", "mytable", "mytable", "mytable_suffix"},
+		{"static_name", "mydb", "mytable", "mydb", "static_name"},
+		{"", "mydb", "mytable", "mydb", "mydb"},       // empty schema expr defaults to sourceSchema
+		{"", "mydb", "mytable", "mytable", "mytable"}, // empty table expr defaults to sourceTable
+		{"db_" + SchemaPlaceholder + "_" + TablePlaceholder + "_v2", "prod", "users", "prod", "db_prod_users_v2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr+"_default_"+tt.defaultValue, func(t *testing.T) {
+			result := substituteExpression(tt.expr, tt.sourceSchema, tt.sourceTable, tt.defaultValue)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewRouter(t *testing.T) {
+	t.Parallel()
+
+	// Empty rules returns nil router
+	router, err := NewRouter(true, nil)
+	require.NoError(t, err)
+	require.Nil(t, router)
+
+	router, err = NewRouter(true, []RoutingRuleConfig{})
+	require.NoError(t, err)
+	require.Nil(t, router)
+
+	// Rules with empty schema and table rules are skipped
+	router, err = NewRouter(true, []RoutingRuleConfig{
+		{Matcher: []string{"db1.*"}, SchemaRule: "", TableRule: ""},
+	})
+	require.NoError(t, err)
+	require.Nil(t, router)
+
+	// Valid rules
+	router, err = NewRouter(true, []RoutingRuleConfig{
+		{Matcher: []string{"db1.*"}, SchemaRule: "target_db", TableRule: TablePlaceholder},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Invalid schema rule
+	_, err = NewRouter(true, []RoutingRuleConfig{
+		{Matcher: []string{"db1.*"}, SchemaRule: "{invalid}", TableRule: TablePlaceholder},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid schema rule")
+
+	// Invalid table rule
+	_, err = NewRouter(true, []RoutingRuleConfig{
+		{Matcher: []string{"db1.*"}, SchemaRule: SchemaPlaceholder, TableRule: "{bad}"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid table rule")
+}
+
+func TestRouterRoute(t *testing.T) {
+	t.Parallel()
+
+	// Nil router returns source unchanged
+	var nilRouter *Router
+	schema, table := nilRouter.Route("mydb", "mytable")
+	require.Equal(t, "mydb", schema)
+	require.Equal(t, "mytable", table)
+
+	// Router with rules
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		// Route all tables in db1 to target_db
+		{Matcher: []string{"db1.*"}, SchemaRule: "target_db", TableRule: TablePlaceholder},
+		// Route specific table to a different name
+		{Matcher: []string{"db2.users"}, SchemaRule: SchemaPlaceholder, TableRule: "customers"},
+		// Route with combined expression
+		{Matcher: []string{"staging.*"}, SchemaRule: "prod", TableRule: SchemaPlaceholder + "_" + TablePlaceholder},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		sourceSchema   string
+		sourceTable    string
+		expectedSchema string
+		expectedTable  string
+	}{
+		// Matches first rule
+		{"db1", "orders", "target_db", "orders"},
+		{"db1", "products", "target_db", "products"},
+		// Matches second rule
+		{"db2", "users", "db2", "customers"},
+		// Matches third rule
+		{"staging", "events", "prod", "staging_events"},
+		// No match - returns source unchanged
+		{"db2", "orders", "db2", "orders"},
+		{"other", "table", "other", "table"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sourceSchema+"."+tt.sourceTable, func(t *testing.T) {
+			schema, table := router.Route(tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.expectedSchema, schema)
+			require.Equal(t, tt.expectedTable, table)
+		})
+	}
+}
+
+func TestRouterCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	// Case-insensitive router
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{Matcher: []string{"db1.*"}, SchemaRule: "target", TableRule: TablePlaceholder},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should match regardless of case
+	schema, table := router.Route("DB1", "MyTable")
+	require.Equal(t, "target", schema)
+	require.Equal(t, "MyTable", table) // {table} substitutes to the original table name
+}
+
+func TestRouterFirstMatchWins(t *testing.T) {
+	t.Parallel()
+
+	t.Run("specific_before_wildcard", func(t *testing.T) {
+		t.Parallel()
+
+		// First matching rule wins
+		router, err := NewRouter(true, []RoutingRuleConfig{
+			{Matcher: []string{"db1.specific"}, SchemaRule: "first", TableRule: TablePlaceholder},
+			{Matcher: []string{"db1.*"}, SchemaRule: "second", TableRule: TablePlaceholder},
+		})
+		require.NoError(t, err)
+
+		// Specific match uses first rule
+		schema, _ := router.Route("db1", "specific")
+		require.Equal(t, "first", schema)
+
+		// General match uses second rule
+		schema, _ = router.Route("db1", "other")
+		require.Equal(t, "second", schema)
+	})
+
+	// Test overlapping rules where multiple rules could match the same table.
+	// The first matching rule in configuration order wins.
+	t.Run("overlapping_rules", func(t *testing.T) {
+		t.Parallel()
+
+		router, err := NewRouter(true, []RoutingRuleConfig{
+			// Rule 1: Specific table match
+			{Matcher: []string{"db1.users"}, SchemaRule: "target_specific", TableRule: "users_v1"},
+			// Rule 2: All tables in db1 (overlaps with Rule 1 for db1.users)
+			{Matcher: []string{"db1.*"}, SchemaRule: "target_db1", TableRule: TablePlaceholder},
+			// Rule 3: Wildcard match (overlaps with Rules 1 and 2)
+			{Matcher: []string{"*.*"}, SchemaRule: "target_all", TableRule: TablePlaceholder},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, router)
+
+		tests := []struct {
+			name         string
+			sourceSchema string
+			sourceTable  string
+			wantSchema   string
+			wantTable    string
+		}{
+			// db1.users matches Rule 1 (most specific), not Rule 2 or 3
+			{"specific_table", "db1", "users", "target_specific", "users_v1"},
+			// db1.orders matches Rule 2 (db1.*), not Rule 3
+			{"schema_wildcard", "db1", "orders", "target_db1", "orders"},
+			// db2.products only matches Rule 3 (*.*)"
+			{"global_wildcard", "db2", "products", "target_all", "products"},
+		}
+
+		for _, tt := range tests {
+			gotSchema, gotTable := router.Route(tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.wantSchema, gotSchema, "schema mismatch for %s", tt.name)
+			require.Equal(t, tt.wantTable, gotTable, "table mismatch for %s", tt.name)
+		}
+	})
+
+	// Verify that rule order in configuration determines which rule wins,
+	// not specificity. If a wildcard rule comes first, it wins.
+	t.Run("order_matters_not_specificity", func(t *testing.T) {
+		t.Parallel()
+
+		// Intentionally put the wildcard rule FIRST - it should win for all matches
+		router, err := NewRouter(true, []RoutingRuleConfig{
+			// Rule 1: Wildcard - catches everything
+			{Matcher: []string{"*.*"}, SchemaRule: "catch_all", TableRule: TablePlaceholder},
+			// Rule 2: More specific, but comes after wildcard
+			{Matcher: []string{"db1.*"}, SchemaRule: "should_not_match", TableRule: TablePlaceholder},
+			// Rule 3: Even more specific, but comes after wildcard
+			{Matcher: []string{"db1.users"}, SchemaRule: "also_should_not_match", TableRule: "renamed"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, router)
+
+		// All should match the first rule (wildcard) because it comes first
+		tests := []struct {
+			sourceSchema string
+			sourceTable  string
+		}{
+			{"db1", "users"},    // Would match all 3 rules, but first wins
+			{"db1", "orders"},   // Would match rules 1 and 2, but first wins
+			{"db2", "products"}, // Only matches rule 1
+		}
+
+		for _, tt := range tests {
+			gotSchema, gotTable := router.Route(tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, "catch_all", gotSchema,
+				"first matching rule should win for %s.%s", tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.sourceTable, gotTable,
+				"first matching rule should win for %s.%s", tt.sourceSchema, tt.sourceTable)
+		}
+	})
+}
+
+func TestRouterSchemaOnly(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		name         string
+		sourceSchema string
+		sourceTable  string
+		wantSchema   string
+		wantTable    string
+	}{
+		{
+			name:         "matching table",
+			sourceSchema: "source_db",
+			sourceTable:  "users",
+			wantSchema:   "target_db",
+			wantTable:    "users",
+		},
+		{
+			name:         "another matching table",
+			sourceSchema: "source_db",
+			sourceTable:  "orders",
+			wantSchema:   "target_db",
+			wantTable:    "orders",
+		},
+		{
+			name:         "non-matching schema",
+			sourceSchema: "other_db",
+			sourceTable:  "users",
+			wantSchema:   "other_db",
+			wantTable:    "users",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotSchema, gotTable := router.Route(tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.wantSchema, gotSchema)
+			require.Equal(t, tt.wantTable, gotTable)
+		})
+	}
+}
+
+func TestRouterTableOnly(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"mydb.source_table"},
+			SchemaRule: SchemaPlaceholder,
+			TableRule:  "target_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		name         string
+		sourceSchema string
+		sourceTable  string
+		wantSchema   string
+		wantTable    string
+	}{
+		{
+			name:         "matching table",
+			sourceSchema: "mydb",
+			sourceTable:  "source_table",
+			wantSchema:   "mydb",
+			wantTable:    "target_table",
+		},
+		{
+			name:         "non-matching table",
+			sourceSchema: "mydb",
+			sourceTable:  "other_table",
+			wantSchema:   "mydb",
+			wantTable:    "other_table",
+		},
+		{
+			name:         "non-matching schema",
+			sourceSchema: "otherdb",
+			sourceTable:  "source_table",
+			wantSchema:   "otherdb",
+			wantTable:    "source_table",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotSchema, gotTable := router.Route(tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.wantSchema, gotSchema)
+			require.Equal(t, tt.wantTable, gotTable)
+		})
+	}
+}
+
+func TestRouterSchemaAndTable(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"src_db.src_table"},
+			SchemaRule: "dst_db",
+			TableRule:  "dst_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Matching
+	schema, table := router.Route("src_db", "src_table")
+	require.Equal(t, "dst_db", schema)
+	require.Equal(t, "dst_table", table)
+
+	// Non-matching
+	schema, table = router.Route("src_db", "other_table")
+	require.Equal(t, "src_db", schema)
+	require.Equal(t, "other_table", table)
+}
+
+func TestRouterWithTransformation(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"prod.*"},
+			SchemaRule: "backup_" + SchemaPlaceholder,
+			TableRule:  TablePlaceholder + "_archive",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	schema, table := router.Route("prod", "users")
+	require.Equal(t, "backup_prod", schema)
+	require.Equal(t, "users_archive", table)
+}
+
+func TestRouterMultipleRules(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"db1.*"},
+			SchemaRule: "target1",
+			TableRule:  TablePlaceholder,
+		},
+		{
+			Matcher:    []string{"db2.*"},
+			SchemaRule: "target2",
+			TableRule:  TablePlaceholder,
+		},
+		{
+			Matcher:    []string{"db3.specific_table"},
+			SchemaRule: "target3",
+			TableRule:  "renamed_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	tests := []struct {
+		sourceSchema string
+		sourceTable  string
+		wantSchema   string
+		wantTable    string
+	}{
+		{"db1", "table1", "target1", "table1"},
+		{"db1", "table2", "target1", "table2"},
+		{"db2", "table1", "target2", "table1"},
+		{"db3", "specific_table", "target3", "renamed_table"},
+		{"db3", "other_table", "db3", "other_table"}, // No match
+		{"db4", "table1", "db4", "table1"},           // No match
+	}
+
+	for _, tt := range tests {
+		gotSchema, gotTable := router.Route(tt.sourceSchema, tt.sourceTable)
+		require.Equal(t, tt.wantSchema, gotSchema, "schema mismatch for %s.%s", tt.sourceSchema, tt.sourceTable)
+		require.Equal(t, tt.wantTable, gotTable, "table mismatch for %s.%s", tt.sourceSchema, tt.sourceTable)
+	}
+}
+
+func TestRouterCaseSensitiveSchema(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"MyDB.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should only match exact case
+	schema, table := router.Route("MyDB", "table1")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "table1", table)
+
+	// Should not match different case
+	schema, table = router.Route("mydb", "table2")
+	require.Equal(t, "mydb", schema)
+	require.Equal(t, "table2", table)
+
+	schema, table = router.Route("MYDB", "table3")
+	require.Equal(t, "MYDB", schema)
+	require.Equal(t, "table3", table)
+}
+
+func TestRouterCaseSensitiveTable(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"mydb.MyTable"},
+			SchemaRule: "target_db",
+			TableRule:  "target_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should only match exact table case
+	schema, table := router.Route("mydb", "MyTable")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "target_table", table)
+
+	// Should not match different table case
+	schema, table = router.Route("mydb", "mytable")
+	require.Equal(t, "mydb", schema)
+	require.Equal(t, "mytable", table)
+
+	schema, table = router.Route("mydb", "MYTABLE")
+	require.Equal(t, "mydb", schema)
+	require.Equal(t, "MYTABLE", table)
+}
+
+func TestRouterCaseSensitiveBoth(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"MyDB.MyTable"},
+			SchemaRule: "target_db",
+			TableRule:  "target_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should only match exact case for both schema and table
+	tests := []struct {
+		sourceSchema string
+		sourceTable  string
+		shouldMatch  bool
+	}{
+		{"MyDB", "MyTable", true},  // Exact match
+		{"mydb", "mytable", false}, // Both wrong case
+		{"MYDB", "MYTABLE", false}, // Both wrong case
+		{"MyDB", "mytable", false}, // Table wrong case
+		{"mydb", "MyTable", false}, // Schema wrong case
+	}
+
+	for _, tt := range tests {
+		schema, table := router.Route(tt.sourceSchema, tt.sourceTable)
+		if tt.shouldMatch {
+			require.Equal(t, "target_db", schema, "schema mismatch for %s.%s", tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, "target_table", table, "table mismatch for %s.%s", tt.sourceSchema, tt.sourceTable)
+		} else {
+			require.Equal(t, tt.sourceSchema, schema, "should pass through for %s.%s", tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.sourceTable, table, "should pass through for %s.%s", tt.sourceSchema, tt.sourceTable)
+		}
+	}
+}
+
+func TestRouterCaseInsensitiveSchema(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"MyDB.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should match regardless of schema case
+	schema, table := router.Route("mydb", "table1")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "table1", table)
+
+	schema, table = router.Route("MYDB", "table2")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "table2", table)
+
+	schema, table = router.Route("MyDb", "table3")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "table3", table)
+}
+
+func TestRouterCaseInsensitiveTable(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"mydb.MyTable"},
+			SchemaRule: "target_db",
+			TableRule:  "target_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should match regardless of table case
+	schema, table := router.Route("mydb", "mytable")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "target_table", table)
+
+	schema, table = router.Route("mydb", "MYTABLE")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "target_table", table)
+
+	schema, table = router.Route("mydb", "MyTable")
+	require.Equal(t, "target_db", schema)
+	require.Equal(t, "target_table", table)
+
+	// Non-matching table should pass through
+	schema, table = router.Route("mydb", "other_table")
+	require.Equal(t, "mydb", schema)
+	require.Equal(t, "other_table", table)
+}
+
+func TestRouterCaseInsensitiveBoth(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"MyDB.MyTable"},
+			SchemaRule: "target_db",
+			TableRule:  "target_table",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// Should match regardless of case for both schema and table
+	tests := []struct {
+		sourceSchema string
+		sourceTable  string
+		shouldMatch  bool
+	}{
+		{"MyDB", "MyTable", true},
+		{"mydb", "mytable", true},
+		{"MYDB", "MYTABLE", true},
+		{"Mydb", "Mytable", true},
+		{"MyDB", "other", false},
+		{"other", "MyTable", false},
+	}
+
+	for _, tt := range tests {
+		schema, table := router.Route(tt.sourceSchema, tt.sourceTable)
+		if tt.shouldMatch {
+			require.Equal(t, "target_db", schema, "schema mismatch for %s.%s", tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, "target_table", table, "table mismatch for %s.%s", tt.sourceSchema, tt.sourceTable)
+		} else {
+			require.Equal(t, tt.sourceSchema, schema, "should pass through for %s.%s", tt.sourceSchema, tt.sourceTable)
+			require.Equal(t, tt.sourceTable, table, "should pass through for %s.%s", tt.sourceSchema, tt.sourceTable)
+		}
+	}
+}
+
+func TestRouterCaseInsensitiveWithSchemaPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(false, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"MyDB.*"},
+			SchemaRule: "backup_" + SchemaPlaceholder,
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// "mydb" matches "MyDB.*" case-insensitively, but output preserves actual source case
+	schema, table := router.Route("mydb", "t1")
+	require.Equal(t, "backup_mydb", schema) // NOT "backup_MyDB"
+	require.Equal(t, "t1", table)
+}
+
+func TestRouterWildcardMatchers(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"*.*"},
+			SchemaRule: "all_to_one",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	// All tables should be routed
+	schema, table := router.Route("any_db", "any_table")
+	require.Equal(t, "all_to_one", schema)
+	require.Equal(t, "any_table", table)
+
+	schema, table = router.Route("other_db", "other_table")
+	require.Equal(t, "all_to_one", schema)
+	require.Equal(t, "other_table", table)
+}
+
+func TestNewRouterInvalidSchemaExpression(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"db.*"},
+			SchemaRule: "{invalid}",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.Error(t, err)
+	require.Nil(t, router)
+	require.Contains(t, err.Error(), "invalid schema rule")
+}
+
+func TestNewRouterInvalidTableExpression(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"db.*"},
+			SchemaRule: SchemaPlaceholder,
+			TableRule:  "{bad}",
+		},
+	})
+	require.Error(t, err)
+	require.Nil(t, router)
+	require.Contains(t, err.Error(), "invalid table rule")
+}
+
+func TestNewRouterInvalidMatcher(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter(true, []RoutingRuleConfig{
+		{
+			Matcher:    []string{"[invalid"},
+			SchemaRule: "target",
+			TableRule:  TablePlaceholder,
+		},
+	})
+	require.Error(t, err)
+	require.Nil(t, router)
+}
+
+func TestNewRouterFromDispatchRulesNilConfig(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouterFromDispatchRules(true, nil)
+	require.NoError(t, err)
+	require.Nil(t, router)
+}
+
+func TestNewRouterFromDispatchRulesNoRoutingRules(t *testing.T) {
+	t.Parallel()
+
+	// Config with dispatch rules but no schema/table routing
+	rules := []*config.DispatchRule{
+		{
+			Matcher:        []string{"test.*"},
+			DispatcherRule: "ts",
+			// No SchemaRule or TableRule
+		},
+	}
+	router, err := NewRouterFromDispatchRules(true, rules)
+	require.NoError(t, err)
+	require.Nil(t, router, "router should be nil when no routing rules configured")
+}
+
+func TestNewRouterFromDispatchRulesWithSchemaRouting(t *testing.T) {
+	t.Parallel()
+
+	rules := []*config.DispatchRule{
+		{
+			Matcher:    []string{"source_db.*"},
+			SchemaRule: "target_db",
+			TableRule:  TablePlaceholder,
+		},
+	}
+	router, err := NewRouterFromDispatchRules(true, rules)
+	require.NoError(t, err)
+	require.NotNil(t, router)
+}
+
+func TestNewRouterFromDispatchRulesWithTableRouting(t *testing.T) {
+	t.Parallel()
+
+	rules := []*config.DispatchRule{
+		{
+			Matcher:    []string{"db.source_table"},
+			SchemaRule: SchemaPlaceholder,
+			TableRule:  "target_table",
+		},
+	}
+	router, err := NewRouterFromDispatchRules(true, rules)
+	require.NoError(t, err)
+	require.NotNil(t, router)
+}
+
+func TestNewRouterFromDispatchRulesMixedRulesWithAndWithoutRouting(t *testing.T) {
+	t.Parallel()
+
+	// Some dispatch rules have routing, some don't
+	rules := []*config.DispatchRule{
+		{
+			Matcher:        []string{"db1.*"},
+			DispatcherRule: "ts",
+			// No routing - just partition dispatch
+		},
+		{
+			Matcher:    []string{"db2.*"},
+			SchemaRule: "routed_db",
+			TableRule:  TablePlaceholder,
+		},
+		{
+			Matcher:        []string{"db3.*"},
+			DispatcherRule: "rowid",
+			// No routing
+		},
+	}
+	router, err := NewRouterFromDispatchRules(true, rules)
+	require.NoError(t, err)
+	require.NotNil(t, router, "router should exist because db2 has routing")
+
+	// db1 has no routing rule - should pass through
+	schema, table := router.Route("db1", "table1")
+	require.Equal(t, "db1", schema)
+	require.Equal(t, "table1", table)
+
+	// db2 has routing - should be routed
+	schema, table = router.Route("db2", "table1")
+	require.Equal(t, "routed_db", schema)
+	require.Equal(t, "table1", table)
+
+	// db3 has no routing rule - should pass through
+	schema, table = router.Route("db3", "table1")
+	require.Equal(t, "db3", schema)
+	require.Equal(t, "table1", table)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #3700

### What is changed and how it works?
Porting changes from https://github.com/pingcap/tiflow/pull/12435 to new ticdc architecture.

The `dispatchers` config is the same as in tiflow - 
```
[[sink.dispatchers]]
matcher = ["uds_000.*"]
schema = "tidb_failover_test"
table = "{table}"

[[sink.dispatchers]]
matcher = ["oyster_production.*"]
schema = "oyster_production"
table = "{table}"
```

We also add the `TargetSchema` and `TargetTable` fields to the `TableName` struct. Since there is now a shared `TableInfo` object that can be accessed by multiple changefeeds and a new concept of `Dispatcher` objects, we clone the `TableInfo` in each dispatcher with the routing information for that table in `handleHandshakeEvent` (which is executed when the dispatcher starts), and then store that cloned/routed TableInfo for the dispatcher. Subsequent DMLs then look up the stored info. Subsequent DDLs also explicitly update routing in `handleSingleDataEvents`.

Another difference between ticdc and tiflow is that DDLs are now handled per-sink instead of in one single entry point. Because of this, we need to apply routing in both the mysql and redo sinks separately - the shared rewriting functionality is in `pkg/sink/util/ddl_routing.go`.

We also copied `FetchDDLTables` and `RenameDDLTable` (and the corresponding tests) from https://github.com/pingcap/tiflow/blob/master/dm/pkg/parser/common.go so we could use them to rewrite DDLs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test (will add, in progress)
- Manual test - deployed to internal dev cluster and bootstrapped a migration shadow with schema mapping, verified changefeed routes DDLs/DMLs correctly

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Do you need to update user documentation, design documentation or monitoring documentation?
Yes - will do so in separate PR

### Release note <!-- bugfixes or new features need a release note -->

Support schema and table routing for mysql-compatible sinks by extending the `dispatchers` config
