### PR TITLE
consumer: dedupe replayed DML by applied watermark

### DIFF
--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -150,6 +150,12 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 	tableIDs := w.getBlockTableIDs(ddl)
 	commitTs := ddl.GetCommitTs()
 	resolvedEvents := make([]*commonEvent.DMLEvent, 0)
+	// resolvedGroups records which EventsGroup has flushed events so we can
+	// advance its AppliedWatermark after the flush is fully finished.
+	resolvedGroups := make([]struct {
+		group       *util.EventsGroup
+		maxCommitTs uint64
+	}, 0)
 	for tableID := range tableIDs {
 		for _, progress := range w.progresses {
 			g, ok := progress.eventsGroup[tableID]
@@ -158,7 +164,19 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 			}
 			before := len(resolvedEvents)
 			resolvedEvents = g.ResolveInto(commitTs, resolvedEvents)
-			total += len(resolvedEvents) - before
+			resolvedCount := len(resolvedEvents) - before
+			if resolvedCount == 0 {
+				continue
+			}
+
+			resolvedGroups = append(resolvedGroups, struct {
+				group       *util.EventsGroup
+				maxCommitTs uint64
+			}{
+				group:       g,
+				maxCommitTs: resolvedEvents[len(resolvedEvents)-1].GetCommitTs(),
+			})
+			total += resolvedCount
 		}
 	}
 
@@ -186,6 +204,11 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 			log.Info("flush DML events before DDL done", zap.Uint64("DDLCommitTs", commitTs),
 				zap.Int("total", total), zap.Duration("duration", time.Since(start)),
 				zap.Any("tables", tableIDs))
