### PR TITLE
log puller: reduce unnecessary resolve lock requests

### DIFF
--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -57,6 +57,9 @@ const (
 	resolveLockMinInterval  time.Duration = 10 * time.Second
 	resolveLockTickInterval time.Duration = 2 * time.Second
 	resolveLockFence        time.Duration = 4 * time.Second
+
+	// resolveLastRunGCThreshold is the size threshold to GC resolveLastRun and drop stale entries.
+	resolveLastRunGCThreshold = 1024
 )
 
 var (
@@ -934,9 +937,6 @@ func (s *subscriptionClient) runResolveLockChecker(ctx context.Context) error {
 }
 
 func gcResolveLastRunMap(resolveLastRun map[uint64]time.Time, now time.Time) map[uint64]time.Time {
-	// resolveLastRunGCThreshold is the size threshold to GC resolveLastRun and drop stale entries.
-	const resolveLastRunGCThreshold = 1024
-
 	if len(resolveLastRun) <= resolveLastRunGCThreshold {
 		return resolveLastRun
 	}

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -311,9 +311,9 @@ func TestErrCacheDispatchWithFullChannelAndCanceledContext(t *testing.T) {
 
 func TestGCResolveLastRunMap(t *testing.T) {
 	now := time.Now()
-	resolveLastRun := make(map[uint64]time.Time, resolveLastRunMaxSize+1)
+	resolveLastRun := make(map[uint64]time.Time, resolveLastRunGCThreshold+1)
 	const keep = 10
-	for i := 0; i < resolveLastRunMaxSize+1; i++ {
+	for i := 0; i < resolveLastRunGCThreshold+1; i++ {
 		lastRunTime := now.Add(-2 * resolveLockMinInterval)
 		if i < keep {
 			lastRunTime = now.Add(-resolveLockMinInterval / 2)


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4241 

### What is changed and how it works?

* **New Constant for Map Size Limit**: Introduced a new constant, `resolveLastRunMaxSize`, set to 1024, to define the maximum allowable size for the `resolveLastRun` map before triggering garbage collection.
* **Refactored Garbage Collection Logic**: Extracted the anonymous garbage collection function for the `resolveLastRun` map into a dedicated, top-level function named `gcResolveLastRunMap`, improving modularity and testability.
* **Updated Map Handling**: Modified the `handleResolveLockTasks` function to utilize the newly extracted `gcResolveLastRunMap` for managing and cleaning the `resolveLastRun` map, ensuring its size is constrained.
* **New Unit Test**: Added a new unit test, `TestGCResolveLastRunMap`, to thoroughly validate the correctness and behavior of the `gcResolveLastRunMap` function, especially concerning its size management and element retention logic.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved per-region resolve caching to throttle repeated resolve attempts and reduce unnecessary work.
  * Added periodic cleanup of stale cache entries to keep memory usage bounded.

* **Tests**
  * Added test coverage for the cache cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->