### PR TITLE
coordinator: fix data race in AddMaintainerOperator

### DIFF
--- a/coordinator/operator/operator_add.go
+++ b/coordinator/operator/operator_add.go
@@ -27,33 +27,43 @@ import (
 )
 
 const (
-	None = iota
+	// None indicates the operator is not canceled and should keep scheduling.
+	None int32 = iota
+	// NodeRemoved indicates the destination node went offline before the operator finished.
 	NodeRemoved
+	// TaskRemoved indicates the changefeed task was removed while the operator was running.
 	TaskRemoved
 )
 
-// AddMaintainerOperator is an operator to schedule a maintainer to a node
+// AddMaintainerOperator schedules a maintainer to a target node for a changefeed.
+//
+// Note: OperatorController can call Schedule/Check/OnNodeRemove concurrently under a
+// shared read lock, so the operator's internal state must be concurrency-safe.
 type AddMaintainerOperator struct {
 	cf       *changefeed.Changefeed
 	dest     node.ID
 	finished atomic.Bool
-	canceled int
+	// canceled records why the operator stops scheduling.
+	// It must be atomic because Schedule can run concurrently with OnNodeRemove/OnTaskRemoved.
+	canceled atomic.Int32
 	db       *changefeed.ChangefeedDB
 }
 
+// NewAddMaintainerOperator creates an AddMaintainerOperator to schedule the given changefeed to dest.
 func NewAddMaintainerOperator(
 	db *changefeed.ChangefeedDB,
 	cf *changefeed.Changefeed,
 	dest node.ID,
 ) *AddMaintainerOperator {
 	return &AddMaintainerOperator{
-		cf:       cf,
-		dest:     dest,
-		db:       db,
-		canceled: None,
+		cf:   cf,
+		dest: dest,
+		db:   db,
 	}
 }
 
