### PR TITLE
Increase sleep duration to ensure changefeed stability before pausing

### DIFF
--- a/tests/integration_tests/kafka_simple_handle_key_only/run.sh
+++ b/tests/integration_tests/kafka_simple_handle_key_only/run.sh
@@ -32,7 +32,7 @@ function run() {
 	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c ${changefeed_id} --config="$CUR/conf/changefeed.toml"
 	run_sql_file $CUR/data/ddl.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
-	sleep 5
+	sleep 20
 
 	cdc_cli_changefeed pause -c ${changefeed_id}
 


### PR DESCRIPTION
## What problem does this PR solve?

This PR addresses a timing issue in the Kafka integration test where the changefeed is paused too quickly after creation, potentially before it has fully initialized and started processing data. This could lead to flaky test behavior where the changefeed might not capture all expected events before being paused.

Issue Number: close #3781

## What is changed and how it works?

The change increases the sleep duration from 5 seconds to 20 seconds between creating the changefeed and pausing it in the Kafka integration test. 

The longer wait time helps prevent race conditions where the test might pause the changefeed before it has properly started, which could cause inconsistent test results.

## Check List

### Tests
- [x] Integration test (modified existing test script)

### Questions
- **Will it cause performance regression or break compatibility?**  
  No, this change only affects test timing and does not impact production code or performance.

- **Do you need to update user documentation, design documentation or monitoring documentation?**  
  No, this is an internal test modification only.

## Release note

```release-note
None
```
