### PR TITLE
Optimize the `cli create` response time when there are a large number of tables

### DIFF
--- a/logservice/schemastore/validator.go
+++ b/logservice/schemastore/validator.go
@@ -124,8 +124,8 @@ func (v *tableVerifier) worker() {
 		}
 
 		localInfos := make([]*common.TableInfo, 0, len(task.values))
-		localIneligible := make([]string, 0)
-		localEligible := make([]string, 0)
+		localIneligible := make([]string, 0, len(task.values))
+		localEligible := make([]string, 0, len(task.values))
 
 		for _, value := range task.values {
 			tbInfo := &timodel.TableInfo{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/3770

### What is changed and how it works?
This pull request addresses the performance bottleneck in the `cli create` command when it interacts with a large number of tables. The core change involves optimizing the `VerifyTables` function by introducing a concurrent processing model. This model leverages a worker pool and batching to parallelize the unmarshaling and filtering of table metadata, leading to a substantial reduction in response time for the CLI operation.

### Highlights

* **Concurrency Optimization**: The `VerifyTables` function has been refactored to utilize a fixed-size worker pool (16 goroutines) for parallel processing of table metadata, significantly improving performance when dealing with a large number of tables.
* **Batch Processing**: Table metadata is now processed in batches of 1024 raw values before being sent to worker goroutines, reducing overhead and improving efficiency.


Cost time for `cli create changefeed` for 1,000,000 tables is reduced to 85s from 240s

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
