### PR TITLE
logservice: bound scan lock by region end key

### DIFF
--- a/logservice/txnutil/lock_resolver.go
+++ b/logservice/txnutil/lock_resolver.go
@@ -84,6 +84,7 @@ func (r *resolver) Resolve(ctx context.Context, keyspaceID uint32, regionID uint
 	bo := tikv.NewGcResolveLockMaxBackoffer(ctx)
 	var loc *tikv.KeyLocation
 	var key []byte
+	var endKey []byte
 	flushRegion := func() error {
 		var err error
 		loc, err = kvStorage.GetRegionCache().LocateRegionByID(bo, regionID)
@@ -91,6 +92,7 @@ func (r *resolver) Resolve(ctx context.Context, keyspaceID uint32, regionID uint
 			return err
 		}
 		key = loc.StartKey
+		endKey = loc.EndKey
 		return nil
 	}
 	if err = flushRegion(); err != nil {
@@ -103,6 +105,7 @@ func (r *resolver) Resolve(ctx context.Context, keyspaceID uint32, regionID uint
 		default:
 		}
 		req.ScanLock().StartKey = key
+		req.ScanLock().EndKey = endKey
 		resp, err := kvStorage.SendReq(bo, req, loc.Region, tikv.ReadTimeoutMedium)
 		if err != nil {
 			return errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4192

### What is changed and how it works?

This PR adds an explicit scan boundary for lock resolving in `logservice/txnutil/lock_resolver.go`.

- Cache region `EndKey` together with `StartKey` when locating the region.
- Set `ScanLockRequest.EndKey` on every scan request.
- Keep lock scanning bounded to the target region to avoid returning out-of-region locks in boundary edge cases.

### Check List

#### Tests

- Unit test

`go test ./logservice/txnutil/...`

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only tightens scan range boundaries for existing region-scoped lock resolving.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock scanning efficiency by properly constraining scan operations to appropriate region boundaries, preventing unnecessary checks beyond intended ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->