### PR TITLE
Increase concurrency in complex transaction integration test to improve stress testing

### DIFF
--- a/tests/integration_tests/complex_transaction/run.sh
+++ b/tests/integration_tests/complex_transaction/run.sh
@@ -38,7 +38,7 @@ if [ "$SINK_TYPE" == "mysql" ]; then
 	# Run the complex transaction workload
 	GO111MODULE=on go run *.go \
 		-dsn "root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/complex_txn" \
-		--concurrency=20 \
+		--concurrency=2000 \
 		--total-txns=200000 \
 		--products=200 \
 		--users=2000


### PR DESCRIPTION
# Pull Request

## What problem does this PR solve?

This PR addresses a performance testing issue where the current concurrency level in the complex transaction integration test is insufficient to properly stress-test the system under realistic workloads. The existing test runs with only 20 concurrent connections, which doesn't adequately simulate production scenarios where hundreds or thousands of concurrent transactions may occur.

Issue Number: close #xxx (issue number to be filled when creating the actual PR)

## What is changed and how it works?

- Increased the concurrency parameter in the complex transaction integration test from 20 to 2000
- This change allows the test to better simulate real-world production workloads where high concurrency is common
- The test will now create 2000 concurrent connections to execute transactions, providing more realistic stress testing of TiCDC's transaction processing capabilities
- The total number of transactions (200,000) remains unchanged, ensuring the test duration remains reasonable while providing better concurrency coverage

## Check List

### Tests
- [x] Integration test (modified existing integration test configuration)
- [ ] Unit test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Questions

#### Will it cause performance regression or break compatibility?
No, this change only modifies test parameters to increase concurrency for more realistic testing. It does not affect production code or functionality.

#### Do you need to update user documentation, design documentation or monitoring documentation?
No documentation updates are required as this is a test-only change.

## Release note

```release-note
None
```
