### PR TITLE
ci(release): only create release for vX.Y.Z and vX.Y.Z-release.n

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,16 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.version }}
+      is_release: ${{ steps.check.outputs.is_release }}
     steps:
       - name: Get the version
         id: tag
         run: echo "version=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
+      - name: Check if release version
+        id: check
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-release\.[0-9]+)?$ ]]; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
       - name: Echo tag
-        run: echo ${{ steps.tag.outputs.version }}
+        run: echo ${{ steps.tag.outputs.version }} is_release=${{ steps.check.outputs.is_release }}
   release:
     name: release
     needs: tag
-    if: '!contains(needs.tag.outputs.version, ''nextgen'')'
+    if: needs.tag.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,4 +68,4 @@ jobs:
           # Pull the latest release
           docker pull pingcap/ticdc:$VERSION
           \`\`\`"
-          gh release create "$VERSION" --prerelease --verify-tag -t "$TITLE" -n "$NOTE"
+          gh release create "$VERSION" --verify-tag -t "$TITLE" -n "$NOTE"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4008

### What is changed and how it works?

Previously all releases were created with `--prerelease` flag unconditionally. This PR modifies the release workflow to:

1. Add a version format check step in the `tag` job that validates if the version matches `vX.Y.Z` or `vX.Y.Z-release.n` pattern
2. Output `is_release` flag based on the version format check
3. The `release` job now only runs when `is_release == 'true'`
4. Remove the `--prerelease` flag from `gh release create` command

**Result:**
- `vX.Y.Z` (e.g., `v8.5.4`) → Creates official release
- `vX.Y.Z-release.n` (e.g., `v8.5.4-release.1`) → Creates official release  
- Other formats (alpha, beta, nightly, rc, etc.) → Skips release creation entirely

### Check List

#### Tests

- No code

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only affects the GitHub Actions release workflow.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```