### PR TITLE
consumer: correct blockedTableIDs in rename table

### DIFF
--- a/pkg/sink/codec/common/ddl.go
+++ b/pkg/sink/codec/common/ddl.go
@@ -175,8 +175,8 @@ func GetBlockedTables(
 
 		ddl.ExtraSchemaName = schemaName
 		ddl.ExtraTableName = tableName
-                extraTableIDs := accessor.GetBlockedTables(schemaName, tableName)
-                blockedTableIDs = append(blockedTableIDs, extraTableIDs...)
+		extraTableIDs := accessor.GetBlockedTables(schemaName, tableName)
+		blockedTableIDs = append(blockedTableIDs, extraTableIDs...)
 	}
 
 	if action == timodel.ActionExchangeTablePartition {

--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -65,54 +65,38 @@ mysql_groups=(
 
 # 12 CPU cores will be allocated to run each kafka heavy group in CI pipelines.
 kafka_groups=(
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	'ddl_with_random_move_table'
-	# # G00
-	# 'generate_column many_pk_or_uk'
-	# # G01
-	# 'canal_json_basic canal_json_claim_check canal_json_content_compatible ddl_for_split_tables_with_random_move_table'
-	# # G02
-	# 'canal_json_handle_key_only ddl_for_split_tables_with_failover'
-	# # G03
-	# 'canal_json_adapter_compatibility ddl_for_split_tables_with_merge_and_split'
-	# # G04
-	# 'open_protocol_claim_check open_protocol_handle_key_only random_drop_message'
-	# # G05
-	# 'move_table drop_many_tables checkpoint_race_ddl_crash'
-	# # G06
-	# 'cdc default_value ddl_for_split_tables_with_random_merge_and_split'
-	# # G07
-	# 'merge_table resolve_lock force_replicate_table ddl_for_split_tables'
-	# # G08
-	# 'kafka_simple_claim_check kafka_simple_claim_check_avro tidb_mysql_test'
-	# # G09
-	# 'kafka_simple_handle_key_only kafka_simple_handle_key_only_avro mq_sink_error_resume multi_source'
-	# # G10
-	# 'kafka_column_selector kafka_column_selector_avro ddl_with_random_move_table'
-	# # G11
-	# 'fail_over region_merge multi_changefeeds'
-	# # G12
-	# 'ddl_for_split_tables_random_schedule'
-	# # G13
-	# 'debezium01 fail_over_ddl_mix'
-	# # G14
-	# 'debezium02'
-	# # G15
-	# 'debezium03'
+	# G00
+	'generate_column many_pk_or_uk'
+	# G01
+	'canal_json_basic canal_json_claim_check canal_json_content_compatible ddl_for_split_tables_with_random_move_table'
+	# G02
+	'canal_json_handle_key_only ddl_for_split_tables_with_failover'
+	# G03
+	'canal_json_adapter_compatibility ddl_for_split_tables_with_merge_and_split'
+	# G04
+	'open_protocol_claim_check open_protocol_handle_key_only random_drop_message'
+	# G05
+	'move_table drop_many_tables checkpoint_race_ddl_crash'
+	# G06
+	'cdc default_value ddl_for_split_tables_with_random_merge_and_split'
+	# G07
+	'merge_table resolve_lock force_replicate_table ddl_for_split_tables'
+	# G08
+	'kafka_simple_claim_check kafka_simple_claim_check_avro tidb_mysql_test'
+	# G09
+	'kafka_simple_handle_key_only kafka_simple_handle_key_only_avro mq_sink_error_resume multi_source'
+	# G10
+	'kafka_column_selector kafka_column_selector_avro ddl_with_random_move_table'
+	# G11
+	'fail_over region_merge multi_changefeeds'
+	# G12
+	'ddl_for_split_tables_random_schedule'
+	# G13
+	'debezium01 fail_over_ddl_mix'
+	# G14
+	'debezium02'
+	# G15
+	'debezium03'
 )
 
 # 12 CPU cores will be allocated to run each pulsar heavy group in CI pipelines.


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #2189

### What is changed and how it works?
 The change ensures that the system correctly identifies and includes all relevant table IDs, specifically both the source and target tables involved in a rename, in the list of blocked tables. This prevents potential inconsistencies or issues that could arise from incomplete blocking during schema changes.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
