### PR TITLE
tests: auto enable table across nodes for pulsar consumer

### DIFF
--- a/tests/integration_tests/_utils/run_pulsar_consumer
+++ b/tests/integration_tests/_utils/run_pulsar_consumer
@@ -16,16 +16,18 @@ downstream_uri="mysql://root@127.0.0.1:3306/?safe-mode=true&batch-dml-enable=fal
 # When upstream enables table-across-nodes (multiple dispatchers/captures producing to the same topic),
 # the consumer can see out-of-order DML commitTs. The consumer needs scheduler.enable-table-across-nodes=true
 # to accept and reorder these fallback events instead of dropping them.
-has_config=false
+add_default_config=true
 for arg in "$@"; do
-	if [[ "$arg" == "--config" || "$arg" == --config=* ]]; then
-		has_config=true
+	case "$arg" in
+	--config | --config=*)
+		add_default_config=false
 		break
-	fi
+		;;
+	esac
 done
 
 consumer_config_args=()
-if [[ "$has_config" == "false" ]]; then
+if $add_default_config; then
 	consumer_replica_config="$workdir/pulsar_consumer_replica_config.toml"
 	cat >"$consumer_replica_config" <<-'EOF'
 		[scheduler]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4130

### What is changed and how it works?

When upstream enables table-across-nodes, the Pulsar consumer may observe out-of-order DML commitTs (Pulsar doesn’t guarantee global ordering across multiple producers). If the consumer runs with the default replica config (`scheduler.enable-table-across-nodes=false`), it treats those events as “fallback” and drops them, which can break data consistency checks in Pulsar integration tests.

This PR updates `tests/integration_tests/_utils/run_pulsar_consumer` to automatically inject a minimal replica config enabling `scheduler.enable-table-across-nodes=true` when the caller does not provide `--config`. If `--config` is already provided, the helper respects it and does not override.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test

Manual test:
- Verified `run_pulsar_consumer` injects `--config <workdir>/pulsar_consumer_replica_config.toml` when `--config` is absent.
- Verified `run_pulsar_consumer` does not inject/override config when `--config` is explicitly provided.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This change only affects the integration test helper script.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Pulsar consumer test utility: it now auto-generates a sensible default consumer configuration (enabling cross-node scheduling) when none is supplied, ensures any provided or generated configuration is applied to the consumer invocation, uses safer command-line argument handling to avoid expansion issues, and preserves existing logging and downstream URI handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->