### PR TITLE
Remove pingcap/check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pierrec/lz4/v4 v4.1.21
-	github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/kvproto v0.0.0-20251109100001-1907922fbd18
@@ -285,6 +284,7 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pingcap/badger v1.5.1-0.20241015064302-38533b6cbf8d // indirect
+	github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0 // indirect
 	github.com/pingcap/fn v1.0.0 // indirect
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect
 	github.com/pingcap/metering_sdk v0.0.0-20251110022152-dac449ac5389 // indirect

--- a/pkg/diff/chunk_test.go
+++ b/pkg/diff/chunk_test.go
@@ -100,14 +100,10 @@ func TestChunkToString(t *testing.T) {
 	conditions, args := chunk.toString("")
 	require.Equal(t, "((`a` > ?) OR (`a` = ? AND `b` > ?) OR (`a` = ? AND `b` = ? AND `c` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` < ?) OR (`a` = ? AND `b` = ? AND `c` <= ?))", conditions)
 	expectArgs := []string{"1", "1", "3", "1", "3", "5", "2", "2", "4", "2", "4", "6"}
-	for i, arg := range args {
-		require.Equal(t, expectArgs[i], arg)
-	}
+	require.Equal(t, expectArgs, args)
 
 	conditions, args = chunk.toString("latin1")
 	require.Equal(t, "((`a` COLLATE 'latin1' > ?) OR (`a` = ? AND `b` COLLATE 'latin1' > ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE 'latin1' > ?)) AND ((`a` COLLATE 'latin1' < ?) OR (`a` = ? AND `b` COLLATE 'latin1' < ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE 'latin1' <= ?))", conditions)
 	expectArgs = []string{"1", "1", "3", "1", "3", "5", "2", "2", "4", "2", "4", "6"}
-	for i, arg := range args {
-		require.Equal(t, expectArgs[i], arg)
-	}
+	require.Equal(t, expectArgs, args)
 }

