### PR TITLE
scheduling: Prevent duplicate add operators by skipping split postFinish when target nodes mismatch

### DIFF
--- a/maintainer/operator/operator_split.go
+++ b/maintainer/operator/operator_split.go
@@ -171,9 +171,17 @@ func (m *SplitDispatcherOperator) PostFinish() {
 		return
 	}
 
-	newReplicaSets := m.spanController.ReplaceReplicaSet([]*replica.SpanReplication{m.replicaSet}, m.splitSpans, m.checkpointTs, m.splitTargetNodes)
+	newReplicaSets, replicasInScheduling := m.spanController.ReplaceReplicaSet(
+		[]*replica.SpanReplication{m.replicaSet},
+		m.splitSpans,
+		m.checkpointTs,
+		m.splitTargetNodes,
+	)
 
-	if m.postFinish != nil {
+	// Only invoke postFinish when ReplaceReplicaSet places the new replicas in scheduling state.
+	// If the target nodes are not aligned with the actual split result, ReplaceReplicaSet falls back
+	// to absent replicas so that the basic scheduler can schedule them, avoiding racing add operators.
+	if m.postFinish != nil && replicasInScheduling {
 		for idx, span := range newReplicaSets {
 			ret := m.postFinish(span, m.splitTargetNodes[idx])
 			if !ret {
@@ -184,6 +192,12 @@ func (m *SplitDispatcherOperator) PostFinish() {
 				m.spanController.MarkSpanAbsent(span)
 			}
 		}
+	} else if m.postFinish != nil && !replicasInScheduling {
+		log.Warn("skip post finish because split target nodes are not aligned with actual split result",
+			zap.String("id", m.replicaSet.ID.String()),
+			zap.Int("targetNodeCount", len(m.splitTargetNodes)),
+			zap.Int("newReplicaCount", len(newReplicaSets)),
+			zap.String("splitSpans", m.splitSpanInfo))
 	}
 
 	log.Info("split dispatcher operator post finish finished", zap.String("dispatcherID", m.replicaSet.ID.String()))


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/4077

### What is changed and how it works?

This pull request addresses a potential issue in the scheduling mechanism where duplicate add operators could be created during a split operation if the provided target nodes do not align with the actual number of resulting spans. The changes ensure that the `postFinish` callback, which typically initiates further scheduling, is only invoked when the target nodes are correctly aligned. In cases of mismatch, the new spans are marked as absent, allowing the system's basic scheduler to take over and prevent redundant operations, thereby improving the robustness of the scheduling process.

### Highlights

* **Conditional postFinish execution**: The `SplitDispatcherOperator.PostFinish` method now conditionally invokes its `postFinish` callback. This callback is only executed if the new replica sets are successfully placed into a scheduling state with aligned target nodes.
* **ReplaceReplicaSet return value**: The `spanController.ReplaceReplicaSet` function has been updated to return an additional boolean value, `replicasInScheduling`, which indicates whether the newly created replica sets were successfully assigned to the specified target nodes.
* **Handling target node mismatch**: If the number of `splitTargetNodes` does not match the number of newly created spans, `ReplaceReplicaSet` will now place these new spans into an "absent" state instead of a "scheduling" state. This allows the basic scheduler to handle them and prevents the creation of duplicate add operators.
* **New test case**: A new unit test, `TestSplitOperator_PostFinishSkipsWhenTargetNodesMismatch`, has been added to specifically verify the behavior where `postFinish` is skipped when target nodes do not align with the actual split results.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
