### PR TITLE
maintainer: avoid racy field access in schedule test

### DIFF
--- a/maintainer/maintainer_test.go
+++ b/maintainer/maintainer_test.go
@@ -330,7 +330,8 @@ func TestMaintainerSchedule(t *testing.T) {
 	maintainer.pushEvent(&Event{changefeedID: cfID, eventType: EventInit})
 
 	require.Eventually(t, func() bool {
-		return maintainer.ddlSpan.IsWorking() && maintainer.postBootstrapMsg == nil
+		// Avoid reading non-atomic internal fields from the test goroutine.
+		return maintainer.ddlSpan.IsWorking() && maintainer.initialized.Load()
 	}, 20*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #4297

`TestMaintainerSchedule` reads `maintainer.postBootstrapMsg` from the test goroutine while the maintainer event loop writes it, which causes race-detector flakes.


### What is changed and how it works?
- Replace the `Eventually` check to avoid reading non-atomic internal field directly.
- Use `maintainer.initialized.Load()` together with `maintainer.ddlSpan.IsWorking()`.

### Tests
- `go test -race ./maintainer -run '^TestMaintainerSchedule$' -count=50`

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
