### PR TITLE
sink: make pulsar sink more robust

### DIFF
--- a/deployments/pulsar-consumer.Dockerfile
+++ b/deployments/pulsar-consumer.Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.25-alpine AS builder
+RUN apk add --no-cache make bash git build-base
+WORKDIR /go/src/github.com/pingcap/ticdc
+COPY . .
+
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+RUN --mount=type=cache,target=/root/.cache/go-build make pulsar_consumer
+
+FROM alpine:3.15
+
+RUN apk update && apk add tzdata curl
+
+ENV TZ=Asia/Shanghai
+
+COPY --from=builder  /go/src/github.com/pingcap/ticdc/bin/cdc_pulsar_consumer /cdc_pulsar_consumer
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/downstreamadapter/sink/pulsar/ddl_producer_test.go
+++ b/downstreamadapter/sink/pulsar/ddl_producer_test.go
@@ -56,7 +56,7 @@ func TestPulsarSyncSendMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		p := newMockDDLProducer()
-		err := p.syncSendMessage(tt.args.ctx, tt.args.topic, tt.args.message)
+		err := p.syncSendMessage(tt.args.ctx, tt.args.topic, tt.args.message, common.MessageTypeDDL)
 		require.NoError(t, err)
 		require.Len(t, p.(*mockProducer).GetEvents(tt.args.topic), 1)
 
@@ -99,7 +99,7 @@ func TestPulsarSyncBroadcastMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		p := newMockDDLProducer()
-		err := p.syncSendMessage(tt.args.ctx, tt.args.topic, tt.args.message)
+		err := p.syncSendMessage(tt.args.ctx, tt.args.topic, tt.args.message, common.MessageTypeDDL)
 		require.NoError(t, err)
 		require.Len(t, p.(*mockProducer).GetEvents(tt.args.topic), 1)
 

--- a/downstreamadapter/sink/pulsar/ddl_producer_test.go
+++ b/downstreamadapter/sink/pulsar/ddl_producer_test.go
@@ -20,6 +20,7 @@ import (
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +49,7 @@ func TestPulsarSyncSendMessage(t *testing.T) {
 				changefeedID: commonType.NewChangefeedID4Test("test_keyspace", "test"),
 				message: &common.Message{
 					Value:        []byte("this value for test input data"),
-					PartitionKey: str2Pointer("test_key"),
+					PartitionKey: util.AddressOf("test_key"),
 				},
 				errCh: make(chan error),
 			},
@@ -91,7 +92,7 @@ func TestPulsarSyncBroadcastMessage(t *testing.T) {
 				changefeedID: commonType.NewChangefeedID4Test("test_keyspace", "test"),
 				message: &common.Message{
 					Value:        []byte("this value for test input data"),
-					PartitionKey: str2Pointer("test_key"),
+					PartitionKey: util.AddressOf("test_key"),
 				},
 				errCh: make(chan error),
 			},

--- a/downstreamadapter/sink/pulsar/dml_producer.go
+++ b/downstreamadapter/sink/pulsar/dml_producer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	pulsarPkg "github.com/pingcap/ticdc/pkg/sink/pulsar"
 	"go.uber.org/zap"
 )
 
@@ -170,7 +171,7 @@ func (p *dmlProducers) asyncSendMessage(
 					zap.Int("messageSize", len(m.Payload)),
 					zap.String("topic", topic),
 					zap.Error(err))
-				// mq.IncPublishedDMLFail(topic, p.id.ID().String(), message.GetSchema())
+				pulsarPkg.IncPublishedDMLFail(topic, p.changefeedID.String())
 				// use this select to avoid send error to a closed channel
 				// the ctx will always be called before the errChan is closed
 				select {
@@ -184,11 +185,11 @@ func (p *dmlProducers) asyncSendMessage(
 			} else if message.Callback != nil {
 				// success
 				message.Callback()
-				// mq.IncPublishedDMLSuccess(topic, p.id.ID().String(), message.GetSchema())
+				pulsarPkg.IncPublishedDMLSuccess(topic, p.changefeedID.String())
 			}
 		})
 
-	// mq.IncPublishedDMLCount(topic, p.id.ID().String(), message.GetSchema())
+	pulsarPkg.IncPublishedDMLCount(topic, p.changefeedID.String())
 
 	return nil
 }

