### PR TITLE
metrics: fix changefeed resolved ts metrics

### DIFF
--- a/pkg/eventservice/dispatcher_stat.go
+++ b/pkg/eventservice/dispatcher_stat.go
@@ -182,6 +182,8 @@ func newDispatcherStat(
 
 // copyStatistics copies statistical data that reflects the dynamic state of the dispatcher.
 func (a *dispatcherStat) copyStatistics(src *dispatcherStat) {
+	a.receivedResolvedTs.Store(src.receivedResolvedTs.Load())
+	a.eventStoreCommitTs.Store(src.eventStoreCommitTs.Load())
 	a.checkpointTs.Store(src.checkpointTs.Load())
 	a.hasReceivedFirstResolvedTs.Store(src.hasReceivedFirstResolvedTs.Load())
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3750

### What is changed and how it works?

<img width="1231" height="583" alt="image" src="https://github.com/user-attachments/assets/57821be8-eefe-4dd9-b6ca-2cc8ac020e14" />
After this pr, dispatcher reset frequently while changefeed resolved ts keeps stable.

### Highlights

* **Metric Synchronization Fix**: Ensures that `receivedResolvedTs` and `eventStoreCommitTs` are correctly synchronized when copying dispatcher statistics, addressing a potential issue with changefeed resolved timestamp metrics.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
