### PR TITLE
ci: split PR build workflow by target branch

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -47,7 +47,7 @@ jobs:
     name: ${{ matrix.task.name }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment
         uses: actions/setup-go@v6
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Tools
         id: cache-tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tools/bin
           key: ubuntu-latest-ticdc-tools-${{ hashFiles('tools/check/go.sum') }}

--- a/.github/workflows/pr_build_and_test_classic.yaml
+++ b/.github/workflows/pr_build_and_test_classic.yaml
@@ -43,7 +43,7 @@ jobs:
     name: ${{ matrix.task.name }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment
         uses: actions/setup-go@v6
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache Tools
         id: cache-tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tools/bin
           key: ubuntu-latest-ticdc-tools-${{ hashFiles('tools/check/go.sum') }}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4397

### What is changed and how it works?

- Remove release branch trigger from \.github/workflows/pr_build_and_test.yaml, so master PRs keep full (classic + next-gen) checks only.
- Add \.github/workflows/pr_build_and_test_classic.yaml for release branch PRs, running classic-only check/build/unit-test jobs.
- Use a distinct workflow name for the new release workflow to avoid ambiguous workflow identity and potential future concurrency collisions.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to optimize automated testing triggers.
  * Restricted one PR build workflow to run only on the main branch.
  * Added a separate PR workflow for release branches that enables parallel, matrix-driven testing with caching.
  * Upgraded CI action versions to their latest releases for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