--- a/downstreamadapter/sink/pulsar/dml_producer_test.go
+++ b/downstreamadapter/sink/pulsar/dml_producer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +30,7 @@ func TestPulsarSyncAsyncSendMessage(t *testing.T) {
 	p := newMockDMLProducer()
 	err := p.asyncSendMessage(ctx, "test", &common.Message{
 		Value:        []byte("this value for test input data"),
-		PartitionKey: str2Pointer("test_key"),
+		PartitionKey: util.AddressOf("test_key"),
 	})
 	require.NoError(t, err)
 }

--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -46,7 +46,7 @@ func (c component) close() {
 		c.topicManager.Close()
 	}
 	if c.client != nil {
-		go c.client.Close()
+		c.client.Close()
 	}
 }
 
@@ -78,6 +78,11 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 	protocol, err := helper.GetProtocol(putil.GetOrZero(sinkConfig.Protocol))
 	if err != nil {
 		return pulsarComponent, config.ProtocolUnknown, errors.Trace(err)
+	}
+	if !config.IsPulsarSupportedProtocols(protocol) {
+		return pulsarComponent, protocol, errors.ErrSinkURIInvalid.
+			GenWithStackByArgs("unsupported protocol, " +
+				"pulsar sink currently only support these protocols: [canal-json]")
 	}
 
 	pulsarComponent.config, err = pulsar.NewPulsarConfig(sinkURI, sinkConfig.PulsarConfig)

--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 
 	pulsarClient "github.com/apache/pulsar-client-go/pulsar"
+	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/columnselector"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/helper"
@@ -29,6 +30,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/pulsar"
 	putil "github.com/pingcap/ticdc/pkg/util"
+	"go.uber.org/zap"
 )
 
 type component struct {
@@ -131,4 +133,40 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 	return pulsarComponent, protocol, nil
+}
+
+// newProducer creates a pulsar producer
+// One topic is used by one producer
+func newProducer(
+	pConfig *config.PulsarConfig,
+	client pulsarClient.Client,
+	topicName string,
+) (pulsarClient.Producer, error) {
+	maxReconnectToBroker := uint(config.DefaultMaxReconnectToPulsarBroker)
+	option := pulsarClient.ProducerOptions{
+		Topic:                topicName,
+		MaxReconnectToBroker: &maxReconnectToBroker,
+	}
+	if pConfig.BatchingMaxMessages != nil {
+		option.BatchingMaxMessages = *pConfig.BatchingMaxMessages
+	}
+	if pConfig.BatchingMaxPublishDelay != nil {
+		option.BatchingMaxPublishDelay = pConfig.BatchingMaxPublishDelay.Duration()
+	}
+	if pConfig.CompressionType != nil {
+		option.CompressionType = pConfig.CompressionType.Value()
+		option.CompressionLevel = pulsarClient.Default
+	}
+	if pConfig.SendTimeout != nil {
+		option.SendTimeout = pConfig.SendTimeout.Duration()
+	}
+
+	producer, err := client.CreateProducer(option)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("create pulsar producer success", zap.String("topic", topicName))
+
+	return producer, nil
 }

--- a/downstreamadapter/sink/pulsar/mock_producer.go
+++ b/downstreamadapter/sink/pulsar/mock_producer.go
@@ -45,15 +45,15 @@ func newMockDMLProducer() dmlProducer {
 }
 
 // SyncBroadcastMessage pulsar consume all partitions
