### PR TITLE
codec(ticdc): correct default value for debezium

### DIFF
--- a/pkg/sink/codec/debezium/helper.go
+++ b/pkg/sink/codec/debezium/helper.go
@@ -135,6 +135,18 @@ func getValueFromDefault(defaultVal any, tp *types.FieldType) any {
 			return v
 		}
 		log.Error("unexpected column value type string for int column", zap.Error(err), zap.Any("defaultValue", defaultVal))
+	case mysql.TypeEnum:
+		v, err := types.ParseEnumName(tp.GetElems(), val, tp.GetCollate())
+		if err == nil {
+			return v
+		}
+		log.Error("unexpected column value type string for enum column", zap.Error(err), zap.Any("defaultValue", defaultVal))
+	case mysql.TypeSet:
+		v, err := types.ParseSetName(tp.GetElems(), val, tp.GetCollate())
+		if err == nil {
+			return v
+		}
+		log.Error("unexpected column value type string for set column", zap.Error(err), zap.Any("defaultValue", defaultVal))
 	case mysql.TypeDouble, mysql.TypeFloat:
 		v, err := strconv.ParseFloat(val, 64)
 		if err == nil {

--- a/tests/integration_tests/debezium03/sql/data_types.sql
+++ b/tests/integration_tests/debezium03/sql/data_types.sql
@@ -390,8 +390,8 @@ INSERT INTO t_json VALUES ('["foo"]', 1);
 */
 
 CREATE TABLE t_enum(
-  col_e   ENUM('a', 'b', 'c'),
-  col_s   SET('a', 'b', 'c'),
+  col_e   ENUM('a', 'b', 'c') DEFAULT 'a',
+  col_s   SET('a', 'b', 'c') DEFAULT 'a',
   pk      INT PRIMARY KEY
 );
 
@@ -400,3 +400,5 @@ INSERT INTO t_enum VALUES ('a', 'c', 1);
 SET sql_mode='';
 INSERT INTO t_enum VALUES ('d', 'e', 2);
 SET sql_mode='strict_trans_tables';
+
+INSERT INTO t_enum VALUES (null, null, 3);

--- a/tests/integration_tests/debezium_basic/data/test.sql
+++ b/tests/integration_tests/debezium_basic/data/test.sql
@@ -5,3 +5,6 @@ USE test;
 create table t1 (id int primary key, account_id int not null);
 alter table t1 add unique key(account_id);
 insert into t1 values (12,34);
+
+CREATE TABLE test.vec(id int primary key, data VECTOR(5));
+INSERT INTO test.vec(id, data) VALUES (1, "[1,2,3,4,5]");


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
This is a cherry-pick of https://github.com/pingcap/tiflow/pull/12475
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/12474

### What is changed and how it works?
Debezium Codec Default Value Handling: The Debezium codec has been improved to correctly handle default values for ENUM and SET column types, specifically addressing cases where the default value might be represented as a string instead of a uint64.

When the value is null, Debezium will use the default value as output. The default value type of enum/set is string rather than uint64.I have tested other data types and not found a similar issue
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