+// Check observes maintainer status updates and marks the operator finished once the maintainer
+// is working and bootstrap is done on the destination node.
 func (m *AddMaintainerOperator) Check(from node.ID, status *heartbeatpb.MaintainerStatus) {
 	if status == nil {
 		return
@@ -70,61 +80,74 @@ func (m *AddMaintainerOperator) Check(from node.ID, status *heartbeatpb.Maintain
 	}
 }
 
+// Schedule builds the "add maintainer" command message, or returns nil when finished/canceled.
 func (m *AddMaintainerOperator) Schedule() *messaging.TargetMessage {
-	if m.finished.Load() || m.canceled != None {
+	if m.finished.Load() || m.canceled.Load() != None {
 		return nil
 	}
 	return m.cf.NewAddMaintainerMessage(m.dest)
 }
 
-// OnNodeRemove is called when node offline, and the maintainer must already move to absent status and will be scheduled again
+// OnNodeRemove cancels the operator when the destination node goes offline.
+//
+// Once canceled, PostFinish will mark the maintainer as absent so it can be rescheduled.
 func (m *AddMaintainerOperator) OnNodeRemove(n node.ID) {
 	if n == m.dest {
 		m.finished.Store(true)
-		m.canceled = NodeRemoved
+		m.canceled.Store(NodeRemoved)
 	}
 }
 
+// AffectedNodes returns the nodes that may be touched by this operator.
 func (m *AddMaintainerOperator) AffectedNodes() []node.ID {
 	return []node.ID{m.dest}
 }
 
+// ID returns the changefeed ID this operator works on.
 func (m *AddMaintainerOperator) ID() common.ChangeFeedID {
 	return m.cf.ID
 }
 
+// IsFinished reports whether the operator has finished scheduling.
 func (m *AddMaintainerOperator) IsFinished() bool {
 	return m.finished.Load()
 }
 
+// OnTaskRemoved cancels the operator when the changefeed task is removed.
 func (m *AddMaintainerOperator) OnTaskRemoved() {
 	m.finished.Store(true)
-	m.canceled = TaskRemoved
+	m.canceled.Store(TaskRemoved)
 }
 
+// Start binds the changefeed to the destination node before the first scheduling attempt.
 func (m *AddMaintainerOperator) Start() {
 	m.db.BindChangefeedToNode("", m.dest, m.cf)
 }
 
+// PostFinish applies side effects after the operator is removed from the controller.
 func (m *AddMaintainerOperator) PostFinish() {
-	if m.canceled == None {
+	switch m.canceled.Load() {
+	case None:
 		m.db.MarkMaintainerReplicating(m.cf)
 		m.cf.SetIsNew(false)
-	} else if m.canceled == NodeRemoved {
+	case NodeRemoved:
 		m.db.MarkMaintainerAbsent(m.cf)
 	}
-	// TaskRemoved only happen when the changefeed is removed, so we don't need to do anything
+	// TaskRemoved only happens when the changefeed is removed, so we don't need to do anything.
 }
 
+// String returns a human-readable description of the operator, for logging.
 func (m *AddMaintainerOperator) String() string {
 	return fmt.Sprintf("add maintainer operator: %s, dest:%s",
 		m.cf.ID, m.dest)
 }
 
+// Type returns the operator type used by metrics/logging.
 func (m *AddMaintainerOperator) Type() string {
 	return "add"
 }
 
+// BlockTsForward indicates whether this operator blocks changefeed checkpoint forwarding.
 func (m *AddMaintainerOperator) BlockTsForward() bool {
 	log.Panic("unreachable code")
 	return false

--- a/coordinator/operator/operator_add_test.go
+++ b/coordinator/operator/operator_add_test.go
@@ -21,29 +21,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAddMaintainerOperator_OnNodeRemove verifies that removing a non-destination node
+// does not affect scheduling, while removing the destination node cancels the operator
+// and stops it from scheduling further commands.
 func TestAddMaintainerOperator_OnNodeRemove(t *testing.T) {
 	op := NewAddMaintainerOperator(nil, &changefeed.Changefeed{}, "n1")
 	op.OnNodeRemove("n2")
-	require.Equal(t, op.canceled, None)
+	require.Equal(t, None, op.canceled.Load())
 	require.False(t, op.finished.Load())
 
 	op.OnNodeRemove("n1")
-	require.Equal(t, op.canceled, NodeRemoved)
+	require.Equal(t, NodeRemoved, op.canceled.Load())
 	require.True(t, op.finished.Load())
 
 	require.Nil(t, op.Schedule())
 }
 
+// TestAddMaintainerOperator_OnTaskRemoved verifies that removing the changefeed task
+// cancels the operator and prevents any further scheduling.
 func TestAddMaintainerOperator_OnTaskRemoved(t *testing.T) {
 	op := NewAddMaintainerOperator(nil, &changefeed.Changefeed{}, "n1")
 
 	op.OnTaskRemoved()
-	require.Equal(t, op.canceled, TaskRemoved)
+	require.Equal(t, TaskRemoved, op.canceled.Load())
 	require.True(t, op.finished.Load())
 
 	require.Nil(t, op.Schedule())
 }
 
+// TestAddMaintainerOperator_CheckRequiresBootstrapDone verifies that the operator only
+// completes after it observes a Working status with BootstrapDone from the destination node.
 func TestAddMaintainerOperator_CheckRequiresBootstrapDone(t *testing.T) {
 	op := NewAddMaintainerOperator(nil, &changefeed.Changefeed{}, "n1")
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4032

### What is changed and how it works?
- Make `AddMaintainerOperator.canceled` concurrency-safe by switching it from a plain int to `atomic.Int32`, because `OperatorController` may call `Schedule/OnNodeRemove/OnTaskRemoved` concurrently under a shared read lock.
- Update unit tests accordingly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No. This change only adds atomic loads/stores around a small in-memory operator state.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a data race in coordinator AddMaintainerOperator when canceling maintainer scheduling on node removal.
```