### PR TITLE
logpuller: fix filterLoop flag propagation for stop tasks

### DIFF
--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -48,7 +48,7 @@ func TestGenerateResolveLockTask(t *testing.T) {
 	}
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
-	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0)
+	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, false)
 	client.totalSpans.spanMap = make(map[SubscriptionID]*subscribedSpan)
 	client.totalSpans.spanMap[SubscriptionID(1)] = span
 	client.pdClock = pdutil.NewClock4Test()
@@ -117,7 +117,7 @@ func TestResolveLockTaskDroppedWhenChannelFull(t *testing.T) {
 	}
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
-	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0)
+	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, false)
 
 	res := span.rangeLock.LockRange(context.Background(), []byte{'b'}, []byte{'c'}, 1, 100)
 	require.Equal(t, regionlock.LockRangeStatusSuccess, res.Status)
@@ -147,6 +147,38 @@ func TestResolveLockTaskDroppedWhenChannelFull(t *testing.T) {
 
 	<-client.resolveLockTaskCh
 	close(client.resolveLockTaskCh)
+}
+
+func TestStopTaskUsesSubscribedSpanFilterLoop(t *testing.T) {
+	client := &subscriptionClient{
+		resolveLockTaskCh: make(chan resolveLockTask, 1),
+		regionTaskQueue:   NewPriorityQueue(),
+	}
+	client.ctx, client.cancel = context.WithCancel(context.Background())
+	defer client.cancel()
+	client.pdClock = pdutil.NewClock4Test()
+
+	rawSpan := heartbeatpb.TableSpan{
+		TableID:  1,
+		StartKey: []byte{'a'},
+		EndKey:   []byte{'z'},
+	}
+	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
+	advanceResolvedTs := func(ts uint64) {}
+	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, true)
+
+	res := span.rangeLock.LockRange(context.Background(), rawSpan.StartKey, rawSpan.EndKey, 1, 1)
+	require.Equal(t, regionlock.LockRangeStatusSuccess, res.Status)
+
+	client.setTableStopped(span)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	task, err := client.regionTaskQueue.Pop(ctx)
+	require.NoError(t, err)
+	region := task.GetRegionInfo()
+	require.True(t, region.isStopped())
+	require.True(t, region.filterLoop)
 }
 
 func TestSubscriptionWithFailedTiKV(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4261

### What is changed and how it works?

This pull request addresses an issue related to filtering data loops in TiCDC, particularly in Bi-Directional Replication (BDR) scenarios. It introduces a `filterLoop` flag within the subscription mechanism to correctly identify and filter out data written by TiCDC itself, preventing infinite replication loops. The changes ensure that this critical filtering state is properly initialized and propagated across various internal components, enhancing the robustness of the replication process.

### Highlights

* **Added `filterLoop` field to `subscribedSpan`**: A new boolean field `filterLoop` was added to the `subscribedSpan` struct. This field indicates whether to filter out values written by TiCDC itself, primarily for BDR (Bi-Directional Replication) mode.
* **Propagated `filterLoop` in `newSubscribedSpan`**: The `newSubscribedSpan` function was updated to accept a `filterLoop` parameter, ensuring that this value is correctly initialized when a new `subscribedSpan` is created.
* **Ensured `filterLoop` consistency in tasks**: The `filterLoop` value is now consistently passed through `rangeTask` and `regionInfo` structures, ensuring that the filtering logic is applied throughout the subscription lifecycle, especially when stopping tables.
* **Updated unit tests**: Existing unit tests were modified to accommodate the new `filterLoop` parameter in `newSubscribedSpan` calls, and a new test case `TestStopTaskUsesSubscribedSpanFilterLoop` was added to verify correct propagation of the `filterLoop` value when a table is stopped.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced filtering logic for Bi-Directional Replication mode to better track TiCDC-generated values in subscription operations.

* **Tests**
  * Added test coverage to verify filtering behavior is correctly applied when managing subscribed table regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->