### PR TITLE
codec: correct column value in canal-json protocol

### DIFF
--- a/pkg/sink/codec/canal/canal_json_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_encoder.go
@@ -33,7 +33,7 @@ var bytesDecoder = charmap.ISO8859_1.NewDecoder()
 
 // TODO: we need to reorg this code later, including use util.jsonWriter and other unreasonable code
 func fillColumns(
-	valueMap map[int64]string,
+	valueMap map[int64]optionalString,
 	tableInfo *commonType.TableInfo,
 	onlyHandleKeyColumn bool,
 	out *jwriter.Writer,
@@ -62,10 +62,11 @@ func fillColumns(
 			}
 			out.String(col.Name.O)
 			out.RawByte(':')
-			if valueMap[colID] == "null" {
+			optionalStr := valueMap[colID]
+			if optionalStr.isNull {
 				out.RawString("null")
 			} else {
-				out.String(valueMap[colID])
+				out.String(optionalStr.value)
 			}
 		}
 	}
@@ -75,8 +76,7 @@ func fillColumns(
 }
 
 func fillUpdateColumns(
-	newValueMap map[int64]string,
-	oldValueMap map[int64]string,
+	newValueMap, oldValueMap map[int64]optionalString,
 	tableInfo *commonType.TableInfo,
 	onlyHandleKeyColumn bool,
 	onlyOutputUpdatedColumn bool,
@@ -106,10 +106,11 @@ func fillUpdateColumns(
 			}
 			out.String(col.Name.O)
 			out.RawByte(':')
-			if oldValueMap[colID] == "null" {
+			optionalStr := oldValueMap[colID]
+			if optionalStr.isNull {
 				out.RawString("null")
 			} else {
-				out.String(oldValueMap[colID])
+				out.String(optionalStr.value)
 			}
 		}
 	}
@@ -203,7 +204,7 @@ func newJSONMessageForDML(
 		out.String("")
 	}
 
-	valueMap := make(map[int64]string, columnLen)                // colId -> value
+	valueMap := make(map[int64]optionalString, columnLen)        // colId -> value
 	javaTypeMap := make(map[int64]common.JavaSQLType, columnLen) // colId -> javaType
 
 	row := e.GetRows()
@@ -287,7 +288,7 @@ func newJSONMessageForDML(
 	} else if e.IsUpdate() {
 		out.RawString(",\"old\":")
 
-		oldValueMap := make(map[int64]string, 0) // colId -> value
+		oldValueMap := make(map[int64]optionalString, 0) // colId -> value
 		preRow := e.GetPreRows()
 		for idx, col := range e.TableInfo.GetColumns() {
 			if !e.ColumnSelector.Select(col) {

--- a/tests/integration_tests/canal_json_basic/data/data.sql
+++ b/tests/integration_tests/canal_json_basic/data/data.sql
@@ -323,3 +323,10 @@ CREATE TABLE 表1 (
 RENAME TABLE 表1 TO 表2;
 
 DROP TABLE 表2;
+
+CREATE TABLE t_null (
+    `id` bigint unsigned not null primary key,
+    `col` varchar(64) collate utf8mb4_bin not null default ''
+);
+
+INSERT INTO t_null VALUES (1, 'test'), (2, 'null'), (3, 'test2'), (4, 'Null'), (5, 'NULL'), (6, ''), (7, 'nüll');

--- a/tests/integration_tests/canal_json_storage_basic/data/data.sql
+++ b/tests/integration_tests/canal_json_storage_basic/data/data.sql
@@ -87,3 +87,9 @@ VALUES (
 
 ALTER TABLE binary_columns ADD c_new INT;
 INSERT INTO binary_columns (c_new) VALUES (2);
+
+CREATE TABLE t_null (
+    `id` bigint unsigned not null primary key,
+    `col` varchar(64) collate utf8mb4_bin not null default ''
+);
+INSERT INTO t_null VALUES (1, 'test'), (2, 'null'), (3, 'test2'), (4, 'Null'), (5, 'NULL'), (6, ''), (7, 'nüll');


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
This is a cherry-pick of https://github.com/pingcap/ticdc/pull/3959
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3958

### What is changed and how it works?
Corrected NULL Value Handling: Refactored the Canal-JSON encoder to use optionalString for column values instead of string. This allows nil to explicitly represent database NULL values, resolving ambiguity with string literals like 'null'.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