+			for _, item := range resolvedGroups {
+				if item.maxCommitTs > item.group.AppliedWatermark {
+					item.group.AppliedWatermark = item.maxCommitTs
+				}
+			}
 			return w.mysqlSink.WriteBlockEvent(ddl)
 		case <-ticker.C:
 			log.Warn("DML events cannot be flushed in time",
@@ -263,11 +286,29 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 
 	watermark := w.globalWatermark()
 	resolvedEvents := make([]*commonEvent.DMLEvent, 0)
+	// resolvedGroups records which EventsGroup has flushed events so we can
+	// advance its AppliedWatermark after the flush is fully finished.
+	resolvedGroups := make([]struct {
+		group       *util.EventsGroup
+		maxCommitTs uint64
+	}, 0)
 	for _, p := range w.progresses {
 		for _, group := range p.eventsGroup {
 			before := len(resolvedEvents)
 			resolvedEvents = group.ResolveInto(watermark, resolvedEvents)
-			total += len(resolvedEvents) - before
+			resolvedCount := len(resolvedEvents) - before
+			if resolvedCount == 0 {
+				continue
+			}
+
+			resolvedGroups = append(resolvedGroups, struct {
+				group       *util.EventsGroup
+				maxCommitTs uint64
+			}{
+				group:       group,
+				maxCommitTs: resolvedEvents[len(resolvedEvents)-1].GetCommitTs(),
+			})
+			total += resolvedCount
 		}
 	}
 	if total == 0 {
@@ -293,6 +334,11 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 		case <-done:
 			log.Info("flush DML events done", zap.Uint64("watermark", watermark),
 				zap.Int("total", total), zap.Duration("duration", time.Since(start)))
+			for _, item := range resolvedGroups {
+				if item.maxCommitTs > item.group.AppliedWatermark {
+					item.group.AppliedWatermark = item.maxCommitTs
+				}
+			}
 			return nil
 		case <-ticker.C:
 			log.Warn("DML events cannot be flushed in time", zap.Uint64("watermark", watermark),
@@ -464,48 +510,33 @@ func (w *writer) appendRow2Group(dml *commonEvent.DMLEvent, progress *partitionP
 		group = util.NewEventsGroup(progress.partition, tableID)
 		progress.eventsGroup[tableID] = group
 	}
-	if commitTs < progress.watermark {
-		log.Warn("DML Event fallback row, since less than the partition watermark, ignore it",
+	if commitTs <= group.AppliedWatermark {
+		log.Warn("DML event replayed after applied, ignore it",
 			zap.Int64("tableID", tableID), zap.Int32("partition", group.Partition),
-			zap.Uint64("commitTs", commitTs), zap.Uint64("watermark", progress.watermark),
-			zap.String("schema", schema), zap.String("table", table))
+			zap.Uint64("commitTs", commitTs),
+			zap.Uint64("appliedWatermark", group.AppliedWatermark), zap.Uint64("highWatermark", group.HighWatermark),
+			zap.Uint64("partitionWatermark", progress.watermark),
+			zap.String("schema", schema), zap.String("table", table), zap.Any("protocol", w.protocol))
 		return
 	}
-	if commitTs >= group.HighWatermark {
-		group.Append(dml, false)
-		log.Info("DML event append to the group",
+	forceInsert := commitTs < group.HighWatermark || commitTs < progress.watermark || w.enableTableAcrossNodes
+	if forceInsert {
+		log.Warn("DML event commit ts fallback, append with forceInsert",
+			zap.Int32("partition", group.Partition),
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
+			zap.Uint64("appliedWatermark", group.AppliedWatermark),
+			zap.Uint64("partitionWatermark", progress.watermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
-			zap.Stringer("eventType", dml.RowTypes[0]))
-		return
-	}
-	if w.enableTableAcrossNodes {
-		log.Warn("DML events fallback, but enableTableAcrossNodes is true, still append it",
-			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
-			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
-			zap.Stringer("eventType", dml.RowTypes[0]))
+			zap.Stringer("eventType", dml.RowTypes[0]), zap.Any("protocol", w.protocol),
+			zap.Bool("IsPartition", dml.TableInfo.TableName.IsPartition))
 		group.Append(dml, true)
 		return
 	}
-	switch w.protocol {
-	case config.ProtocolCanalJSON:
-		// for partition table, the canal-json message cannot assign physical table id to each dml message,
-		// we cannot distinguish whether it's a real fallback event or not, still append it.
-		if w.partitionTableAccessor.IsPartitionTable(schema, table) {
-			log.Warn("DML events fallback, but it's canal-json and partition table, still append it",
-				zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
-				zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
-				zap.Stringer("eventType", dml.RowTypes[0]))
-			group.Append(dml, true)
-			return
-		}
-		log.Warn("DML event fallback row, since less than the group high watermark, ignore it",
-			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
-			zap.Any("partitionWatermark", progress.watermark), zap.Any("watermark", progress.watermark),
-			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
-			zap.Stringer("eventType", dml.RowTypes[0]),
-			zap.Any("protocol", w.protocol), zap.Bool("IsPartition", dml.TableInfo.TableName.IsPartition))
-	default:
-		log.Panic("unknown protocol", zap.Any("protocol", w.protocol))
-	}
+	group.Append(dml, false)
+	log.Info("DML event append to the group",
+		zap.Int32("partition", group.Partition),
+		zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
+		zap.Uint64("appliedWatermark", group.AppliedWatermark),
+		zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
+		zap.Stringer("eventType", dml.RowTypes[0]))
 }

--- a/cmd/pulsar-consumer/writer_test.go
+++ b/cmd/pulsar-consumer/writer_test.go
@@ -17,11 +17,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/ticdc/cmd/util"
 	"github.com/pingcap/ticdc/downstreamadapter/sink"
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/config"
 	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
 	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -273,4 +276,59 @@ func TestWriterWrite_handlesOutOfOrderDDLsByCommitTs(t *testing.T) {
 	}, s.ddls)
 	require.Len(t, w.ddlList, 1)
 	require.Equal(t, "CREATE TABLE `common_1`.`a` (`a` BIGINT PRIMARY KEY,`b` INT)", w.ddlList[0].Query)
+}
+
+func TestAppendRow2Group_DoesNotDropCommitTsFallbackBeforeApplied(t *testing.T) {
+	// Scenario:
+	// 1) TiCDC writes DML messages to Pulsar in commitTs order.
+	// 2) Under network partition / changefeed restart, TiCDC may replay older commitTs
+	//    at a later time (commitTs appears to go backwards).
+	//
+	// The pulsar-consumer must not drop these "fallback commitTs" events unless they
+	// have already been flushed to downstream (AppliedWatermark), otherwise replayed
+	// messages cannot heal missing windows.
+	w := &writer{
+		progresses: []*partitionProgress{
+			{
+				partition:   0,
+				eventsGroup: make(map[int64]*util.EventsGroup),
+			},
+		},
+		protocol:               config.ProtocolCanalJSON,
+		partitionTableAccessor: codeccommon.NewPartitionTableAccessor(),
+	}
+
+	newDMLEvent := func(tableID int64, commitTs uint64) *commonEvent.DMLEvent {
+		return &commonEvent.DMLEvent{
+			PhysicalTableID: tableID,
+			CommitTs:        commitTs,
+			RowTypes:        []common.RowType{common.RowTypeUpdate},
+			Rows:            chunk.NewChunkWithCapacity(nil, 0),
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "test", Table: "t"},
+			},
+		}
+	}
+
+	progress := w.progresses[0]
+
+	// Step 1: observe a larger commitTs first (e.g. produced before restart).
+	w.appendRow2Group(newDMLEvent(1, 200), progress)
+
+	// Step 2: observe a smaller commitTs later (e.g. replayed after restart).
+	w.appendRow2Group(newDMLEvent(1, 100), progress)
+
+	group := progress.eventsGroup[1]
+	require.NotNil(t, group)
+
+	// Expect: commitTs=100 is still kept and can be resolved.
+	resolved := group.ResolveInto(150, nil)
+	require.Len(t, resolved, 1)
+	require.Equal(t, uint64(100), resolved[0].CommitTs)
+
+	// Step 3: once downstream has flushed beyond commitTs=100, replay is safe to ignore.
+	group.AppliedWatermark = 200
+	w.appendRow2Group(newDMLEvent(1, 100), progress)
+	resolved = group.ResolveInto(150, nil)
+	require.Empty(t, resolved)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4051

### What is changed and how it works?
pulsar consumer also needs to be fixed
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved event flushing logic with enhanced watermark tracking and advancement per event group.
  * Simplified event append handling with unified error recovery path and better logging for diagnostics.

* **Tests**
  * Added test coverage for event replay scenarios with out-of-order commit timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->