### PR TITLE
logpuller: add context in resolve lock warning log

### DIFF
--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -967,6 +967,7 @@ func (s *subscriptionClient) handleResolveLockTasks(ctx context.Context) error {
 				zap.Uint64("regionID", regionID),
 				zap.Uint64("targetTs", targetTs),
 				zap.Time("lastRun", lastRun),
+				zap.Any("state", state),
 				zap.Error(err))
 		}
 		resolveLastRun[regionID] = time.Now()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4186

### What is changed and how it works?

When `subscription client resolve lock fail` is logged, key runtime context for troubleshooting is missing.
This change keeps the previous behavior and adds more context in the warning log:
- capture `lastRun` once per region before interval checks
- include `targetTs` in the warning log
- include `lastRun` in the warning log

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test (`go test ./logservice/logpuller/...`)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Improve logpuller resolve lock warning logs by including target ts and last run time.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized resolve-lock task handling to ensure timing checks are consistently applied and preserved behavioral outcomes.
  * Improved diagnostic logging on resolve failures to include relevant run timing and state details for better troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->