### PR TITLE
dispatchermanager: avoid redo init nil pointer panic

### DIFF
--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -47,6 +47,9 @@ func initRedoComponet(
 	}
 	manager.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()
 	manager.redoSink = redo.New(ctx, changefeedID, manager.config.Consistent)
+	if manager.redoSink == nil {
+		return errors.WrapError(errors.ErrStorageInitialize, errors.New("redo sink initialization returned nil"))
+	}
 	manager.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
 	// Publish redo availability only after all redo components are initialized,
 	// so scheduler precheck won't observe a partially initialized manager.

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -251,6 +251,7 @@ func (h *SchedulerDispatcherRequestHandler) Handle(dispatcherManager *Dispatcher
 
 func isRedoDispatcherManagerReady(dispatcherManager *DispatcherManager) bool {
 	return dispatcherManager.RedoEnable &&
+		dispatcherManager.redoSink != nil &&
 		dispatcherManager.redoDispatcherMap != nil &&
 		dispatcherManager.redoSchemaIDToDispatchers != nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/4271

### What is changed and how it works?

This pull request enhances the robustness of the redo dispatcher manager by addressing potential nil pointer panics during its initialization and subsequent pre-check operations. The changes ensure that redo-related components are fully prepared and validated before being utilized, thereby improving the stability of the system when operating in redo mode.

### Highlights

* **Redo Component Initialization**: Reordered the initialization sequence for redo components to ensure `RedoEnable` is set to true only after all necessary redo structures (`redoDispatcherMap`, `redoSink`, `redoSchemaIDToDispatchers`) are fully initialized, preventing potential nil pointer panics.
* **Scheduler Pre-check Enhancement**: Expanded the pre-check logic for scheduler requests in redo mode to include a nil check for `dispatcherManager.redoSchemaIDToDispatchers`, adding an extra layer of safety against nil pointer dereferences during scheduler operations.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initialization timing for redo functionality adjusted so availability is announced only after full setup, preventing premature scheduling checks.
  * Readiness validation for redo mode strengthened to require all necessary components be initialized before allowing redo operations, improving stability and preventing partial-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->