### PR TITLE
integration_tests: skip in_flight_syncpoint test in next-gen

### DIFF
--- a/tests/integration_tests/in_flight_syncpoint_during_scheduling/run.sh
+++ b/tests/integration_tests/in_flight_syncpoint_during_scheduling/run.sh
@@ -34,7 +34,7 @@ run() {
 		return
 	fi
 
-# TODO tenfyzhong 2026-02-26 16:17:25 Need to be compatible with next gen mode
+	# TODO tenfyzhong 2026-02-26 16:17:25 Need to be compatible with next gen mode
 	if [ "${NEXT_GEN:-0}" = "1" ]; then
 		return
 	fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4280

### What is changed and how it works?

- Skip `in_flight_syncpoint_during_scheduling` when `NEXT_GEN=1`.
- Keep the existing test flow unchanged when next-gen mode is disabled.
- Add a TODO marker for implementing full next-gen compatibility.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```bash
bash -n tests/integration_tests/in_flight_syncpoint_during_scheduling/run.sh
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This change only affects integration test gating under next-gen mode.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated an integration test to skip execution when a specific feature flag is enabled, preventing unnecessary test runs under that configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->