-func (p *mockProducer) syncBroadcastMessage(ctx context.Context, topic string, message *common.Message,
+func (p *mockProducer) syncBroadcastMessage(ctx context.Context, topic string, message *common.Message, messageType common.MessageType,
 ) error {
-	return p.syncSendMessage(ctx, topic, message)
+	return p.syncSendMessage(ctx, topic, message, messageType)
 }
 
 // SyncSendMessage sends a message
 // partitionNum is not used,pulsar consume all partitions
 func (p *mockProducer) syncSendMessage(ctx context.Context, topic string,
-	message *common.Message,
+	message *common.Message, messageType common.MessageType,
 ) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -549,4 +549,6 @@ func (s *sink) Close(_ bool) {
 	s.dmlProducer.close()
 	s.comp.close()
 	s.statistics.Close()
+	s.eventChan.Close()
+	s.rowChan.Close()
 }

--- a/downstreamadapter/sink/pulsar/sink_test.go
+++ b/downstreamadapter/sink/pulsar/sink_test.go
@@ -25,6 +25,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/metrics"
+	"github.com/pingcap/ticdc/utils/chann"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
@@ -53,8 +54,8 @@ func newPulsarSinkForTest(t *testing.T) (*sink, error) {
 		ddlProducer:  newMockDDLProducer(),
 
 		checkpointTsChan: make(chan uint64, 16),
-		eventChan:        make(chan *commonEvent.DMLEvent, 32),
-		rowChan:          make(chan *commonEvent.MQRowEvent, 32),
+		eventChan:        chann.NewUnlimitedChannelDefault[*commonEvent.DMLEvent](),
+		rowChan:          chann.NewUnlimitedChannelDefault[*commonEvent.MQRowEvent](),
 
 		protocol:      protocol,
 		partitionRule: helper.GetDDLDispatchRule(protocol),

--- a/downstreamadapter/sink/topicmanager/pulsar_topic_manager.go
+++ b/downstreamadapter/sink/topicmanager/pulsar_topic_manager.go
@@ -65,8 +65,3 @@ func (m *pulsarTopicManager) CreateTopicAndWaitUntilVisible(ctx context.Context,
 // Close
 func (m *pulsarTopicManager) Close() {
 }
-
-// str2Pointer returns the pointer of the string.
-func str2Pointer(str string) *string {
-	return &str
-}

--- a/downstreamadapter/sink/topicmanager/pulsar_topic_manager.go
+++ b/downstreamadapter/sink/topicmanager/pulsar_topic_manager.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/pingcap/ticdc/pkg/config"
-	cerror "github.com/pingcap/ticdc/pkg/errors"
 )
 
 // pulsarTopicManager is a manager for pulsar topics.
@@ -37,11 +36,6 @@ func GetPulsarTopicManagerAndTryCreateTopic(
 	client pulsar.Client,
 ) (TopicManager, error) {
 	topicManager := newPulsarTopicManager(cfg, client)
-
-	if _, err := topicManager.CreateTopicAndWaitUntilVisible(ctx, topic); err != nil {
-		return nil, cerror.WrapError(cerror.ErrKafkaCreateTopic, err)
-	}
-
 	return topicManager, nil
 }
 

--- a/downstreamadapter/sink/topicmanager/pulsar_topic_manager_test.go
+++ b/downstreamadapter/sink/topicmanager/pulsar_topic_manager_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/sink/pulsar"
+	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +46,7 @@ func TestGetPartitionNumMock(t *testing.T) {
 
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Sink = &config.SinkConfig{
-		Protocol: str2Pointer("canal-json"),
+		Protocol: util.AddressOf("canal-json"),
 	}
 
 	ctx := context.Background()

--- a/pkg/metrics/pulsar.go
+++ b/pkg/metrics/pulsar.go
@@ -1,0 +1,59 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	pulsarPublishedDDLSchemaTableCount      = "published_DDL_schema_table_count"
+	pulsarPublishedDMLSchemaTableCount      = "published_DML_schema_table_count"
+	pulsarPublishedMessageTypeResolvedCount = "published_message_type_resolved_count"
+)
+
+var (
+	// pulsar producer DDL scheme, type: count/success/fail, May there are too many tables
+	PublishedDDLSchemaTableCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "pulsar",
+			Name:      pulsarPublishedDDLSchemaTableCount,
+			Help:      "pulsar published schema count",
+		}, []string{"topic", "changefeed", "type"})
+
+	// pulsar producer DML scheme, type:count/success/fail , May there are too many tables
+	PublishedDMLSchemaTableCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "pulsar",
+			Name:      pulsarPublishedDMLSchemaTableCount,
+			Help:      "pulsar published dml message count",
+		}, []string{"topic", "changefeed", "type"})
+
+	// pulsar producer WATER count, type:count/success/fail , May there are too many tables
+	PulsarPublishedMessageTypeResolvedCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "pulsar",
+			Name:      pulsarPublishedMessageTypeResolvedCount,
+			Help:      "pulsar published message type resolved count ",
+		}, []string{"topic", "changefeed", "type"})
+)
+
+func initPulsarMetrics(registry *prometheus.Registry) {
+	registry.MustRegister(PublishedDDLSchemaTableCount)
+	registry.MustRegister(PublishedDMLSchemaTableCount)
+	registry.MustRegister(PulsarPublishedMessageTypeResolvedCount)
+}

