### PR TITLE
MysqlSink: Reduce the backoff duration of DML retry

### DIFF
--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -73,9 +73,9 @@ const (
 	defaultCharacterSet   = "utf8mb4"
 
 	// BackoffBaseDelay indicates the base delay time for retrying.
-	BackoffBaseDelay = 500 * time.Millisecond
+	BackoffBaseDelay = 100 * time.Millisecond
 	// BackoffMaxDelay indicates the max delay time for retrying.
-	BackoffMaxDelay = 60 * time.Second
+	BackoffMaxDelay = 5 * time.Second
 
 	defaultBatchDMLEnable  = true
 	defaultMultiStmtEnable = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/4247

### What is changed and how it works?

This pull request optimizes the DML retry mechanism within the MySQL sink by adjusting the backoff durations. The changes aim to accelerate the retry process for failed DML operations, potentially improving the responsiveness and throughput of the sink by reducing the time spent waiting between retry attempts.

### Highlights

* **DML Retry Backoff Duration**: The base delay for DML retries has been significantly reduced from 500 milliseconds to 100 milliseconds, and the maximum delay has been decreased from 60 seconds to 5 seconds.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL connection retry efficiency by reducing initial and maximum retry delay times, enabling faster recovery from connection failures and reducing overall system downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->