### PR TITLE
deployments: fix kafka-consumer build on arm64

### DIFF
--- a/deployments/kafka-consumer.Dockerfile
+++ b/deployments/kafka-consumer.Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_LDFLAGS="-lsasl2" make k
 FROM alpine:3.15
 
 # `libsasl` is required at runtime because the vendored `librdkafka` archive is linked with `-lsasl2`.
-RUN apk update && apk add tzdata curl libsasl
+RUN apk add --no-cache tzdata curl libsasl
 
 ENV TZ=Asia/Shanghai
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4198

### What is changed and how it works?

`deployments/kafka-consumer.Dockerfile` fails to build on `linux/arm64` via `docker buildx` due to missing `ld.gold` and SASL dependencies required by the vendored `librdkafka` archive. The resulting image may also fail at runtime due to missing `libsasl2.so.3`.

This PR installs the required packages and ensures the consumer binary is linked and runnable on arm64:
- Install `binutils-gold` and `cyrus-sasl-dev` in the builder stage.
- Link with `-lsasl2` via `CGO_LDFLAGS`.
- Install `libsasl` in the runtime stage.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```bash
docker buildx build --platform linux/arm64 -f deployments/kafka-consumer.Dockerfile -t ticdc/kafka-consumer:local-arm64 --load .
docker run --rm --entrypoint /cdc_kafka_consumer ticdc/kafka-consumer:local-arm64 --help
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kafka consumer deployment to properly support arm64 builds and ensure runtime support for SASL authentication.
  * Runtime image now includes required libraries so SASL-linked consumer runs correctly.
  * Deployment image handling adjusted to include the built consumer binary and ensure the container remains running for operations and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->