--- a/pkg/metrics/sink.go
+++ b/pkg/metrics/sink.go
@@ -243,4 +243,7 @@ func initSinkMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(WorkerBatchDuration)
 	registry.MustRegister(CheckpointTsMessageDuration)
 	registry.MustRegister(CheckpointTsMessageCount)
+
+	// pulsar sink metrics
+	initPulsarMetrics(registry)
 }

--- a/pkg/sink/pulsar/metrics.go
+++ b/pkg/sink/pulsar/metrics.go
@@ -1,0 +1,65 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulsar
+
+import (
+	ticdcMetrics "github.com/pingcap/ticdc/pkg/metrics"
+	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+)
+
+// IncPublishedDDLCount DDL
+func IncPublishedDDLCount(topic, changefeed string, messageType common.MessageType) {
+	if isResolvedMessage(messageType) {
+		ticdcMetrics.PulsarPublishedMessageTypeResolvedCount.WithLabelValues(topic, changefeed, "count").Inc()
+		return
+	}
+	ticdcMetrics.PublishedDDLSchemaTableCount.WithLabelValues(topic, changefeed, "count").Inc()
+}
+
+// IncPublishedDDLSuccess success
+func IncPublishedDDLSuccess(topic, changefeed string, messageType common.MessageType) {
+	if isResolvedMessage(messageType) {
+		ticdcMetrics.PulsarPublishedMessageTypeResolvedCount.WithLabelValues(topic, changefeed, "success").Inc()
+		return
+	}
+	ticdcMetrics.PublishedDDLSchemaTableCount.WithLabelValues(topic, changefeed, "success").Inc()
+}
+
+// IncPublishedDDLFail fail
+func IncPublishedDDLFail(topic, changefeed string, messageType common.MessageType) {
+	if isResolvedMessage(messageType) {
+		ticdcMetrics.PulsarPublishedMessageTypeResolvedCount.WithLabelValues(topic, changefeed, "fail").Inc()
+		return
+	}
+	ticdcMetrics.PublishedDDLSchemaTableCount.WithLabelValues(topic, changefeed, "fail").Inc()
+}
+
+// IncPublishedDMLCount count
+func IncPublishedDMLCount(topic, changefeed string) {
+	ticdcMetrics.PublishedDMLSchemaTableCount.WithLabelValues(topic, changefeed, "count").Inc()
+}
+
+// IncPublishedDMLSuccess success
+func IncPublishedDMLSuccess(topic, changefeed string) {
+	ticdcMetrics.PublishedDMLSchemaTableCount.WithLabelValues(topic, changefeed, "success").Inc()
+}
+
+// IncPublishedDMLFail fail
+func IncPublishedDMLFail(topic, changefeed string) {
+	ticdcMetrics.PublishedDMLSchemaTableCount.WithLabelValues(topic, changefeed, "fail").Inc()
+}
+
+func isResolvedMessage(messageType common.MessageType) bool {
+	return messageType == common.MessageTypeResolved
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #1226

### What is changed and how it works?
- Enhanced Pulsar Sink Robustness: The Pulsar sink has been made more robust through improved error handling, comprehensive metric collection, and refined channel management for event processing.
- New Pulsar Metrics: Dedicated Prometheus metrics have been introduced to track DDL, DML, and resolved messages, including counts, successes, and failures, providing better observability into the Pulsar sink's operation.
- Unlimited Channel Adoption: The eventChan and rowChan in the Pulsar sink have been migrated to chann.UnlimitedChannel, which helps prevent blocking and improves event processing flow.
- Refactored Producer Logic: The DDL and DML producer interfaces and implementations now include messageType for more granular metric tracking, and common producer creation logic has been centralized in helper.go.
- Simplified Topic Management: The Pulsar topic manager no longer attempts automatic topic creation, streamlining its responsibility and removing associated error wrapping.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
