### PR TITLE
logservice: avoid dispatcher registration failure during schema store initialization

### DIFF
--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1287,6 +1287,7 @@ func (e *eventStore) writeEvents(
 	metrics.EventStoreWriteRequestsCount.Inc()
 	prepareStart := time.Now()
 	batch := db.NewBatch()
+	defer batch.Close()
 	kvCount := 0
 	var totalValueBytesBefore int64
 	var totalValueBytesAfter int64

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -1032,6 +1032,9 @@ func (c *eventBroker) addDispatcher(info DispatcherInfo) error {
 			zap.Uint64("startTs", info.GetStartTs()), zap.String("span", common.FormatTableSpan(span)),
 			zap.Error(err),
 		)
+		// Mark removed to avoid processing notifications before unregister completes.
+		dispatcher.isRemoved.Store(true)
+		c.eventStore.UnregisterDispatcher(changefeedID, id)
 		status.removeDispatcher(id)
 		if status.isEmpty() {
 			c.changefeedMap.Delete(changefeedID)

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -172,6 +172,21 @@ func TestOnNotify(t *testing.T) {
 	log.Info("Pass case 6")
 }
 
+func TestAddDispatcherUnregisterOnSchemaStoreError(t *testing.T) {
+	broker, es, ss, _ := newEventBrokerForTest()
+	defer broker.close()
+
+	ss.registerTableError = errors.New("register schema store failed")
+
+	info := newMockDispatcherInfoForTest(t)
+	err := broker.addDispatcher(info)
+	require.Error(t, err)
+
+	_, ok := es.spansMap.Load(info.GetTableSpan())
+	require.False(t, ok)
+	require.Equal(t, uint64(1), es.unregisterCount.Load())
+}
+
 func TestScanRangeCappedByScanWindow(t *testing.T) {
 	broker, _, _, _ := newEventBrokerForTest()
 	// Close the broker, so we can catch all message in the test.

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -163,6 +164,7 @@ type mockEventStore struct {
 	resolvedTsUpdateInterval time.Duration
 	dispatcherMap            sync.Map // key is common.DispatcherID, value is span
 	spansMap                 sync.Map // key is *heartbeatpb.TableSpan
+	unregisterCount          atomic.Uint64
 }
 
 func newMockEventStore(resolvedTsUpdateInterval int) *mockEventStore {
@@ -245,7 +247,9 @@ func (m *mockEventStore) UnregisterDispatcher(changefeedID common.ChangeFeedID, 
 	span, ok := m.dispatcherMap.Load(dispatcherID)
 	if ok {
 		m.spansMap.Delete(span)
+		m.dispatcherMap.Delete(dispatcherID)
 	}
+	m.unregisterCount.Add(1)
 }
 
 func (m *mockEventStore) GetIterator(dispatcherID common.DispatcherID, dataRange common.DataRange) eventstore.EventIterator {

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -129,16 +129,22 @@ func CreateTiStore(ctx context.Context, urls string, credential *security.Creden
 		retry.WithBackoffBaseDelay(200),
 		retry.WithBackoffMaxDelay(4000),
 		retry.WithIsRetryableErr(func(err error) bool {
-			switch errors.Cause(err) {
-			case context.Canceled:
-				return false
-			}
-			return true
+			return isCreateTiStoreRetryable(ctx, err)
 		}))
 	if err != nil {
 		return nil, errors.WrapError(errors.ErrNewStore, err)
 	}
 	return tiStore, nil
+}
+
+func isCreateTiStoreRetryable(ctx context.Context, err error) bool {
+	switch errors.Cause(err) {
+	case context.Canceled:
+		// Only stop retrying if the caller's context is canceled.
+		// Otherwise treat it as transient (e.g. internal client cancellation).
+		return ctx.Err() == nil
+	}
+	return true
 }
 
 // init initializes the upstream

--- a/pkg/upstream/upstream_test.go
+++ b/pkg/upstream/upstream_test.go
@@ -136,3 +136,16 @@ func TestRegisterTopo(t *testing.T) {
 		return len(resp.Kvs) == 0
 	}, time.Second*5, time.Millisecond*100)
 }
+
+func TestIsCreateTiStoreRetryable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	require.True(t, isCreateTiStoreRetryable(ctx, context.Canceled))
+	require.True(t, isCreateTiStoreRetryable(ctx, errors.Trace(context.Canceled)))
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, isCreateTiStoreRetryable(canceledCtx, context.Canceled))
+	require.False(t, isCreateTiStoreRetryable(canceledCtx, errors.Trace(context.Canceled)))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4285

### What is changed and how it works?

This pull request aims to avoid schema store registration failure like the following:
```
[2026/02/22 13:16:56.220 +08:00] [ERROR] [event_broker.go:983] ["register table to schemaStore failed"] [keyspaceID=1] [dispatcherID=31207855160892268629454174482575748278] [tableID=181] [startTs=464450330781810783] [span="tableID: 181, startKey: 7800000174800000ff00000000b55f7200fe, endKey: 7800000174800000ff00000000b55f7300fe, keyspaceID: 1"] [error="[CDC:ErrNewStore]new store failed: context canceled"]
```

### Highlights

* **Event Dispatcher Robustness**: Enhanced the `addDispatcher` function to ensure proper unregistration and marking of dispatchers as removed immediately upon schema store registration failure, preventing inconsistent states.
* **Improved `CreateTiStore` Retry Logic**: Refactored the retry mechanism for `CreateTiStore` to differentiate between caller-initiated context cancellations (which should stop retries) and internal client cancellations (which should continue retries), improving resilience.
* **Comprehensive Testing**: Added new unit tests to validate the corrected `addDispatcher` error handling and the refined `CreateTiStore` retry behavior.
* **Mock Event Store Enhancements**: Updated the mock event store to accurately track unregistration calls and ensure complete cleanup of dispatcher mappings during tests.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures event dispatchers are properly marked and unregistered on schema registration failures to avoid stray dispatching.
  * Refines upstream connection retry handling to respect caller cancellation.
  * Ensures event store write batches are always released to prevent resource leaks.

* **Tests**
  * Added tests covering dispatcher unregistration on schema errors and retry cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->