### PR TITLE
tests: rebalance heavy integration test groups

### DIFF
--- a/tests/integration_tests/run_heavy_it_in_ci.sh
+++ b/tests/integration_tests/run_heavy_it_in_ci.sh
@@ -32,15 +32,15 @@ mysql_groups=(
 	# G00
 	'api_v2 generate_column many_pk_or_uk multi_source'
 	# G01
-	'ddl_for_split_tables_with_random_move_table'
+	'ddl_for_split_tables_with_random_move_table syncpoint_check_ts random_drop_message'
 	# G02
-	'ddl_for_split_tables_with_failover'
+	'ddl_for_split_tables_with_failover in_flight_syncpoint_during_scheduling '
 	# G03
 	'cdc move_table in_flight_ddl_during_scheduling checkpoint_race_ddl_crash'
 	# G04
 	'complex_transaction'
 	# G05
-	'ddl_for_split_tables_with_merge_and_split syncpoint in_flight_syncpoint_during_scheduling syncpoint_check_ts random_drop_message'
+	'ddl_for_split_tables_with_merge_and_split syncpoint'
 	# G06
 	'ddl_for_split_tables_with_random_merge_and_split'
 	# G07


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #4255

### What is changed and how it works?
- Rebalanced heavy integration test groups in `tests/integration_tests/run_heavy_it_in_ci.sh`.
- Moved `syncpoint_check_ts` and `random_drop_message` from G05 to G01.
- Moved `in_flight_syncpoint_during_scheduling` from G05 to G02.
- Kept G05 focused on `ddl_for_split_tables_with_merge_and_split syncpoint` to reduce tail runtime.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for MySQL database operations, including additional scenarios for synchronization and failover procedures to enhance overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->