### PR TITLE
common: accept legacy namespace in changefeed ID JSON

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -16,6 +16,7 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"regexp"
 	"strconv"
 
@@ -158,6 +159,45 @@ func NewGIDWithValue(Low uint64, High uint64) GID {
 type ChangeFeedDisplayName struct {
 	Name     string `json:"name"`
 	Keyspace string `json:"keyspace"`
+}
+
+// changeFeedDisplayNameJSON is a compatibility shim for ChangeFeedDisplayName JSON encoding.
+//
+// Why: some historical TiCDC versions persisted the user-facing dimension as "namespace".
+// Newer TiCDC versions renamed it to "keyspace". Mixed-version upgrades/rollbacks must
+// not make changefeeds "disappear" (e.g., keyspace becomes empty and gets filtered out)
+// or become un-recreatable due to occupied meta keys. To keep metadata compatible across
+// versions, we accept both field names on unmarshal and emit both on marshal.
+type changeFeedDisplayNameJSON struct {
+	Name      string `json:"name"`
+	Keyspace  string `json:"keyspace,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// MarshalJSON emits both "keyspace" (newer) and "namespace" (legacy) so that either
+// field name can be used to read the metadata without an explicit migration step.
+func (r ChangeFeedDisplayName) MarshalJSON() ([]byte, error) {
+	return json.Marshal(changeFeedDisplayNameJSON{
+		Name:      r.Name,
+		Keyspace:  r.Keyspace,
+		Namespace: r.Keyspace,
+	})
+}
+
+// UnmarshalJSON accepts both "keyspace" (newer) and "namespace" (legacy).
+// If both are present, "keyspace" takes precedence.
+func (r *ChangeFeedDisplayName) UnmarshalJSON(data []byte) error {
+	var decoded changeFeedDisplayNameJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	r.Name = decoded.Name
+	if decoded.Keyspace != "" {
+		r.Keyspace = decoded.Keyspace
+		return nil
+	}
+	r.Keyspace = decoded.Namespace
+	return nil
 }
 
 func NewChangeFeedDisplayName(name string, keyspace string) ChangeFeedDisplayName {

--- a/pkg/common/types_test.go
+++ b/pkg/common/types_test.go
@@ -1,3 +1,16 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/pkg/common/types_test.go
+++ b/pkg/common/types_test.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeFeedDisplayNameJSONCompatibility(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: TiCDC historically persisted changefeed IDs using "namespace".
+	// Newer versions renamed the dimension to "keyspace". We must be able to
+	// read both to avoid cross-version upgrades/rollbacks making changefeeds
+	// "disappear" (e.g., keyspace becomes empty and gets filtered out).
+
+	t.Run("unmarshal legacy namespace", func(t *testing.T) {
+		t.Parallel()
+
+		// Step: decode legacy JSON that only contains "namespace".
+		var got ChangeFeedDisplayName
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"cf","namespace":"default"}`), &got))
+
+		// Expect: Keyspace is filled from the legacy field.
+		require.Equal(t, ChangeFeedDisplayName{Name: "cf", Keyspace: "default"}, got)
+	})
+
+	t.Run("unmarshal new keyspace", func(t *testing.T) {
+		t.Parallel()
+
+		// Step: decode newer JSON that only contains "keyspace".
+		var got ChangeFeedDisplayName
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"cf","keyspace":"default"}`), &got))
+
+		// Expect: Keyspace is filled from the new field.
+		require.Equal(t, ChangeFeedDisplayName{Name: "cf", Keyspace: "default"}, got)
+	})
+
+	t.Run("keyspace wins when both exist", func(t *testing.T) {
+		t.Parallel()
+
+		// Step: decode mixed JSON produced/consumed by different versions.
+		var got ChangeFeedDisplayName
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"cf","namespace":"ns","keyspace":"ks"}`), &got))
+
+		// Expect: new field takes precedence to match current semantics.
+		require.Equal(t, ChangeFeedDisplayName{Name: "cf", Keyspace: "ks"}, got)
+	})
+
+	t.Run("marshal emits both fields", func(t *testing.T) {
+		t.Parallel()
+
+		// Step: encode a display name.
+		data, err := json.Marshal(ChangeFeedDisplayName{Name: "cf", Keyspace: "default"})
+		require.NoError(t, err)
+
+		// Expect: both fields exist so that either a legacy ("namespace") or a newer
+		// ("keyspace") TiCDC binary can read metadata without rewriting it first.
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Equal(t, "cf", got["name"])
+		require.Equal(t, "default", got["namespace"])
+		require.Equal(t, "default", got["keyspace"])
+	})
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4079

### What is changed and how it works?
- Accept legacy `namespace` field when unmarshalling `ChangeFeedDisplayName` JSON (treat it as an alias of `keyspace`).
- Marshal `ChangeFeedDisplayName` with both `keyspace` and legacy `namespace` to keep metadata readable across versions.
- Add a unit test to cover both formats.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test: N/A

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No. This only changes JSON encoding/decoding for changefeed display name metadata and improves cross-version compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix changefeed metadata compatibility when upgrading between TiCDC versions that used "namespace" vs "keyspace" in changefeed ID JSON.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved JSON compatibility for display names: serialized output now includes both legacy and current field names so older and newer consumers can read data without migration; deserialization accepts either field and prefers the current one when both exist.

* **Tests**
  * Added unit tests covering forward/backward compatibility and serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->