### PR TITLE
consumer: avoid stalling CREATE TABLE/SCHEMA DDL on watermark

### DIFF
--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -221,10 +222,13 @@ func (w *writer) getBlockTableIDs(ddl *commonEvent.DDLEvent) map[int64]struct{} 
 	return tableIDs
 }
 
-// append DDL wait to be handled, only consider the constraint among DDLs.
-// for DDL a / b received in the order, a.CommitTs < b.CommitTs should be true.
+// appendDDL enqueues a DDL event to be flushed later.
+//
+// DDLs may be received out of commit-ts order (e.g. due to MQ delivery or buffering), so Write() sorts
+// ddlList by commit-ts before executing. ddlWithMaxCommitTs is a guard against per-table commit-ts
+// regressions: executing an older DDL after a newer one may corrupt downstream schema/DML ordering.
 func (w *writer) appendDDL(ddl *commonEvent.DDLEvent) {
-	// DDL CommitTs fallback, just crash it to indicate the bug.
+	// If commitTs goes backwards for a blocked table, ignore this DDL instead of applying it out of order.
 	tableIDs := w.getBlockTableIDs(ddl)
 	for tableID := range tableIDs {
 		maxCommitTs, ok := w.ddlWithMaxCommitTs[tableID]
@@ -362,6 +366,17 @@ func (w *writer) WriteMessage(ctx context.Context, message pulsar.Message) bool 
 
 // Write will synchronously write data downstream
 func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool {
+	// DDL events can be received out of commit-ts order (e.g. due to protocol-level broadcasting and
+	// buffering differences between DDL kinds). We must execute DDLs in commit-ts order; otherwise a
+	// "future" DDL that is not yet eligible (commitTs > watermark) can block executing earlier DDLs
+	// that are already eligible, and the subsequent watermark-based DML flush can observe an out-of-date
+	// downstream schema (e.g. DML applied before its ALTER TABLE), causing integration test failures.
+	if len(w.ddlList) > 1 {
+		sort.SliceStable(w.ddlList, func(i, j int) bool {
+			return w.ddlList[i].GetCommitTs() < w.ddlList[j].GetCommitTs()
+		})
+	}
+
 	watermark := w.globalWatermark()
 	ddlList := make([]*commonEvent.DDLEvent, 0)
 	for i, todoDDL := range w.ddlList {

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -189,3 +189,88 @@ func TestWriterWrite_doesNotBypassWatermarkForCreateTableLike(t *testing.T) {
 	require.Equal(t, []string{"CREATE TABLE `test`.`t2` LIKE `test`.`t1`"}, s.ddls)
 	require.Empty(t, w.ddlList)
 }
+
+func TestWriterWrite_handlesOutOfOrderDDLsByCommitTs(t *testing.T) {
+	// Scenario: In real topics, DDL messages can be received out of commit-ts order. A "future" DDL that
+	// is not yet eligible (commitTs > watermark) must not block earlier DDLs that are eligible; otherwise
+	// the subsequent watermark-based DML flush can observe an out-of-date downstream schema.
+	//
+	// Steps:
+	// 1) Provide a ddlList whose slice order is out of commit-ts order, and set watermark such that a
+	//    DDL in the middle is just beyond watermark.
+	// 2) Call writer.Write and expect all DDLs with commitTs <= watermark execute (in commit-ts order),
+	//    and only the truly "future" DDL remains pending.
+	ctx := context.Background()
+	s := &recordingSink{}
+	p := &partitionProgress{partition: 0, watermark: 944040962}
+	w := &writer{
+		progresses: []*partitionProgress{p},
+		mysqlSink:  s,
+	}
+	w.ddlList = []*commonEvent.DDLEvent{
+		{
+			Query:      "CREATE TABLE `common_1`.`add_and_drop_columns` (`id` INT(11) NOT NULL PRIMARY KEY)",
+			SchemaName: "common_1",
+			TableName:  "add_and_drop_columns",
+			Type:       byte(timodel.ActionCreateTable),
+			FinishedTs: 786754590,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+			},
+		},
+		{
+			Query:      "CREATE DATABASE `common`",
+			SchemaName: "common",
+			Type:       byte(timodel.ActionCreateSchema),
+			FinishedTs: 931195931,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+			},
+		},
+		{
+			// This DDL is just barely in the future of watermark, and would block later DDLs if we
+			// execute in slice order instead of commit-ts order.
+			Query:      "CREATE TABLE `common_1`.`a` (`a` BIGINT PRIMARY KEY,`b` INT)",
+			SchemaName: "common_1",
+			TableName:  "a",
+			Type:       byte(timodel.ActionCreateTable),
+			FinishedTs: 944040963,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+			},
+		},
+		{
+			Query:      "ALTER TABLE `common_1`.`add_and_drop_columns` ADD COLUMN `col1` INT NULL, ADD COLUMN `col2` INT NULL, ADD COLUMN `col3` INT NULL",
+			SchemaName: "common_1",
+			TableName:  "add_and_drop_columns",
+			Type:       byte(timodel.ActionAddColumn),
+			FinishedTs: 852290601,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+				TableIDs:      []int64{9},
+			},
+		},
+		{
+			Query:      "ALTER TABLE `common_1`.`add_and_drop_columns` DROP COLUMN `col1`, DROP COLUMN `col2`",
+			SchemaName: "common_1",
+			TableName:  "add_and_drop_columns",
+			Type:       byte(timodel.ActionDropColumn),
+			FinishedTs: 904719361,
+			BlockedTables: &commonEvent.InfluencedTables{
+				InfluenceType: commonEvent.InfluenceTypeNormal,
+				TableIDs:      []int64{9},
+			},
+		},
+	}
+
+	w.Write(ctx, codeccommon.MessageTypeDDL)
+
+	require.Equal(t, []string{
+		"CREATE TABLE `common_1`.`add_and_drop_columns` (`id` INT(11) NOT NULL PRIMARY KEY)",
+		"ALTER TABLE `common_1`.`add_and_drop_columns` ADD COLUMN `col1` INT NULL, ADD COLUMN `col2` INT NULL, ADD COLUMN `col3` INT NULL",
+		"ALTER TABLE `common_1`.`add_and_drop_columns` DROP COLUMN `col1`, DROP COLUMN `col2`",
+		"CREATE DATABASE `common`",
+	}, s.ddls)
+	require.Len(t, w.ddlList, 1)
+	require.Equal(t, "CREATE TABLE `common_1`.`a` (`a` BIGINT PRIMARY KEY,`b` INT)", w.ddlList[0].Query)
+}


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #4034

### What is changed and how it works?
- In kafka-consumer and pulsar-consumer, allow CREATE SCHEMA and *independent* CREATE TABLE DDLs to bypass watermark gating, while preserving commitTs order by stopping at the first DDL that still needs watermark.
- For ActionCreateTable, only bypass when the DDL does not depend on existing tables (e.g. do NOT bypass CREATE TABLE ... LIKE ..., which encodes dependencies via BlockedTableNames / BlockedTables.TableIDs).
- Add unit tests to cover bypass behavior, CREATE TABLE LIKE gating, and ordering guarantees.

### Check List 

#### Tests 

- Unit test (passed: go test ./cmd/kafka-consumer -run TestWriterWrite_ -count=1; go test ./cmd/pulsar-consumer -run TestWriterWrite_ -count=1)
- Integration test (N/A)
- Manual test (add detailed scripts or steps below) (N/A)
- No code (N/A)

#### Questions 

##### Will it cause performance regression or break compatibility?
No.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note 

```release-note
Fix kafka/pulsar consumer stalling CREATE TABLE/SCHEMA DDL when upstream resolved-ts is blocked.
```