### PR TITLE
redo: always init blockedTables to avoid panic

### DIFF
--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -266,7 +266,7 @@ func (ra *RedoApplier) applyDDL(
 				timodel.ActionAddCheckConstraint, timodel.ActionDropCheckConstraint, timodel.ActionAlterCheckConstraint,
 				timodel.ActionAlterTableAttributes, timodel.ActionAlterCacheTable, timodel.ActionAlterNoCacheTable,
 				timodel.ActionMultiSchemaChange, timodel.ActionAlterTTLInfo, timodel.ActionAlterTTLRemove:
-				tableDDLTs = ra.getTableDDLTs(ddl.DDL.BlockTables.TableIDs...)
+				tableDDLTs = ra.getTableDDLTs(ddl.DDL.BlockedTables.TableIDs...)
 			case timodel.ActionExchangeTablePartition, timodel.ActionReorganizePartition,
 				timodel.ActionAddTablePartition, timodel.ActionDropTablePartition, timodel.ActionTruncateTablePartition,
 				timodel.ActionAlterTablePartitionAttributes, timodel.ActionAlterTablePartitioning, timodel.ActionRemovePartitioning,
@@ -321,7 +321,7 @@ func (ra *RedoApplier) applyDDL(
 	}
 	log.Warn("apply DDL", zap.Any("ddl", ddl))
 	// Wait block tables to flush data before applying DDL.
-	tableIDs := ra.getBlockTableIDs(ddl.DDL.BlockTables)
+	tableIDs := ra.getBlockTableIDs(ddl.DDL.BlockedTables)
 	for tableID := range tableIDs {
 		if err := ra.waitTableFlush(ctx, tableID, ddl.DDL.CommitTs); err != nil {
 			return err

--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -402,11 +402,6 @@ func (t *DDLEvent) Len() int32 {
 	return 1
 }
 
-type SchemaTableName struct {
-	SchemaName string
-	TableName  string
-}
-
 type DB struct {
 	SchemaID   int64
 	SchemaName string

--- a/pkg/common/event/interface.go
+++ b/pkg/common/event/interface.go
@@ -175,6 +175,11 @@ func ToTablesPB(tables []Table) []*heartbeatpb.Table {
 	return res
 }
 
+type SchemaTableName struct {
+	SchemaName string `msg:"schema-name"`
+	TableName  string `msg:"table-name"`
+}
+
 type Table struct {
 	SchemaID         int64 `msg:"-"`
 	TableID          int64 `msg:"table"`

--- a/pkg/common/event/interface_gen.go
+++ b/pkg/common/event/interface_gen.go
@@ -256,6 +256,134 @@ func (z *InfluencedTables) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *SchemaTableName) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "schema-name":
+			z.SchemaName, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "SchemaName")
+				return
+			}
+		case "table-name":
+			z.TableName, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "TableName")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z SchemaTableName) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "schema-name"
+	err = en.Append(0x82, 0xab, 0x73, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.SchemaName)
+	if err != nil {
+		err = msgp.WrapError(err, "SchemaName")
+		return
+	}
+	// write "table-name"
+	err = en.Append(0xaa, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.TableName)
+	if err != nil {
+		err = msgp.WrapError(err, "TableName")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z SchemaTableName) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "schema-name"
+	o = append(o, 0x82, 0xab, 0x73, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.SchemaName)
+	// string "table-name"
+	o = append(o, 0xaa, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x6e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.TableName)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SchemaTableName) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "schema-name":
+			z.SchemaName, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SchemaName")
+				return
+			}
+		case "table-name":
+			z.TableName, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TableName")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z SchemaTableName) Msgsize() (s int) {
+	s = 1 + 12 + msgp.StringPrefixSize + len(z.SchemaName) + 11 + msgp.StringPrefixSize + len(z.TableName)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *Table) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/pkg/common/event/interface_gen_test.go
+++ b/pkg/common/event/interface_gen_test.go
@@ -122,6 +122,119 @@ func BenchmarkDecodeInfluencedTables(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalSchemaTableName(t *testing.T) {
+	v := SchemaTableName{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSchemaTableName(b *testing.B) {
+	v := SchemaTableName{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSchemaTableName(b *testing.B) {
+	v := SchemaTableName{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSchemaTableName(b *testing.B) {
+	v := SchemaTableName{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSchemaTableName(t *testing.T) {
+	v := SchemaTableName{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeSchemaTableName Msgsize() is inaccurate")
+	}
+
+	vn := SchemaTableName{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSchemaTableName(b *testing.B) {
+	v := SchemaTableName{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSchemaTableName(b *testing.B) {
+	v := SchemaTableName{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalTable(t *testing.T) {
 	v := Table{}
 	bts, err := v.MarshalMsg(nil)

--- a/pkg/common/event/redo_gen.go
+++ b/pkg/common/event/redo_gen.go
@@ -43,21 +43,40 @@ func (z *DDLEventInRedoLog) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Query")
 				return
 			}
-		case "block-tables":
+		case "blocked-tables":
 			if dc.IsNil() {
 				err = dc.ReadNil()
 				if err != nil {
-					err = msgp.WrapError(err, "BlockTables")
+					err = msgp.WrapError(err, "BlockedTables")
 					return
 				}
-				z.BlockTables = nil
+				z.BlockedTables = nil
 			} else {
-				if z.BlockTables == nil {
-					z.BlockTables = new(InfluencedTables)
+				if z.BlockedTables == nil {
+					z.BlockedTables = new(InfluencedTables)
 				}
-				err = z.BlockTables.DecodeMsg(dc)
+				err = z.BlockedTables.DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "BlockTables")
+					err = msgp.WrapError(err, "BlockedTables")
+					return
+				}
+			}
+		case "blocked-table-names":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "BlockedTableNames")
+				return
+			}
+			if cap(z.BlockedTableNames) >= int(zb0002) {
+				z.BlockedTableNames = (z.BlockedTableNames)[:zb0002]
+			} else {
+				z.BlockedTableNames = make([]SchemaTableName, zb0002)
+			}
+			for za0001 := range z.BlockedTableNames {
+				err = z.BlockedTableNames[za0001].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "BlockedTableNames", za0001)
 					return
 				}
 			}
@@ -80,21 +99,21 @@ func (z *DDLEventInRedoLog) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 		case "need_added_tables":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "NeedAddedTables")
 				return
 			}
-			if cap(z.NeedAddedTables) >= int(zb0002) {
-				z.NeedAddedTables = (z.NeedAddedTables)[:zb0002]
+			if cap(z.NeedAddedTables) >= int(zb0003) {
+				z.NeedAddedTables = (z.NeedAddedTables)[:zb0003]
 			} else {
-				z.NeedAddedTables = make([]Table, zb0002)
+				z.NeedAddedTables = make([]Table, zb0003)
 			}
-			for za0001 := range z.NeedAddedTables {
-				err = z.NeedAddedTables[za0001].DecodeMsg(dc)
+			for za0002 := range z.NeedAddedTables {
+				err = z.NeedAddedTables[za0002].DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "NeedAddedTables", za0001)
+					err = msgp.WrapError(err, "NeedAddedTables", za0002)
 					return
 				}
 			}
@@ -111,9 +130,9 @@ func (z *DDLEventInRedoLog) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *DDLEventInRedoLog) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 6
+	// map header, size 7
 	// write "start-ts"
-	err = en.Append(0x86, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
+	err = en.Append(0x87, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
 	if err != nil {
 		return
 	}
@@ -142,20 +161,37 @@ func (z *DDLEventInRedoLog) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Query")
 		return
 	}
-	// write "block-tables"
-	err = en.Append(0xac, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x2d, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+	// write "blocked-tables"
+	err = en.Append(0xae, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x65, 0x64, 0x2d, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
 	if err != nil {
 		return
 	}
-	if z.BlockTables == nil {
+	if z.BlockedTables == nil {
 		err = en.WriteNil()
 		if err != nil {
 			return
 		}
 	} else {
-		err = z.BlockTables.EncodeMsg(en)
+		err = z.BlockedTables.EncodeMsg(en)
 		if err != nil {
-			err = msgp.WrapError(err, "BlockTables")
+			err = msgp.WrapError(err, "BlockedTables")
+			return
+		}
+	}
+	// write "blocked-table-names"
+	err = en.Append(0xb3, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x65, 0x64, 0x2d, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x6e, 0x61, 0x6d, 0x65, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.BlockedTableNames)))
+	if err != nil {
+		err = msgp.WrapError(err, "BlockedTableNames")
+		return
+	}
+	for za0001 := range z.BlockedTableNames {
+		err = z.BlockedTableNames[za0001].EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "BlockedTableNames", za0001)
 			return
 		}
 	}
@@ -186,10 +222,10 @@ func (z *DDLEventInRedoLog) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "NeedAddedTables")
 		return
 	}
-	for za0001 := range z.NeedAddedTables {
-		err = z.NeedAddedTables[za0001].EncodeMsg(en)
+	for za0002 := range z.NeedAddedTables {
+		err = z.NeedAddedTables[za0002].EncodeMsg(en)
 		if err != nil {
-			err = msgp.WrapError(err, "NeedAddedTables", za0001)
+			err = msgp.WrapError(err, "NeedAddedTables", za0002)
 			return
 		}
 	}
@@ -199,9 +235,9 @@ func (z *DDLEventInRedoLog) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *DDLEventInRedoLog) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 6
+	// map header, size 7
 	// string "start-ts"
-	o = append(o, 0x86, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
+	o = append(o, 0x87, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
 	o = msgp.AppendUint64(o, z.StartTs)
 	// string "commit-ts"
 	o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x2d, 0x74, 0x73)
@@ -209,14 +245,24 @@ func (z *DDLEventInRedoLog) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "query"
 	o = append(o, 0xa5, 0x71, 0x75, 0x65, 0x72, 0x79)
 	o = msgp.AppendString(o, z.Query)
-	// string "block-tables"
-	o = append(o, 0xac, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x2d, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
-	if z.BlockTables == nil {
+	// string "blocked-tables"
+	o = append(o, 0xae, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x65, 0x64, 0x2d, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+	if z.BlockedTables == nil {
 		o = msgp.AppendNil(o)
 	} else {
-		o, err = z.BlockTables.MarshalMsg(o)
+		o, err = z.BlockedTables.MarshalMsg(o)
 		if err != nil {
-			err = msgp.WrapError(err, "BlockTables")
+			err = msgp.WrapError(err, "BlockedTables")
+			return
+		}
+	}
+	// string "blocked-table-names"
+	o = append(o, 0xb3, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x65, 0x64, 0x2d, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x6e, 0x61, 0x6d, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.BlockedTableNames)))
+	for za0001 := range z.BlockedTableNames {
+		o, err = z.BlockedTableNames[za0001].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "BlockedTableNames", za0001)
 			return
 		}
 	}
@@ -234,10 +280,10 @@ func (z *DDLEventInRedoLog) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "need_added_tables"
 	o = append(o, 0xb1, 0x6e, 0x65, 0x65, 0x64, 0x5f, 0x61, 0x64, 0x64, 0x65, 0x64, 0x5f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.NeedAddedTables)))
-	for za0001 := range z.NeedAddedTables {
-		o, err = z.NeedAddedTables[za0001].MarshalMsg(o)
+	for za0002 := range z.NeedAddedTables {
+		o, err = z.NeedAddedTables[za0002].MarshalMsg(o)
 		if err != nil {
-			err = msgp.WrapError(err, "NeedAddedTables", za0001)
+			err = msgp.WrapError(err, "NeedAddedTables", za0002)
 			return
 		}
 	}
@@ -280,20 +326,39 @@ func (z *DDLEventInRedoLog) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Query")
 				return
 			}
-		case "block-tables":
+		case "blocked-tables":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
 					return
 				}
-				z.BlockTables = nil
+				z.BlockedTables = nil
 			} else {
-				if z.BlockTables == nil {
-					z.BlockTables = new(InfluencedTables)
+				if z.BlockedTables == nil {
+					z.BlockedTables = new(InfluencedTables)
 				}
-				bts, err = z.BlockTables.UnmarshalMsg(bts)
+				bts, err = z.BlockedTables.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "BlockTables")
+					err = msgp.WrapError(err, "BlockedTables")
+					return
+				}
+			}
+		case "blocked-table-names":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BlockedTableNames")
+				return
+			}
+			if cap(z.BlockedTableNames) >= int(zb0002) {
+				z.BlockedTableNames = (z.BlockedTableNames)[:zb0002]
+			} else {
+				z.BlockedTableNames = make([]SchemaTableName, zb0002)
+			}
+			for za0001 := range z.BlockedTableNames {
+				bts, err = z.BlockedTableNames[za0001].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BlockedTableNames", za0001)
 					return
 				}
 			}
