### PR TITLE
sink: modify the write order of the index file and data file in storage writer

### DIFF
--- a/downstreamadapter/sink/cloudstorage/writer.go
+++ b/downstreamadapter/sink/cloudstorage/writer.go
@@ -266,7 +266,7 @@ func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath 
 	d.metricWriteBytes.Add(float64(bytesCnt))
 	d.metricFileCount.Add(1)
 
-	// write the index file to external storage in the end.
+	// then write the index file to external storage in the end.
 	// the file content is simply the last data file path
 	err := d.writeIndexFile(ctx, indexFilePath, path.Base(dataFilePath)+"\n")
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3784

### What is changed and how it works?
Index File Write Order: The process of writing the index file has been reordered to occur after the corresponding data file is successfully written, ensuring better consistency in cloud storage.
writeDataFile Signature Update: The writeDataFile function now accepts both the data file path and the index file path as distinct arguments, improving clarity and enabling the reordered write logic.

After this PR, the data file will be written before the index file. If the CDC restarts:
1. If the index file is written, the data may be duplicated to write a new data file.
2. If the index file is not written, the data file will be overwritten.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
