### PR TITLE
logservice: fix event store on disk size overflow

### DIFF
--- a/logservice/eventstore/disk_space_usage_test.go
+++ b/logservice/eventstore/disk_space_usage_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventstore
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiskSpaceUsageClampsNegativeInProgressBytes(t *testing.T) {
+	m := &pebble.Metrics{}
+	m.WAL.PhysicalSize = 100
+	m.Table.ObsoleteSize = 50
+	m.Table.ZombieSize = 200
+	m.Compact.InProgressBytes = -1024
+
+	require.Equal(t, uint64(350), diskSpaceUsage(m))
+}

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1099,7 +1099,9 @@ func diskSpaceUsage(m *pebble.Metrics) uint64 {
 	}
 	usageBytes += m.Table.ObsoleteSize
 	usageBytes += m.Table.ZombieSize
-	usageBytes += uint64(m.Compact.InProgressBytes)
+	if m.Compact.InProgressBytes > 0 {
+		usageBytes += uint64(m.Compact.InProgressBytes)
+	}
 	return usageBytes
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4062

### What is changed and how it works?

- Clamp negative `pebble.Metrics.Compact.InProgressBytes` when calculating event store disk usage to avoid uint64 wraparound.
- Add a regression unit test for `diskSpaceUsage`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This only affects metric calculation and adds one conditional check.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix TiCDC event store on-disk data size metric overflow that could cause EiB-scale spikes.
```
