### PR TITLE
maintainer: enforce two phase barrier ordering

### DIFF
--- a/maintainer/barrier.go
+++ b/maintainer/barrier.go
@@ -178,12 +178,11 @@ func (b *Barrier) handleBootstrapResponse(bootstrapRespMap map[node.ID]*heartbea
 				// it's the maintainer's responsibility to resend the write action
 				event.selected.Store(true)
 				event.writerDispatcher = common.NewDispatcherIDFromPB(span.ID)
-				event.nonWriterDispatchersAdvanced = true
+				event.phase = barrierEventPhaseWrite
 			case heartbeatpb.BlockStage_DONE:
 				// it's the maintainer's responsibility to resend the pass action
 				event.selected.Store(true)
-				event.writerDispatcherAdvanced = true
-				event.nonWriterDispatchersAdvanced = true
+				event.phase = barrierEventPhasePostWrite
 			}
 			event.markDispatcherEventDone(common.NewDispatcherIDFromPB(span.ID))
 		}
@@ -305,7 +304,7 @@ func (b *Barrier) handleEventDone(changefeedID common.ChangeFeedID, dispatcherID
 	// the writer already synced ddl to downstream
 	if event.writerDispatcher == dispatcherID {
 		if event.needSchedule {
-			// we need do schedule when writerDispatcherAdvanced
+			// we need do schedule when the writer dispatcher reports done
 			// Otherwise, if we do schedule when just selected = true, then ask dispatcher execute ddl
 			// when meeting truncate table,
 			// there is possible that dml for the new table will arrive before truncate ddl executed.
@@ -317,7 +316,7 @@ func (b *Barrier) handleEventDone(changefeedID common.ChangeFeedID, dispatcherID
 			}
 		} else {
 			// the pass action will be sent periodically in resend logic if not acked
-			event.writerDispatcherAdvanced = true
+			event.phase = barrierEventPhasePostWrite
 			event.lastResendTime = time.Now().Add(-20 * time.Second)
 		}
 	}
@@ -406,7 +405,7 @@ func (b *Barrier) getOrInsertNewEvent(changefeedID common.ChangeFeedID, dispatch
 // check whether the event is get all the done message from dispatchers
 // if so, remove the event from blockedTs, not need to resend message anymore
 func (b *Barrier) checkEventFinish(be *BarrierEvent) {
-	if !be.writerDispatcherAdvanced {
+	if be.phase != barrierEventPhasePostWrite {
 		return
 	}
 	if !be.allDispatcherReported() {
@@ -450,7 +449,7 @@ func (b *Barrier) tryScheduleEvent(event *BarrierEvent) bool {
 		return false
 	}
 	event.scheduleBlockEvent()
-	event.writerDispatcherAdvanced = true
+	event.phase = barrierEventPhasePostWrite
 	event.lastResendTime = time.Now().Add(-20 * time.Second)
 	return true
 }

--- a/maintainer/barrier_event.go
+++ b/maintainer/barrier_event.go
@@ -33,6 +33,30 @@ import (
 
 // BarrierEvent is a barrier event that reported by dispatchers, note is a block multiple dispatchers
 // all of these dispatchers should report the same event
+type barrierEventPhase int
+
+const (
+	// barrierEventPhasePass means non writer dispatchers are still waiting for pass done.
+	barrierEventPhasePass barrierEventPhase = iota
+	// barrierEventPhaseWrite means non writer dispatchers are done and writer should write.
+	barrierEventPhaseWrite
+	// barrierEventPhasePostWrite means writer is done and the event waits for final convergence.
+	barrierEventPhasePostWrite
+)
+
+func (p barrierEventPhase) String() string {
+	switch p {
+	case barrierEventPhasePass:
+		return "pass"
+	case barrierEventPhaseWrite:
+		return "write"
+	case barrierEventPhasePostWrite:
+		return "postWrite"
+	default:
+		return "unknown"
+	}
+}
+
 type BarrierEvent struct {
 	cfID               common.ChangeFeedID
 	commitTs           uint64
@@ -44,8 +68,7 @@ type BarrierEvent struct {
 	// table trigger dispatcher reported the block event, we should use it as the writer
 	tableTriggerDispatcherRelated bool
 	writerDispatcher              common.DispatcherID
-	writerDispatcherAdvanced      bool
-	nonWriterDispatchersAdvanced  bool
+	phase                         barrierEventPhase
 
 	blockedDispatchers *heartbeatpb.InfluencedTables
 	dropDispatchers    *heartbeatpb.InfluencedTables
@@ -87,6 +110,7 @@ func NewBlockEvent(cfID common.ChangeFeedID,
 		nodeManager:        appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName),
 		selected:           atomic.Bool{},
 		hasNewTable:        len(status.NeedAddedTables) > 0,
+		phase:              barrierEventPhasePass,
 
 		blockedDispatchers: status.BlockTables,
 		dropDispatchers:    status.NeedDroppedTables,
@@ -205,7 +229,7 @@ func (be *BarrierEvent) onAllDispatcherReportedBlockEvent(dispatcherID common.Di
 
 	be.selected.Store(true)
 	be.writerDispatcher = dispatcher
-	be.nonWriterDispatchersAdvanced = false
+	be.phase = barrierEventPhasePass
 	be.lastResendTime = time.Now()
 	// Mark writer as done for pass phase so allDispatcherReported reflects non writer progress.
 	be.markDispatcherEventDone(be.writerDispatcher)
@@ -474,7 +498,7 @@ func (be *BarrierEvent) checkBlockedDispatchers() {
 				if replication.GetStatus().CheckpointTs >= be.commitTs {
 					// one related table has forward checkpointTs, means the block event can be advanced
 					be.selected.Store(true)
-					be.writerDispatcherAdvanced = true
+					be.phase = barrierEventPhasePostWrite
 					log.Info("one related dispatcher has forward checkpointTs, means the block event can be advanced",
 						zap.String("changefeed", be.cfID.Name()),
 						zap.Uint64("commitTs", be.commitTs),
@@ -493,7 +517,7 @@ func (be *BarrierEvent) checkBlockedDispatchers() {
 			if replication.GetStatus().CheckpointTs >= be.commitTs {
 				// one related table has forward checkpointTs, means the block event can be advanced
 				be.selected.Store(true)
-				be.writerDispatcherAdvanced = true
+				be.phase = barrierEventPhasePostWrite
 				log.Info("one related dispatcher has forward checkpointTs, means the block event can be advanced",
 					zap.String("changefeed", be.cfID.Name()),
 					zap.Uint64("commitTs", be.commitTs),
@@ -510,7 +534,7 @@ func (be *BarrierEvent) checkBlockedDispatchers() {
 			if replication.GetStatus().CheckpointTs >= be.commitTs {
 				// one related table has forward checkpointTs, means the block event can be advanced
 				be.selected.Store(true)
-				be.writerDispatcherAdvanced = true
+				be.phase = barrierEventPhasePostWrite
 				log.Info("one related dispatcher has forward checkpointTs, means the block event can be advanced",
 					zap.String("changefeed", be.cfID.Name()),
 					zap.Uint64("commitTs", be.commitTs),
@@ -536,7 +560,7 @@ func (be *BarrierEvent) resend(mode int64) []*messaging.TargetMessage {
 					zap.Uint64("commitTs", be.commitTs),
 					zap.Bool("isSyncPoint", be.isSyncPoint),
 					zap.Bool("selected", be.selected.Load()),
-					zap.Bool("writerDispatcherAdvanced", be.writerDispatcherAdvanced),
+					zap.String("phase", be.phase.String()),
 					zap.String("coverage", be.rangeChecker.Detail()),
 					zap.Any("blocker", be.blockedDispatchers),
 					zap.Any("resend", msgs),
@@ -547,7 +571,7 @@ func (be *BarrierEvent) resend(mode int64) []*messaging.TargetMessage {
 					zap.Uint64("commitTs", be.commitTs),
 					zap.Bool("isSyncPoint", be.isSyncPoint),
 					zap.Bool("selected", be.selected.Load()),
-					zap.Bool("writerDispatcherAdvanced", be.writerDispatcherAdvanced),
+					zap.String("phase", be.phase.String()),
 					zap.Any("blocker", be.blockedDispatchers),
 					zap.Any("resend", msgs),
 				)
@@ -564,7 +588,7 @@ func (be *BarrierEvent) resend(mode int64) []*messaging.TargetMessage {
 				zap.Uint64("commitTs", be.commitTs),
 				zap.Bool("isSyncPoint", be.isSyncPoint),
 				zap.Bool("selected", be.selected.Load()),
-				zap.Bool("writerDispatcherAdvanced", be.writerDispatcherAdvanced),
+				zap.String("phase", be.phase.String()),
 				zap.Any("blocker", be.blockedDispatchers))
 		}
 		be.checkBlockedDispatchers()
@@ -574,15 +598,15 @@ func (be *BarrierEvent) resend(mode int64) []*messaging.TargetMessage {
 	// Two-phase block handling:
 	// 1) pass all non-writer dispatchers;
 	// 2) after non-writers done, write by writer dispatcher.
-	if be.writerDispatcherAdvanced {
+	if be.phase == barrierEventPhasePostWrite {
 		if !be.allDispatcherReported() {
 			return be.sendPassAction(mode)
 		}
 		return nil
 	}
-	if !be.nonWriterDispatchersAdvanced {
+	if be.phase == barrierEventPhasePass {
 		if be.allDispatcherReported() {
-			be.nonWriterDispatchersAdvanced = true
+			be.phase = barrierEventPhaseWrite
 		} else {
 			return be.sendPassAction(mode)
 		}

--- a/maintainer/barrier_event_test.go
+++ b/maintainer/barrier_event_test.go
@@ -126,7 +126,7 @@ func TestResendAction(t *testing.T) {
 
 	// writer not advanced yet, resend pass action first.
 	event.selected.Store(true)
-	event.writerDispatcherAdvanced = false
+	event.phase = barrierEventPhasePass
 	event.writerDispatcher = dispatcherIDs[0]
 	msgs = event.resend(common.DefaultMode)
 	require.Len(t, msgs, 1)
@@ -136,7 +136,7 @@ func TestResendAction(t *testing.T) {
 	require.Equal(t, resp.DispatcherStatuses[0].Action.CommitTs, uint64(10))
 
 	event.lastResendTime = time.Time{}
-	event.nonWriterDispatchersAdvanced = true
+	event.phase = barrierEventPhaseWrite
 	msgs = event.resend(common.DefaultMode)
 	require.Len(t, msgs, 1)
 	resp = msgs[0].Message[0].(*heartbeatpb.HeartBeatResponse)
@@ -152,7 +152,7 @@ func TestResendAction(t *testing.T) {
 		},
 	}, false)
 	event.selected.Store(true)
-	event.writerDispatcherAdvanced = true
+	event.phase = barrierEventPhasePostWrite
 	msgs = event.resend(common.DefaultMode)
 	require.Len(t, msgs, 1)
 	resp = msgs[0].Message[0].(*heartbeatpb.HeartBeatResponse)
@@ -170,7 +170,7 @@ func TestResendAction(t *testing.T) {
 		},
 	}, false)
 	event.selected.Store(true)
-	event.writerDispatcherAdvanced = true
+	event.phase = barrierEventPhasePostWrite
 	msgs = event.resend(common.DefaultMode)
 	require.Len(t, msgs, 1)
 	resp = msgs[0].Message[0].(*heartbeatpb.HeartBeatResponse)
@@ -189,7 +189,7 @@ func TestResendAction(t *testing.T) {
 		},
 	}, false)
 	event.selected.Store(true)
-	event.writerDispatcherAdvanced = true
+	event.phase = barrierEventPhasePostWrite
 	msgs = event.resend(common.DefaultMode)
 	require.Len(t, msgs, 1)
 	resp = msgs[0].Message[0].(*heartbeatpb.HeartBeatResponse)

--- a/maintainer/barrier_test.go
+++ b/maintainer/barrier_test.go
@@ -93,7 +93,7 @@ func TestOneBlockEvent(t *testing.T) {
 	require.Equal(t, uint64(10), event.commitTs)
 	require.True(t, event.writerDispatcher == spanController.GetDDLDispatcherID())
 	require.True(t, event.selected.Load())
-	require.False(t, event.writerDispatcherAdvanced)
+	require.Equal(t, barrierEventPhasePass, event.phase)
 	require.Len(t, resp.DispatcherStatuses, 1)
 	require.Equal(t, resp.DispatcherStatuses[0].Ack.CommitTs, uint64(10))
 
@@ -915,7 +915,7 @@ func TestUpdateCheckpointTs(t *testing.T) {
 	require.Equal(t, uint64(10), event.commitTs)
 	require.True(t, event.writerDispatcher == spanController.GetDDLDispatcherID())
 	require.True(t, event.selected.Load())
-	require.False(t, event.writerDispatcherAdvanced)
+	require.Equal(t, barrierEventPhasePass, event.phase)
 	require.Len(t, resp.DispatcherStatuses, 1)
 	require.Equal(t, resp.DispatcherStatuses[0].Ack.CommitTs, uint64(10))
 	// the checkpoint ts is updated
@@ -982,7 +982,7 @@ func TestHandleBlockBootstrapResponse(t *testing.T) {
 	event := barrier.blockedEvents.m[getEventKey(6, false)]
 	require.NotNil(t, event)
 	require.False(t, event.selected.Load())
-	require.False(t, event.writerDispatcherAdvanced)
+	require.Equal(t, barrierEventPhasePass, event.phase)
 	require.True(t, event.allDispatcherReported())
 
 	// one waiting dispatcher, and one writing
@@ -1020,7 +1020,7 @@ func TestHandleBlockBootstrapResponse(t *testing.T) {
 	event = barrier.blockedEvents.m[getEventKey(6, false)]
 	require.NotNil(t, event)
 	require.True(t, event.selected.Load())
-	require.False(t, event.writerDispatcherAdvanced)
+	require.Equal(t, barrierEventPhaseWrite, event.phase)
 
 	// two done dispatchers
 	barrier = NewBarrier(spanController, operatorController, false, map[node.ID]*heartbeatpb.MaintainerBootstrapResponse{
@@ -1057,7 +1057,7 @@ func TestHandleBlockBootstrapResponse(t *testing.T) {
 	event = barrier.blockedEvents.m[getEventKey(6, false)]
 	require.NotNil(t, event)
 	require.True(t, event.selected.Load())
-	require.True(t, event.writerDispatcherAdvanced)
+	require.Equal(t, barrierEventPhasePostWrite, event.phase)
 
 	// nil, none stage
 	barrier = NewBarrier(spanController, operatorController, false, map[node.ID]*heartbeatpb.MaintainerBootstrapResponse{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked barrier coordination to a clearer multi-phase progression (pass → write → post-write), improving scheduling and reliability of block processing.

* **Tests**
  * Updated and expanded tests to validate the new phase-driven barrier flow, dispatcher reassignment, and scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->