--- a/pkg/diff/chunk_test.go
+++ b/pkg/diff/chunk_test.go
@@ -14,14 +14,12 @@
 package diff
 
 import (
-	"github.com/pingcap/check"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-var _ = check.Suite(&testChunkSuite{})
-
-type testChunkSuite struct{}
-
-func (*testChunkSuite) TestChunkUpdate(c *check.C) {
+func TestChunkUpdate(t *testing.T) {
 	chunk := &ChunkRange{
 		Bounds: []*Bound{
 			{
@@ -63,18 +61,18 @@ func (*testChunkSuite) TestChunkUpdate(c *check.C) {
 	for _, cs := range testCases {
 		newChunk := chunk.copyAndUpdate(cs.boundArgs[0], cs.boundArgs[1], cs.boundArgs[2])
 		conditions, args := newChunk.toString("")
-		c.Assert(conditions, check.Equals, cs.expectStr)
-		c.Assert(args, check.DeepEquals, cs.expectArgs)
+		require.Equal(t, cs.expectStr, conditions)
+		require.Equal(t, cs.expectArgs, args)
 	}
 
 	// the origin chunk is not changed
 	conditions, args := chunk.toString("")
-	c.Assert(conditions, check.Equals, "((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))")
+	require.Equal(t, "((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))", conditions)
 	expectArgs := []string{"1", "1", "3", "2", "2", "4"}
-	c.Assert(args, check.DeepEquals, expectArgs)
+	require.Equal(t, expectArgs, args)
 }
 
-func (*testChunkSuite) TestChunkToString(c *check.C) {
+func TestChunkToString(t *testing.T) {
 	chunk := &ChunkRange{
 		Bounds: []*Bound{
 			{
@@ -100,16 +98,16 @@ func (*testChunkSuite) TestChunkToString(c *check.C) {
 	}
 
 	conditions, args := chunk.toString("")
-	c.Assert(conditions, check.Equals, "((`a` > ?) OR (`a` = ? AND `b` > ?) OR (`a` = ? AND `b` = ? AND `c` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` < ?) OR (`a` = ? AND `b` = ? AND `c` <= ?))")
+	require.Equal(t, "((`a` > ?) OR (`a` = ? AND `b` > ?) OR (`a` = ? AND `b` = ? AND `c` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` < ?) OR (`a` = ? AND `b` = ? AND `c` <= ?))", conditions)
 	expectArgs := []string{"1", "1", "3", "1", "3", "5", "2", "2", "4", "2", "4", "6"}
 	for i, arg := range args {
-		c.Assert(arg, check.Equals, expectArgs[i])
+		require.Equal(t, expectArgs[i], arg)
 	}
 
 	conditions, args = chunk.toString("latin1")
-	c.Assert(conditions, check.Equals, "((`a` COLLATE 'latin1' > ?) OR (`a` = ? AND `b` COLLATE 'latin1' > ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE 'latin1' > ?)) AND ((`a` COLLATE 'latin1' < ?) OR (`a` = ? AND `b` COLLATE 'latin1' < ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE 'latin1' <= ?))")
+	require.Equal(t, "((`a` COLLATE 'latin1' > ?) OR (`a` = ? AND `b` COLLATE 'latin1' > ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE 'latin1' > ?)) AND ((`a` COLLATE 'latin1' < ?) OR (`a` = ? AND `b` COLLATE 'latin1' < ?) OR (`a` = ? AND `b` = ? AND `c` COLLATE 'latin1' <= ?))", conditions)
 	expectArgs = []string{"1", "1", "3", "1", "3", "5", "2", "2", "4", "2", "4", "6"}
 	for i, arg := range args {
-		c.Assert(arg, check.Equals, expectArgs[i])
+		require.Equal(t, expectArgs[i], arg)
 	}
 }

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -17,24 +17,16 @@ import (
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/util/dbutil"
 	"github.com/pingcap/tidb/pkg/util/dbutil/dbutiltest"
+	"github.com/stretchr/testify/require"
 )
 
-func TestClient(t *testing.T) {
-	check.TestingT(t)
-}
-
-var _ = check.Suite(&testDiffSuite{})
-
-type testDiffSuite struct{}
-
-func (*testDiffSuite) TestGenerateSQLs(c *check.C) {
+func TestGenerateSQLs(t *testing.T) {
 	createTableSQL := "CREATE TABLE `diff_test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), `id_gen` int(11) GENERATED ALWAYS AS ((`id` + 1)) VIRTUAL, primary key(`id`, `name`))"
 	tableInfo, err := dbutiltest.GetTableInfoBySQL(createTableSQL, parser.New())
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	rowsData := map[string]*dbutil.ColumnData{
 		"id":          {Data: []byte("1"), IsNull: false},
@@ -47,40 +39,40 @@ func (*testDiffSuite) TestGenerateSQLs(c *check.C) {
 
 	replaceSQL := generateDML("replace", rowsData, tableInfo, "diff_test")
 	deleteSQL := generateDML("delete", rowsData, tableInfo, "diff_test")
-	c.Assert(replaceSQL, check.Equals, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,'xxx','2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, check.Equals, "DELETE FROM `diff_test`.`atest` WHERE `id` = 1 AND `name` = 'xxx' AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;")
+	require.Equal(t, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,'xxx','2018-01-01 00:00:00','10:10:10',11.1111);", replaceSQL)
+	require.Equal(t, "DELETE FROM `diff_test`.`atest` WHERE `id` = 1 AND `name` = 'xxx' AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;", deleteSQL)
 
 	// test the unique key
 	createTableSQL2 := "CREATE TABLE `diff_test`.`atest` (`id` int(24), `name` varchar(24), `birthday` datetime, `update_time` time, `money` decimal(20,2), unique key(`id`, `name`))"
 	tableInfo2, err := dbutiltest.GetTableInfoBySQL(createTableSQL2, parser.New())
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	replaceSQL = generateDML("replace", rowsData, tableInfo2, "diff_test")
 	deleteSQL = generateDML("delete", rowsData, tableInfo2, "diff_test")
-	c.Assert(replaceSQL, check.Equals, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,'xxx','2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, check.Equals, "DELETE FROM `diff_test`.`atest` WHERE `id` = 1 AND `name` = 'xxx' AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;")
+	require.Equal(t, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,'xxx','2018-01-01 00:00:00','10:10:10',11.1111);", replaceSQL)
+	require.Equal(t, "DELETE FROM `diff_test`.`atest` WHERE `id` = 1 AND `name` = 'xxx' AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;", deleteSQL)
 
 	// test value is nil
 	rowsData["name"] = &dbutil.ColumnData{Data: []byte(""), IsNull: true}
 	replaceSQL = generateDML("replace", rowsData, tableInfo, "diff_test")
 	deleteSQL = generateDML("delete", rowsData, tableInfo, "diff_test")
-	c.Assert(replaceSQL, check.Equals, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, check.Equals, "DELETE FROM `diff_test`.`atest` WHERE `id` = 1 AND `name` is NULL AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;")
+	require.Equal(t, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (1,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);", replaceSQL)
+	require.Equal(t, "DELETE FROM `diff_test`.`atest` WHERE `id` = 1 AND `name` is NULL AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;", deleteSQL)
 
 	rowsData["id"] = &dbutil.ColumnData{Data: []byte(""), IsNull: true}
 	replaceSQL = generateDML("replace", rowsData, tableInfo, "diff_test")
 	deleteSQL = generateDML("delete", rowsData, tableInfo, "diff_test")
-	c.Assert(replaceSQL, check.Equals, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, check.Equals, "DELETE FROM `diff_test`.`atest` WHERE `id` is NULL AND `name` is NULL AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;")
+	require.Equal(t, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,NULL,'2018-01-01 00:00:00','10:10:10',11.1111);", replaceSQL)
+	require.Equal(t, "DELETE FROM `diff_test`.`atest` WHERE `id` is NULL AND `name` is NULL AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;", deleteSQL)
 
 	// test value with "'"
 	rowsData["name"] = &dbutil.ColumnData{Data: []byte("a'a"), IsNull: false}
 	replaceSQL = generateDML("replace", rowsData, tableInfo, "diff_test")
 	deleteSQL = generateDML("delete", rowsData, tableInfo, "diff_test")
-	c.Assert(replaceSQL, check.Equals, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,'a\\'a','2018-01-01 00:00:00','10:10:10',11.1111);")
-	c.Assert(deleteSQL, check.Equals, "DELETE FROM `diff_test`.`atest` WHERE `id` is NULL AND `name` = 'a\\'a' AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;")
+	require.Equal(t, "REPLACE INTO `diff_test`.`atest`(`id`,`name`,`birthday`,`update_time`,`money`) VALUES (NULL,'a\\'a','2018-01-01 00:00:00','10:10:10',11.1111);", replaceSQL)
+	require.Equal(t, "DELETE FROM `diff_test`.`atest` WHERE `id` is NULL AND `name` = 'a\\'a' AND `birthday` = '2018-01-01 00:00:00' AND `update_time` = '10:10:10' AND `money` = 11.1111;", deleteSQL)
 }
 
-func (*testDiffSuite) TestConfigHash(c *check.C) {
+func TestConfigHash(t *testing.T) {
 	tbDiff := &TableDiff{
 		Range:     "a > 1",
 		ChunkSize: 1000,
@@ -91,10 +83,10 @@ func (*testDiffSuite) TestConfigHash(c *check.C) {
 	tbDiff.CheckThreadCount = 10
 	tbDiff.setConfigHash()
 	hash2 := tbDiff.configHash
-	c.Assert(hash1, check.Equals, hash2)
+	require.Equal(t, hash2, hash1)
 
 	tbDiff.Range = "b < 10"
 	tbDiff.setConfigHash()
 	hash3 := tbDiff.configHash
-	c.Assert(hash1 == hash3, check.Equals, false)
+	require.NotEqual(t, hash1, hash3)
 }

--- a/pkg/diff/merge_test.go
+++ b/pkg/diff/merge_test.go
@@ -15,21 +15,18 @@ package diff
 
 import (
 	"container/heap"
+	"testing"
 
-	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/util/dbutil"
 	"github.com/pingcap/tidb/pkg/util/dbutil/dbutiltest"
+	"github.com/stretchr/testify/require"
 )
 
-var _ = check.Suite(&testMergerSuite{})
-
-type testMergerSuite struct{}
-
-func (s *testMergerSuite) TestMerge(c *check.C) {
+func TestMerge(t *testing.T) {
 	createTableSQL := "create table test.test(id int(24), name varchar(24), age int(24), primary key(id, name));"
 	tableInfo, err := dbutiltest.GetTableInfoBySQL(createTableSQL, parser.New())
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	_, orderKeyCols := dbutil.SelectUniqueOrderKey(tableInfo)
 	ids := []string{"3", "2", "2", "4", "1", "NULL"}
@@ -60,7 +57,7 @@ func (s *testMergerSuite) TestMerge(c *check.C) {
 		rowData := heap.Pop(rowDatas).(RowData)
 		id := string(rowData.Data["id"].Data)
 		name := string(rowData.Data["name"].Data)
-		c.Assert(id, check.Equals, expectIDs[i])
-		c.Assert(name, check.Equals, expectNames[i])
+		require.Equal(t, expectIDs[i], id)
+		require.Equal(t, expectNames[i], name)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4301 

This removes pingcap/check as direct dependency. Most of this repo already is using testify.

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Migrated test infrastructure from gocheck to Go's standard testing framework with testify assertions for improved maintainability and consistency.

* **Chores**
  * Updated dependency management by transitioning pingcap/check to an indirect dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->