@@ -315,21 +380,21 @@ func (z *DDLEventInRedoLog) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 		case "need_added_tables":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "NeedAddedTables")
 				return
 			}
-			if cap(z.NeedAddedTables) >= int(zb0002) {
-				z.NeedAddedTables = (z.NeedAddedTables)[:zb0002]
+			if cap(z.NeedAddedTables) >= int(zb0003) {
+				z.NeedAddedTables = (z.NeedAddedTables)[:zb0003]
 			} else {
-				z.NeedAddedTables = make([]Table, zb0002)
+				z.NeedAddedTables = make([]Table, zb0003)
 			}
-			for za0001 := range z.NeedAddedTables {
-				bts, err = z.NeedAddedTables[za0001].UnmarshalMsg(bts)
+			for za0002 := range z.NeedAddedTables {
+				bts, err = z.NeedAddedTables[za0002].UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "NeedAddedTables", za0001)
+					err = msgp.WrapError(err, "NeedAddedTables", za0002)
 					return
 				}
 			}
@@ -347,11 +412,15 @@ func (z *DDLEventInRedoLog) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *DDLEventInRedoLog) Msgsize() (s int) {
-	s = 1 + 9 + msgp.Uint64Size + 10 + msgp.Uint64Size + 6 + msgp.StringPrefixSize + len(z.Query) + 13
-	if z.BlockTables == nil {
+	s = 1 + 9 + msgp.Uint64Size + 10 + msgp.Uint64Size + 6 + msgp.StringPrefixSize + len(z.Query) + 15
+	if z.BlockedTables == nil {
 		s += msgp.NilSize
 	} else {
-		s += z.BlockTables.Msgsize()
+		s += z.BlockedTables.Msgsize()
+	}
+	s += 20 + msgp.ArrayHeaderSize
+	for za0001 := range z.BlockedTableNames {
+		s += z.BlockedTableNames[za0001].Msgsize()
 	}
 	s += 20
 	if z.NeedDroppedTables == nil {
@@ -360,8 +429,8 @@ func (z *DDLEventInRedoLog) Msgsize() (s int) {
 		s += z.NeedDroppedTables.Msgsize()
 	}
 	s += 18 + msgp.ArrayHeaderSize
-	for za0001 := range z.NeedAddedTables {
-		s += z.NeedAddedTables[za0001].Msgsize()
+	for za0002 := range z.NeedAddedTables {
+		s += z.NeedAddedTables[za0002].Msgsize()
 	}
 	return
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4090

### What is changed and how it works?
1. Init BlockedTables for old arch compatibility
2. Add BlockedTableNames to ensure the waitAsyncDDLDone check success
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
