### PR TITLE
dispatchermanager: fix redo readiness race

### DIFF
--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -733,7 +733,7 @@ func (e *DispatcherManager) aggregateDispatcherHeartbeats(needCompleteStatus boo
 	toCleanMap := make([]*cleanMap, 0)
 	dispatcherCount := 0
 
-	if e.IsRedoEnabled() {
+	if e.IsRedoReady() {
 		redoSeq := e.redoDispatcherMap.ForEach(func(id common.DispatcherID, dispatcherItem *dispatcher.RedoDispatcher) {
 			dispatcherCount++
 			status, cleanMap, watermark := getDispatcherStatus(id, dispatcherItem, needCompleteStatus)

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -122,7 +122,7 @@ type DispatcherManager struct {
 	// redo related
 	// RedoEnable is immutable after construction and records whether redo is configured for the changefeed.
 	RedoEnable bool
-	// redoReady publishes that redo components are fully initialized and safe for concurrent access.
+	// redoReady set to true after the redo components are fully initialized and safe for concurrent access.
 	redoReady atomic.Bool
 	redoSink  *redo.Sink
 	// redoGlobalTs stores the resolved-ts of the redo metadata and blocks events in the common dispatcher where the commit-ts is greater than the resolved-ts.

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -120,8 +120,8 @@ type DispatcherManager struct {
 	// sink is used to send all the events to the downstream.
 	sink sink.Sink
 	// redo related
-	// RedoEnable is immutable after construction and records whether redo is configured for the changefeed.
-	RedoEnable bool
+	// redoEnabled is immutable after construction and records whether redo is configured for the changefeed.
+	redoEnabled bool
 	// redoReady set to true after the redo components are fully initialized and safe for concurrent access.
 	redoReady atomic.Bool
 	redoSink  *redo.Sink
@@ -200,7 +200,7 @@ func NewDispatcherManager(
 		latestRedoWatermark:   NewWatermark(0),
 		schemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
 		sinkQuota:             cfConfig.MemoryQuota,
-		RedoEnable:            redoEnabled(cfConfig),
+		redoEnabled:           isRedoConfigEnabled(cfConfig),
 
 		metricTableTriggerEventDispatcherCount: metrics.TableTriggerEventDispatcherGauge.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name(), "eventDispatcher"),
 		metricEventDispatcherCount:             metrics.EventDispatcherGauge.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name(), "eventDispatcher"),
@@ -315,7 +315,7 @@ func NewDispatcherManager(
 		zap.Uint64("startTs", startTs),
 		zap.Uint64("sinkQuota", manager.sinkQuota),
 		zap.Uint64("redoQuota", manager.redoQuota),
-		zap.Bool("redoEnable", manager.RedoEnable),
+		zap.Bool("redoEnable", manager.redoEnabled),
 		zap.Bool("outputRawChangeEvent", manager.sharedInfo.IsOutputRawChangeEvent()),
 		zap.String("filterConfig", filterCfg.String()),
 	)
@@ -462,7 +462,7 @@ func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]di
 			currentPdTs,
 			e.sink,
 			e.sharedInfo,
-			e.RedoEnable,
+			e.redoEnabled,
 			&e.redoGlobalTs,
 		)
 		if e.heartBeatTask == nil {
@@ -732,7 +732,7 @@ func (e *DispatcherManager) aggregateDispatcherHeartbeats(needCompleteStatus boo
 	toCleanMap := make([]*cleanMap, 0)
 	dispatcherCount := 0
 
-	if e.RedoEnable {
+	if e.redoEnabled {
 		redoSeq := e.redoDispatcherMap.ForEach(func(id common.DispatcherID, dispatcherItem *dispatcher.RedoDispatcher) {
 			dispatcherCount++
 			status, cleanMap, watermark := getDispatcherStatus(id, dispatcherItem, needCompleteStatus)
@@ -866,7 +866,7 @@ func (e *DispatcherManager) mergeEventDispatcher(dispatcherIDs []common.Dispatch
 		0,     // currentPDTs will be calculated later.
 		e.sink,
 		e.sharedInfo,
-		e.RedoEnable,
+		e.redoEnabled,
 		&e.redoGlobalTs,
 	)
 
@@ -899,7 +899,7 @@ func (e *DispatcherManager) close(removeChangefeed bool) {
 		zap.Stringer("changefeedID", e.changefeedID))
 
 	defer e.closing.Store(false)
-	if e.RedoEnable {
+	if e.redoEnabled {
 		closeAllDispatchers(e.changefeedID, e.redoDispatcherMap, e.redoSink.SinkType())
 		log.Info("closed all redo dispatchers",
 			zap.Stringer("changefeedID", e.changefeedID))
@@ -945,7 +945,7 @@ func (e *DispatcherManager) close(removeChangefeed bool) {
 
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
-	if e.RedoEnable {
+	if e.redoEnabled {
 		e.redoSink.Close(removeChangefeed)
 		// FIXME: cleanup redo log when remove the changefeed
 		e.closeRedoMeta(removeChangefeed)

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -119,8 +119,9 @@ type DispatcherManager struct {
 
 	// sink is used to send all the events to the downstream.
 	sink sink.Sink
+
 	// redo related
-	// redoEnabled is immutable after construction and records whether redo is configured for the changefeed.
+	// redoEnabled is immutable and set to true if enabled.
 	redoEnabled bool
 	// redoReady set to true after the redo components are fully initialized and safe for concurrent access.
 	redoReady atomic.Bool
@@ -315,7 +316,7 @@ func NewDispatcherManager(
 		zap.Uint64("startTs", startTs),
 		zap.Uint64("sinkQuota", manager.sinkQuota),
 		zap.Uint64("redoQuota", manager.redoQuota),
-		zap.Bool("redoEnable", manager.redoEnabled),
+		zap.Bool("redoEnable", manager.IsRedoEnabled()),
 		zap.Bool("outputRawChangeEvent", manager.sharedInfo.IsOutputRawChangeEvent()),
 		zap.String("filterConfig", filterCfg.String()),
 	)
@@ -462,7 +463,7 @@ func (e *DispatcherManager) newEventDispatchers(infos map[common.DispatcherID]di
 			currentPdTs,
 			e.sink,
 			e.sharedInfo,
-			e.redoEnabled,
+			e.IsRedoEnabled(),
 			&e.redoGlobalTs,
 		)
 		if e.heartBeatTask == nil {
@@ -732,7 +733,7 @@ func (e *DispatcherManager) aggregateDispatcherHeartbeats(needCompleteStatus boo
 	toCleanMap := make([]*cleanMap, 0)
 	dispatcherCount := 0
 
-	if e.redoEnabled {
+	if e.IsRedoEnabled() {
 		redoSeq := e.redoDispatcherMap.ForEach(func(id common.DispatcherID, dispatcherItem *dispatcher.RedoDispatcher) {
 			dispatcherCount++
 			status, cleanMap, watermark := getDispatcherStatus(id, dispatcherItem, needCompleteStatus)
@@ -866,7 +867,7 @@ func (e *DispatcherManager) mergeEventDispatcher(dispatcherIDs []common.Dispatch
 		0,     // currentPDTs will be calculated later.
 		e.sink,
 		e.sharedInfo,
-		e.redoEnabled,
+		e.IsRedoEnabled(),
 		&e.redoGlobalTs,
 	)
 
@@ -899,7 +900,7 @@ func (e *DispatcherManager) close(removeChangefeed bool) {
 		zap.Stringer("changefeedID", e.changefeedID))
 
 	defer e.closing.Store(false)
-	if e.redoEnabled {
+	if e.IsRedoEnabled() {
 		closeAllDispatchers(e.changefeedID, e.redoDispatcherMap, e.redoSink.SinkType())
 		log.Info("closed all redo dispatchers",
 			zap.Stringer("changefeedID", e.changefeedID))
@@ -945,7 +946,7 @@ func (e *DispatcherManager) close(removeChangefeed bool) {
 
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
-	if e.redoEnabled {
+	if e.IsRedoEnabled() {
 		e.redoSink.Close(removeChangefeed)
 		// FIXME: cleanup redo log when remove the changefeed
 		e.closeRedoMeta(removeChangefeed)

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -120,8 +120,11 @@ type DispatcherManager struct {
 	// sink is used to send all the events to the downstream.
 	sink sink.Sink
 	// redo related
+	// RedoEnable is immutable after construction and records whether redo is configured for the changefeed.
 	RedoEnable bool
-	redoSink   *redo.Sink
+	// redoReady publishes that redo components are fully initialized and safe for concurrent access.
+	redoReady atomic.Bool
+	redoSink  *redo.Sink
 	// redoGlobalTs stores the resolved-ts of the redo metadata and blocks events in the common dispatcher where the commit-ts is greater than the resolved-ts.
 	redoGlobalTs atomic.Uint64
 
@@ -197,6 +200,7 @@ func NewDispatcherManager(
 		latestRedoWatermark:   NewWatermark(0),
 		schemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
 		sinkQuota:             cfConfig.MemoryQuota,
+		RedoEnable:            redoEnabled(cfConfig),
 
 		metricTableTriggerEventDispatcherCount: metrics.TableTriggerEventDispatcherGauge.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name(), "eventDispatcher"),
 		metricEventDispatcherCount:             metrics.EventDispatcherGauge.WithLabelValues(changefeedID.Keyspace(), changefeedID.Name(), "eventDispatcher"),

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_info.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_info.go
@@ -104,5 +104,9 @@ func (e *DispatcherManager) IsRedoEnabled() bool {
 
 // IsRedoReady reports whether redo is configured and its runtime components are fully initialized.
 func (e *DispatcherManager) IsRedoReady() bool {
-	return isRedoDispatcherManagerReady(e)
+	return e.IsRedoEnabled() &&
+		e.redoReady.Load() &&
+		e.redoSink != nil &&
+		e.redoDispatcherMap != nil &&
+		e.redoSchemaIDToDispatchers != nil
 }

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_info.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_info.go
@@ -96,3 +96,8 @@ func (e *DispatcherManager) GetAllDispatchers(schemaID int64) []common.Dispatche
 func (e *DispatcherManager) GetCurrentOperatorMap() *sync.Map {
 	return &e.currentOperatorMap
 }
+
+// IsRedoReady reports whether redo is configured and its runtime components are fully initialized.
+func (e *DispatcherManager) IsRedoReady() bool {
+	return isRedoDispatcherManagerReady(e)
+}

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_info.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_info.go
@@ -97,6 +97,11 @@ func (e *DispatcherManager) GetCurrentOperatorMap() *sync.Map {
 	return &e.currentOperatorMap
 }
 
+// IsRedoEnabled reports whether redo is configured for the changefeed.
+func (e *DispatcherManager) IsRedoEnabled() bool {
+	return e.redoEnabled
+}
+
 // IsRedoReady reports whether redo is configured and its runtime components are fully initialized.
 func (e *DispatcherManager) IsRedoReady() bool {
 	return isRedoDispatcherManagerReady(e)

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -58,9 +58,6 @@ func initRedoComponet(
 		return errors.WrapError(errors.ErrStorageInitialize, errors.New("redo sink initialization returned nil"))
 	}
 	manager.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
-	// Publish redo availability only after all redo components are initialized,
-	// so scheduler precheck won't observe a partially initialized manager.
-	manager.redoReady.Store(true)
 
 	totalQuota := manager.sinkQuota
 	consistentMemoryUsage := manager.config.Consistent.MemoryUsage
@@ -90,6 +87,9 @@ func initRedoComponet(
 		err := manager.redoSink.Run(ctx)
 		manager.handleError(ctx, err)
 	}()
+	// Publish redo availability only after all redo components are initialized,
+	// so scheduler precheck won't observe a partially initialized manager.
+	manager.redoReady.Store(true)
 	return nil
 }
 

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -34,7 +34,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func redoEnabled(cfConfig *config.ChangefeedConfig) bool {
+func isRedoConfigEnabled(cfConfig *config.ChangefeedConfig) bool {
 	if cfConfig == nil {
 		return false
 	}
@@ -49,7 +49,7 @@ func initRedoComponet(
 	startTs uint64,
 	newChangefeed bool,
 ) error {
-	if !manager.RedoEnable {
+	if !manager.redoEnabled {
 		return nil
 	}
 	manager.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -35,6 +35,9 @@ import (
 )
 
 func redoEnabled(cfConfig *config.ChangefeedConfig) bool {
+	if cfConfig == nil {
+		return false
+	}
 	return cfConfig.Consistent != nil && pkgRedo.IsConsistentEnabled(util.GetOrZero(cfConfig.Consistent.Level))
 }
 

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -49,7 +49,7 @@ func initRedoComponet(
 	startTs uint64,
 	newChangefeed bool,
 ) error {
-	if !manager.redoEnabled {
+	if !manager.IsRedoEnabled() {
 		return nil
 	}
 	manager.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -34,6 +34,10 @@ import (
 	"go.uber.org/zap"
 )
 
+func redoEnabled(cfConfig *config.ChangefeedConfig) bool {
+	return cfConfig.Consistent != nil && pkgRedo.IsConsistentEnabled(util.GetOrZero(cfConfig.Consistent.Level))
+}
+
 func initRedoComponet(
 	ctx context.Context,
 	manager *DispatcherManager,
@@ -42,7 +46,7 @@ func initRedoComponet(
 	startTs uint64,
 	newChangefeed bool,
 ) error {
-	if manager.config.Consistent == nil || !pkgRedo.IsConsistentEnabled(util.GetOrZero(manager.config.Consistent.Level)) {
+	if !manager.RedoEnable {
 		return nil
 	}
 	manager.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()
@@ -53,7 +57,7 @@ func initRedoComponet(
 	manager.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
 	// Publish redo availability only after all redo components are initialized,
 	// so scheduler precheck won't observe a partially initialized manager.
-	manager.RedoEnable = true
+	manager.redoReady.Store(true)
 
 	totalQuota := manager.sinkQuota
 	consistentMemoryUsage := manager.config.Consistent.MemoryUsage

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -33,7 +33,9 @@ import (
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
+	pkgRedo "github.com/pingcap/ticdc/pkg/redo"
 	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/utils/dynstream"
 	"github.com/pingcap/ticdc/utils/threadpool"
 	"github.com/stretchr/testify/require"
 )
@@ -56,6 +58,41 @@ func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.S
 	mockSink.EXPECT().Close(gomock.Any()).AnyTimes()
 	mockSink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return mockSink
+}
+
+type testDynamicStream[A dynstream.Area, P dynstream.Path, T dynstream.Event, D dynstream.Dest, H dynstream.Handler[A, P, T, D]] struct {
+	onAddPath func() error
+}
+
+func (s *testDynamicStream[A, P, T, D, H]) Start() {}
+
+func (s *testDynamicStream[A, P, T, D, H]) Close() {}
+
+func (s *testDynamicStream[A, P, T, D, H]) Push(path P, event T) {}
+
+func (s *testDynamicStream[A, P, T, D, H]) Wake(path P) {}
+
+func (s *testDynamicStream[A, P, T, D, H]) Feedback() <-chan dynstream.Feedback[A, P, D] {
+	return nil
+}
+
+func (s *testDynamicStream[A, P, T, D, H]) AddPath(path P, dest D, area ...dynstream.AreaSettings) error {
+	if s.onAddPath != nil {
+		return s.onAddPath()
+	}
+	return nil
+}
+
+func (s *testDynamicStream[A, P, T, D, H]) RemovePath(path P) error {
+	return nil
+}
+
+func (s *testDynamicStream[A, P, T, D, H]) Release(path P) {}
+
+func (s *testDynamicStream[A, P, T, D, H]) SetAreaSettings(area A, settings dynstream.AreaSettings) {}
+
+func (s *testDynamicStream[A, P, T, D, H]) GetMetrics() dynstream.Metrics[A, P] {
+	return dynstream.Metrics[A, P]{}
 }
 
 // createTestDispatcher creates a test dispatcher with given parameters
@@ -215,6 +252,74 @@ func TestCollectComponentStatusWhenChangedWatermarkSeqNoFallback(t *testing.T) {
 	require.NotNil(t, req.Request)
 	require.NotNil(t, req.Request.RedoWatermark)
 	require.Equal(t, uint64(200), req.Request.RedoWatermark.Seq)
+}
+
+func TestInitRedoComponentPublishesReadyAfterRedoRegistration(t *testing.T) {
+	manager := &DispatcherManager{
+		changefeedID:        common.NewChangeFeedIDWithName("redo-test", common.DefaultKeyspaceName),
+		latestRedoWatermark: NewWatermark(0),
+		sinkQuota:           200,
+		redoEnabled:         true,
+		config: &config.ChangefeedConfig{
+			Consistent: &config.ConsistentConfig{
+				Level:                 util.AddressOf(string(pkgRedo.ConsistentLevelEventual)),
+				MaxLogSize:            util.AddressOf(pkgRedo.DefaultMaxLogSize),
+				Storage:               util.AddressOf("blackhole://"),
+				FlushIntervalInMs:     util.AddressOf(int64(pkgRedo.MinFlushIntervalInMs)),
+				MetaFlushIntervalInMs: util.AddressOf(int64(pkgRedo.MinFlushIntervalInMs)),
+				EncodingWorkerNum:     util.AddressOf(1),
+				FlushWorkerNum:        util.AddressOf(1),
+				UseFileBackend:        util.AddressOf(false),
+				MemoryUsage: &config.ConsistentMemoryUsage{
+					MemoryQuotaPercentage: 25,
+				},
+			},
+		},
+	}
+	registrationStarted := make(chan struct{})
+	releaseRegistration := make(chan struct{})
+	hb := &HeartBeatCollector{
+		redoResolvedTsForwardMessageDynamicStream: &testDynamicStream[int, common.GID, RedoResolvedTsForwardMessage, *DispatcherManager, *RedoResolvedTsForwardMessageHandler]{
+			onAddPath: func() error {
+				select {
+				case <-registrationStarted:
+				default:
+					close(registrationStarted)
+				}
+				<-releaseRegistration
+				return nil
+			},
+		},
+		redoMetaMessageDynamicStream: &testDynamicStream[int, common.GID, RedoMetaMessage, *DispatcherManager, *RedoMetaMessageHandler]{},
+	}
+	appcontext.SetService(appcontext.HeartbeatCollector, hb)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- initRedoComponet(ctx, manager, manager.changefeedID, nil, 0, false)
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-registrationStarted:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, uint64(50), manager.redoQuota)
+	require.Equal(t, uint64(150), manager.sinkQuota)
+	require.False(t, manager.IsRedoReady())
+
+	close(releaseRegistration)
+	require.NoError(t, <-errCh)
+	require.True(t, manager.IsRedoReady())
+
+	cancel()
+	manager.wg.Wait()
 }
 
 func TestMergeDispatcherNormal(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -33,9 +33,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
-	pkgRedo "github.com/pingcap/ticdc/pkg/redo"
 	"github.com/pingcap/ticdc/pkg/util"
-	"github.com/pingcap/ticdc/utils/dynstream"
 	"github.com/pingcap/ticdc/utils/threadpool"
 	"github.com/stretchr/testify/require"
 )
@@ -58,41 +56,6 @@ func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.S
 	mockSink.EXPECT().Close(gomock.Any()).AnyTimes()
 	mockSink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return mockSink
-}
-
-type testDynamicStream[A dynstream.Area, P dynstream.Path, T dynstream.Event, D dynstream.Dest, H dynstream.Handler[A, P, T, D]] struct {
-	onAddPath func() error
-}
-
-func (s *testDynamicStream[A, P, T, D, H]) Start() {}
-
-func (s *testDynamicStream[A, P, T, D, H]) Close() {}
-
-func (s *testDynamicStream[A, P, T, D, H]) Push(path P, event T) {}
-
-func (s *testDynamicStream[A, P, T, D, H]) Wake(path P) {}
-
-func (s *testDynamicStream[A, P, T, D, H]) Feedback() <-chan dynstream.Feedback[A, P, D] {
-	return nil
-}
-
-func (s *testDynamicStream[A, P, T, D, H]) AddPath(path P, dest D, area ...dynstream.AreaSettings) error {
-	if s.onAddPath != nil {
-		return s.onAddPath()
-	}
-	return nil
-}
-
-func (s *testDynamicStream[A, P, T, D, H]) RemovePath(path P) error {
-	return nil
-}
-
-func (s *testDynamicStream[A, P, T, D, H]) Release(path P) {}
-
-func (s *testDynamicStream[A, P, T, D, H]) SetAreaSettings(area A, settings dynstream.AreaSettings) {}
-
-func (s *testDynamicStream[A, P, T, D, H]) GetMetrics() dynstream.Metrics[A, P] {
-	return dynstream.Metrics[A, P]{}
 }
 
 // createTestDispatcher creates a test dispatcher with given parameters
@@ -252,74 +215,6 @@ func TestCollectComponentStatusWhenChangedWatermarkSeqNoFallback(t *testing.T) {
 	require.NotNil(t, req.Request)
 	require.NotNil(t, req.Request.RedoWatermark)
 	require.Equal(t, uint64(200), req.Request.RedoWatermark.Seq)
-}
-
-func TestInitRedoComponentPublishesReadyAfterRedoRegistration(t *testing.T) {
-	manager := &DispatcherManager{
-		changefeedID:        common.NewChangeFeedIDWithName("redo-test", common.DefaultKeyspaceName),
-		latestRedoWatermark: NewWatermark(0),
-		sinkQuota:           200,
-		redoEnabled:         true,
-		config: &config.ChangefeedConfig{
-			Consistent: &config.ConsistentConfig{
-				Level:                 util.AddressOf(string(pkgRedo.ConsistentLevelEventual)),
-				MaxLogSize:            util.AddressOf(pkgRedo.DefaultMaxLogSize),
-				Storage:               util.AddressOf("blackhole://"),
-				FlushIntervalInMs:     util.AddressOf(int64(pkgRedo.MinFlushIntervalInMs)),
-				MetaFlushIntervalInMs: util.AddressOf(int64(pkgRedo.MinFlushIntervalInMs)),
-				EncodingWorkerNum:     util.AddressOf(1),
-				FlushWorkerNum:        util.AddressOf(1),
-				UseFileBackend:        util.AddressOf(false),
-				MemoryUsage: &config.ConsistentMemoryUsage{
-					MemoryQuotaPercentage: 25,
-				},
-			},
-		},
-	}
-	registrationStarted := make(chan struct{})
-	releaseRegistration := make(chan struct{})
-	hb := &HeartBeatCollector{
-		redoResolvedTsForwardMessageDynamicStream: &testDynamicStream[int, common.GID, RedoResolvedTsForwardMessage, *DispatcherManager, *RedoResolvedTsForwardMessageHandler]{
-			onAddPath: func() error {
-				select {
-				case <-registrationStarted:
-				default:
-					close(registrationStarted)
-				}
-				<-releaseRegistration
-				return nil
-			},
-		},
-		redoMetaMessageDynamicStream: &testDynamicStream[int, common.GID, RedoMetaMessage, *DispatcherManager, *RedoMetaMessageHandler]{},
-	}
-	appcontext.SetService(appcontext.HeartbeatCollector, hb)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- initRedoComponet(ctx, manager, manager.changefeedID, nil, 0, false)
-	}()
-
-	require.Eventually(t, func() bool {
-		select {
-		case <-registrationStarted:
-			return true
-		default:
-			return false
-		}
-	}, 5*time.Second, 10*time.Millisecond)
-	require.Equal(t, uint64(50), manager.redoQuota)
-	require.Equal(t, uint64(150), manager.sinkQuota)
-	require.False(t, manager.IsRedoReady())
-
-	close(releaseRegistration)
-	require.NoError(t, <-errCh)
-	require.True(t, manager.IsRedoReady())
-
-	cancel()
-	manager.wg.Wait()
 }
 
 func TestMergeDispatcherNormal(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -251,6 +251,7 @@ func (h *SchedulerDispatcherRequestHandler) Handle(dispatcherManager *Dispatcher
 
 func isRedoDispatcherManagerReady(dispatcherManager *DispatcherManager) bool {
 	return dispatcherManager.RedoEnable &&
+		dispatcherManager.redoReady.Load() &&
 		dispatcherManager.redoSink != nil &&
 		dispatcherManager.redoDispatcherMap != nil &&
 		dispatcherManager.redoSchemaIDToDispatchers != nil

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -250,7 +250,7 @@ func (h *SchedulerDispatcherRequestHandler) Handle(dispatcherManager *Dispatcher
 }
 
 func isRedoDispatcherManagerReady(dispatcherManager *DispatcherManager) bool {
-	return dispatcherManager.RedoEnable &&
+	return dispatcherManager.IsRedoEnabled() &&
 		dispatcherManager.redoReady.Load() &&
 		dispatcherManager.redoSink != nil &&
 		dispatcherManager.redoDispatcherMap != nil &&

--- a/downstreamadapter/dispatchermanager/helper.go
+++ b/downstreamadapter/dispatchermanager/helper.go
@@ -249,14 +249,6 @@ func (h *SchedulerDispatcherRequestHandler) Handle(dispatcherManager *Dispatcher
 	return false
 }
 
-func isRedoDispatcherManagerReady(dispatcherManager *DispatcherManager) bool {
-	return dispatcherManager.IsRedoEnabled() &&
-		dispatcherManager.redoReady.Load() &&
-		dispatcherManager.redoSink != nil &&
-		dispatcherManager.redoDispatcherMap != nil &&
-		dispatcherManager.redoSchemaIDToDispatchers != nil
-}
-
 // preCheckForSchedulerHandler validates a scheduling request and decides whether it should be applied.
 //
 // It returns the stable key used in currentOperatorMap (dispatcherID), and a boolean indicating whether the
@@ -285,7 +277,7 @@ func preCheckForSchedulerHandler(req SchedulerDispatcherRequest, dispatcherManag
 	}
 
 	isRedo := common.IsRedoMode(req.Config.Mode)
-	if isRedo && !isRedoDispatcherManagerReady(dispatcherManager) {
+	if isRedo && !dispatcherManager.IsRedoReady() {
 		return common.DispatcherID{}, false
 	}
 	if _, operatorExists := dispatcherManager.currentOperatorMap.Load(operatorKey); operatorExists {

--- a/downstreamadapter/dispatchermanager/helper_test.go
+++ b/downstreamadapter/dispatchermanager/helper_test.go
@@ -209,7 +209,7 @@ func TestIsRedoDispatcherManagerReadySkipsComponentChecksUntilPublished(t *testi
 	t.Parallel()
 
 	dm := &DispatcherManager{
-		RedoEnable: true,
+		redoEnabled: true,
 	}
 
 	start := make(chan struct{})
@@ -245,7 +245,7 @@ func TestIsRedoDispatcherManagerReadyReturnsTrueAfterPublication(t *testing.T) {
 	t.Parallel()
 
 	dm := &DispatcherManager{
-		RedoEnable:                true,
+		redoEnabled:               true,
 		redoDispatcherMap:         newDispatcherMap[*dispatcher.RedoDispatcher](),
 		redoSink:                  &redo.Sink{},
 		redoSchemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
@@ -259,12 +259,13 @@ func TestDispatcherManagerIsRedoReadyRequiresPublication(t *testing.T) {
 	t.Parallel()
 
 	dm := &DispatcherManager{
-		RedoEnable:                true,
+		redoEnabled:               true,
 		redoDispatcherMap:         newDispatcherMap[*dispatcher.RedoDispatcher](),
 		redoSink:                  &redo.Sink{},
 		redoSchemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
 	}
 
+	require.True(t, dm.IsRedoEnabled())
 	require.False(t, dm.IsRedoReady())
 
 	dm.redoReady.Store(true)

--- a/downstreamadapter/dispatchermanager/helper_test.go
+++ b/downstreamadapter/dispatchermanager/helper_test.go
@@ -15,12 +15,14 @@ package dispatchermanager
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pingcap/ticdc/downstreamadapter/dispatcher"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/mock"
+	"github.com/pingcap/ticdc/downstreamadapter/sink/redo"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/stretchr/testify/require"
@@ -201,4 +203,54 @@ func TestPreCheckForSchedulerHandler_CreateSkippedWhenDispatcherExists(t *testin
 
 	_, ok := preCheckForSchedulerHandler(createReq, dm)
 	require.False(t, ok)
+}
+
+func TestIsRedoDispatcherManagerReadySkipsComponentChecksUntilPublished(t *testing.T) {
+	t.Parallel()
+
+	dm := &DispatcherManager{
+		RedoEnable: true,
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			dm.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()
+			dm.redoSink = &redo.Sink{}
+			dm.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
+			dm.redoDispatcherMap = nil
+			dm.redoSink = nil
+			dm.redoSchemaIDToDispatchers = nil
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			require.False(t, isRedoDispatcherManagerReady(dm))
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}
+
+func TestIsRedoDispatcherManagerReadyReturnsTrueAfterPublication(t *testing.T) {
+	t.Parallel()
+
+	dm := &DispatcherManager{
+		RedoEnable:                true,
+		redoDispatcherMap:         newDispatcherMap[*dispatcher.RedoDispatcher](),
+		redoSink:                  &redo.Sink{},
+		redoSchemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
+	}
+	dm.redoReady.Store(true)
+
+	require.True(t, isRedoDispatcherManagerReady(dm))
 }

--- a/downstreamadapter/dispatchermanager/helper_test.go
+++ b/downstreamadapter/dispatchermanager/helper_test.go
@@ -15,7 +15,6 @@ package dispatchermanager
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -203,56 +202,6 @@ func TestPreCheckForSchedulerHandler_CreateSkippedWhenDispatcherExists(t *testin
 
 	_, ok := preCheckForSchedulerHandler(createReq, dm)
 	require.False(t, ok)
-}
-
-func TestDispatcherManagerIsRedoReadySkipsComponentChecksUntilPublished(t *testing.T) {
-	t.Parallel()
-
-	dm := &DispatcherManager{
-		redoEnabled: true,
-	}
-
-	start := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		<-start
-		for i := 0; i < 1000; i++ {
-			dm.redoDispatcherMap = newDispatcherMap[*dispatcher.RedoDispatcher]()
-			dm.redoSink = &redo.Sink{}
-			dm.redoSchemaIDToDispatchers = dispatcher.NewSchemaIDToDispatchers()
-			dm.redoDispatcherMap = nil
-			dm.redoSink = nil
-			dm.redoSchemaIDToDispatchers = nil
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		<-start
-		for i := 0; i < 1000; i++ {
-			require.False(t, dm.IsRedoReady())
-		}
-	}()
-
-	close(start)
-	wg.Wait()
-}
-
-func TestDispatcherManagerIsRedoReadyReturnsTrueAfterPublication(t *testing.T) {
-	t.Parallel()
-
-	dm := &DispatcherManager{
-		redoEnabled:               true,
-		redoDispatcherMap:         newDispatcherMap[*dispatcher.RedoDispatcher](),
-		redoSink:                  &redo.Sink{},
-		redoSchemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
-	}
-	dm.redoReady.Store(true)
-
-	require.True(t, dm.IsRedoReady())
 }
 
 func TestDispatcherManagerIsRedoReadyRequiresPublication(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/helper_test.go
+++ b/downstreamadapter/dispatchermanager/helper_test.go
@@ -205,7 +205,7 @@ func TestPreCheckForSchedulerHandler_CreateSkippedWhenDispatcherExists(t *testin
 	require.False(t, ok)
 }
 
-func TestIsRedoDispatcherManagerReadySkipsComponentChecksUntilPublished(t *testing.T) {
+func TestDispatcherManagerIsRedoReadySkipsComponentChecksUntilPublished(t *testing.T) {
 	t.Parallel()
 
 	dm := &DispatcherManager{
@@ -233,7 +233,7 @@ func TestIsRedoDispatcherManagerReadySkipsComponentChecksUntilPublished(t *testi
 		defer wg.Done()
 		<-start
 		for i := 0; i < 1000; i++ {
-			require.False(t, isRedoDispatcherManagerReady(dm))
+			require.False(t, dm.IsRedoReady())
 		}
 	}()
 
@@ -241,7 +241,7 @@ func TestIsRedoDispatcherManagerReadySkipsComponentChecksUntilPublished(t *testi
 	wg.Wait()
 }
 
-func TestIsRedoDispatcherManagerReadyReturnsTrueAfterPublication(t *testing.T) {
+func TestDispatcherManagerIsRedoReadyReturnsTrueAfterPublication(t *testing.T) {
 	t.Parallel()
 
 	dm := &DispatcherManager{
@@ -252,7 +252,7 @@ func TestIsRedoDispatcherManagerReadyReturnsTrueAfterPublication(t *testing.T) {
 	}
 	dm.redoReady.Store(true)
 
-	require.True(t, isRedoDispatcherManagerReady(dm))
+	require.True(t, dm.IsRedoReady())
 }
 
 func TestDispatcherManagerIsRedoReadyRequiresPublication(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/helper_test.go
+++ b/downstreamadapter/dispatchermanager/helper_test.go
@@ -254,3 +254,20 @@ func TestIsRedoDispatcherManagerReadyReturnsTrueAfterPublication(t *testing.T) {
 
 	require.True(t, isRedoDispatcherManagerReady(dm))
 }
+
+func TestDispatcherManagerIsRedoReadyRequiresPublication(t *testing.T) {
+	t.Parallel()
+
+	dm := &DispatcherManager{
+		RedoEnable:                true,
+		redoDispatcherMap:         newDispatcherMap[*dispatcher.RedoDispatcher](),
+		redoSink:                  &redo.Sink{},
+		redoSchemaIDToDispatchers: dispatcher.NewSchemaIDToDispatchers(),
+	}
+
+	require.False(t, dm.IsRedoReady())
+
+	dm.redoReady.Store(true)
+
+	require.True(t, dm.IsRedoReady())
+}

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -52,6 +52,13 @@ type DispatcherOrchestrator struct {
 	msgGuardWaitGroup util.GuardedWaitGroup
 }
 
+type bootstrapResponseManager interface {
+	GetDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]
+	GetRedoDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]
+	GetCurrentOperatorMap() *sync.Map
+	IsRedoReady() bool
+}
+
 func New() *DispatcherOrchestrator {
 	m := &DispatcherOrchestrator{
 		mc:                 appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter),
@@ -367,7 +374,7 @@ func (m *DispatcherOrchestrator) handleCloseRequest(
 
 func createBootstrapResponse(
 	changefeedID *heartbeatpb.ChangefeedID,
-	manager *dispatchermanager.DispatcherManager,
+	manager bootstrapResponseManager,
 	startTs, redoStartTs uint64,
 ) *heartbeatpb.MaintainerBootstrapResponse {
 	response := &heartbeatpb.MaintainerBootstrapResponse{
@@ -449,7 +456,7 @@ func (m *DispatcherOrchestrator) handleDispatcherError(
 }
 
 func retrieveRedoDispatcherSpanForBootstrapResponse(
-	manager *dispatchermanager.DispatcherManager,
+	manager bootstrapResponseManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
 	if !manager.IsRedoReady() {
@@ -469,7 +476,7 @@ func retrieveRedoDispatcherSpanForBootstrapResponse(
 }
 
 func retrieveDispatcherSpanForBootstrapResponse(
-	manager *dispatchermanager.DispatcherManager,
+	manager bootstrapResponseManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
 	manager.GetDispatcherMap().ForEach(func(id common.DispatcherID, d *dispatcher.EventDispatcher) {
@@ -487,7 +494,7 @@ func retrieveDispatcherSpanForBootstrapResponse(
 
 func retrieveOperatorsForBootstrapResponse(
 	changefeedID *heartbeatpb.ChangefeedID,
-	manager *dispatchermanager.DispatcherManager,
+	manager bootstrapResponseManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
 	manager.GetCurrentOperatorMap().Range(func(key, value any) bool {

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -52,13 +52,6 @@ type DispatcherOrchestrator struct {
 	msgGuardWaitGroup util.GuardedWaitGroup
 }
 
-type bootstrapResponseManager interface {
-	GetDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]
-	GetRedoDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]
-	GetCurrentOperatorMap() *sync.Map
-	IsRedoReady() bool
-}
-
 func New() *DispatcherOrchestrator {
 	m := &DispatcherOrchestrator{
 		mc:                 appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter),
@@ -374,7 +367,7 @@ func (m *DispatcherOrchestrator) handleCloseRequest(
 
 func createBootstrapResponse(
 	changefeedID *heartbeatpb.ChangefeedID,
-	manager bootstrapResponseManager,
+	manager *dispatchermanager.DispatcherManager,
 	startTs, redoStartTs uint64,
 ) *heartbeatpb.MaintainerBootstrapResponse {
 	response := &heartbeatpb.MaintainerBootstrapResponse{
@@ -456,7 +449,7 @@ func (m *DispatcherOrchestrator) handleDispatcherError(
 }
 
 func retrieveRedoDispatcherSpanForBootstrapResponse(
-	manager bootstrapResponseManager,
+	manager *dispatchermanager.DispatcherManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
 	if !manager.IsRedoReady() {
@@ -476,7 +469,7 @@ func retrieveRedoDispatcherSpanForBootstrapResponse(
 }
 
 func retrieveDispatcherSpanForBootstrapResponse(
-	manager bootstrapResponseManager,
+	manager *dispatchermanager.DispatcherManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
 	manager.GetDispatcherMap().ForEach(func(id common.DispatcherID, d *dispatcher.EventDispatcher) {
@@ -494,7 +487,7 @@ func retrieveDispatcherSpanForBootstrapResponse(
 
 func retrieveOperatorsForBootstrapResponse(
 	changefeedID *heartbeatpb.ChangefeedID,
-	manager bootstrapResponseManager,
+	manager *dispatchermanager.DispatcherManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
 	manager.GetCurrentOperatorMap().Range(func(key, value any) bool {

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -262,7 +262,7 @@ func (m *DispatcherOrchestrator) handleBootstrapRequest(
 	if tableTriggerDispatcher := manager.GetTableTriggerEventDispatcher(); tableTriggerDispatcher != nil {
 		startTs = tableTriggerDispatcher.GetStartTs()
 	}
-	if manager.RedoEnable {
+	if manager.IsRedoReady() {
 		if tableTriggerRedoDispatcher := manager.GetTableTriggerRedoDispatcher(); tableTriggerRedoDispatcher != nil {
 			redoStartTs = tableTriggerRedoDispatcher.GetStartTs()
 		}
@@ -322,7 +322,7 @@ func (m *DispatcherOrchestrator) handlePostBootstrapRequest(
 			zap.Any("changefeedID", cfId.Name()), zap.Error(err))
 		return m.handleDispatcherError(from, req.ChangefeedID, err)
 	}
-	if manager.RedoEnable {
+	if manager.IsRedoReady() {
 		err := manager.InitalizeTableTriggerRedoDispatcher(req.RedoSchemas)
 		if err != nil {
 			log.Error("failed to initialize table trigger redo dispatcher",
@@ -381,7 +381,7 @@ func createBootstrapResponse(
 	}
 
 	retrieveDispatcherSpanForBootstrapResponse(manager, response)
-	if manager.RedoEnable {
+	if manager.IsRedoReady() {
 		// table trigger redo dispatcher startTs
 		if redoStartTs != 0 {
 			response.RedoCheckpointTs = redoStartTs
@@ -452,6 +452,9 @@ func retrieveRedoDispatcherSpanForBootstrapResponse(
 	manager *dispatchermanager.DispatcherManager,
 	response *heartbeatpb.MaintainerBootstrapResponse,
 ) {
+	if !manager.IsRedoReady() {
+		return
+	}
 	manager.GetRedoDispatcherMap().ForEach(func(id common.DispatcherID, d *dispatcher.RedoDispatcher) {
 		response.Spans = append(response.Spans, &heartbeatpb.BootstrapTableSpan{
 			ID:              id.ToPB(),
@@ -491,7 +494,7 @@ func retrieveOperatorsForBootstrapResponse(
 		req := value.(dispatchermanager.SchedulerDispatcherRequest)
 		dispatcherID := common.NewDispatcherIDFromPB(req.Config.DispatcherID)
 		if common.IsRedoMode(req.Config.Mode) {
-			if manager.RedoEnable && manager.GetRedoDispatcherMap() != nil {
+			if manager.IsRedoReady() {
 				_, ok := manager.GetRedoDispatcherMap().Get(dispatcherID)
 				// Log error if dispatcher not found and action is not create
 				// It's possible that the dispatcher is not found when the action is create

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -229,7 +229,7 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 
 	t.Run("nil redo map", func(t *testing.T) {
 		manager := newBootstrapTestManager(t)
-		manager.RedoEnable = true
+		setDispatcherManagerField(t, manager, "redoEnabled", true)
 
 		require.NotPanics(t, func() {
 			response := createBootstrapResponse(changefeedID, manager, 0, 123)
@@ -240,7 +240,7 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 
 	t.Run("partial redo state", func(t *testing.T) {
 		manager := newBootstrapTestManager(t)
-		manager.RedoEnable = true
+		setDispatcherManagerField(t, manager, "redoEnabled", true)
 		setDispatcherManagerField(t, manager, "redoDispatcherMap", redoDispatcherMap)
 		manager.SetTableTriggerRedoDispatcher(redoDispatcher)
 
@@ -251,7 +251,7 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 
 	t.Run("published redo state", func(t *testing.T) {
 		manager := newBootstrapTestManager(t)
-		manager.RedoEnable = true
+		setDispatcherManagerField(t, manager, "redoEnabled", true)
 		setDispatcherManagerField(t, manager, "redoDispatcherMap", redoDispatcherMap)
 		setDispatcherManagerField(t, manager, "redoSchemaIDToDispatchers", dispatcher.NewSchemaIDToDispatchers())
 		setDispatcherManagerField(t, manager, "redoSink", &redo.Sink{})

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -14,15 +14,12 @@
 package dispatcherorchestrator
 
 import (
-	"reflect"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/pingcap/ticdc/downstreamadapter/dispatcher"
 	"github.com/pingcap/ticdc/downstreamadapter/dispatchermanager"
-	"github.com/pingcap/ticdc/downstreamadapter/sink/redo"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/messaging"
@@ -226,10 +223,12 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 	)
 	redoDispatcherMap := &dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]{}
 	redoDispatcherMap.Set(redoDispatcherID, redoDispatcher)
+	dispatcherMap := &dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]{}
 
 	t.Run("nil redo map", func(t *testing.T) {
-		manager := newBootstrapTestManager(t)
-		setDispatcherManagerField(t, manager, "redoEnabled", true)
+		manager := &fakeBootstrapResponseManager{
+			dispatcherMap: dispatcherMap,
+		}
 
 		require.NotPanics(t, func() {
 			response := createBootstrapResponse(changefeedID, manager, 0, 123)
@@ -239,10 +238,11 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 	})
 
 	t.Run("partial redo state", func(t *testing.T) {
-		manager := newBootstrapTestManager(t)
-		setDispatcherManagerField(t, manager, "redoEnabled", true)
-		setDispatcherManagerField(t, manager, "redoDispatcherMap", redoDispatcherMap)
-		manager.SetTableTriggerRedoDispatcher(redoDispatcher)
+		manager := &fakeBootstrapResponseManager{
+			dispatcherMap:     dispatcherMap,
+			redoReady:         false,
+			redoDispatcherMap: redoDispatcherMap,
+		}
 
 		response := createBootstrapResponse(changefeedID, manager, 0, 123)
 		require.Zero(t, response.RedoCheckpointTs)
@@ -250,13 +250,11 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 	})
 
 	t.Run("published redo state", func(t *testing.T) {
-		manager := newBootstrapTestManager(t)
-		setDispatcherManagerField(t, manager, "redoEnabled", true)
-		setDispatcherManagerField(t, manager, "redoDispatcherMap", redoDispatcherMap)
-		setDispatcherManagerField(t, manager, "redoSchemaIDToDispatchers", dispatcher.NewSchemaIDToDispatchers())
-		setDispatcherManagerField(t, manager, "redoSink", &redo.Sink{})
-		manager.SetTableTriggerRedoDispatcher(redoDispatcher)
-		setDispatcherManagerRedoReady(t, manager, true)
+		manager := &fakeBootstrapResponseManager{
+			dispatcherMap:     dispatcherMap,
+			redoReady:         true,
+			redoDispatcherMap: redoDispatcherMap,
+		}
 
 		response := createBootstrapResponse(changefeedID, manager, 0, 123)
 		require.Equal(t, uint64(123), response.RedoCheckpointTs)
@@ -264,29 +262,25 @@ func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
 	})
 }
 
-func newBootstrapTestManager(t *testing.T) *dispatchermanager.DispatcherManager {
-	t.Helper()
-
-	manager := &dispatchermanager.DispatcherManager{}
-	setDispatcherManagerField(t, manager, "dispatcherMap", &dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]{})
-	return manager
+type fakeBootstrapResponseManager struct {
+	dispatcherMap     *dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]
+	redoReady         bool
+	redoDispatcherMap *dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]
+	currentOperators  sync.Map
 }
 
-func setDispatcherManagerField[T any](t *testing.T, manager *dispatchermanager.DispatcherManager, field string, value T) {
-	t.Helper()
-
-	fieldValue := reflect.ValueOf(manager).Elem().FieldByName(field)
-	require.True(t, fieldValue.IsValid(), "field %s not found", field)
-
-	reflect.NewAt(fieldValue.Type(), unsafe.Pointer(fieldValue.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+func (m *fakeBootstrapResponseManager) GetDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher] {
+	return m.dispatcherMap
 }
 
-func setDispatcherManagerRedoReady(t *testing.T, manager *dispatchermanager.DispatcherManager, ready bool) {
-	t.Helper()
+func (m *fakeBootstrapResponseManager) IsRedoReady() bool {
+	return m.redoReady
+}
 
-	fieldValue := reflect.ValueOf(manager).Elem().FieldByName("redoReady")
-	require.True(t, fieldValue.IsValid(), "field redoReady not found")
+func (m *fakeBootstrapResponseManager) GetRedoDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher] {
+	return m.redoDispatcherMap
+}
 
-	readyFlag := (*atomic.Bool)(unsafe.Pointer(fieldValue.UnsafeAddr()))
-	readyFlag.Store(ready)
+func (m *fakeBootstrapResponseManager) GetCurrentOperatorMap() *sync.Map {
+	return &m.currentOperators
 }

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -4,18 +4,25 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package dispatcherorchestrator
 
 import (
+	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/pingcap/ticdc/downstreamadapter/dispatcher"
+	"github.com/pingcap/ticdc/downstreamadapter/dispatchermanager"
+	"github.com/pingcap/ticdc/downstreamadapter/sink/redo"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/messaging"
@@ -196,4 +203,90 @@ func TestGetPendingMessageKey_SupportedTypes(t *testing.T) {
 	key, ok = getPendingMessageKey(closeReq)
 	require.True(t, ok)
 	require.Equal(t, pendingMessageKey{changefeedID: cfID, msgType: messaging.TypeMaintainerCloseRequest}, key)
+}
+
+func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := &heartbeatpb.ChangefeedID{
+		Keyspace: "test-namespace",
+		Name:     "test-changefeed",
+	}
+	redoDispatcherID := common.NewDispatcherID()
+	redoDispatcher := dispatcher.NewRedoDispatcher(
+		redoDispatcherID,
+		common.KeyspaceDDLSpan(0),
+		123,
+		0,
+		dispatcher.NewSchemaIDToDispatchers(),
+		false,
+		false,
+		nil,
+		nil,
+	)
+	redoDispatcherMap := &dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]{}
+	redoDispatcherMap.Set(redoDispatcherID, redoDispatcher)
+
+	t.Run("nil redo map", func(t *testing.T) {
+		manager := newBootstrapTestManager(t)
+		manager.RedoEnable = true
+
+		require.NotPanics(t, func() {
+			response := createBootstrapResponse(changefeedID, manager, 0, 123)
+			require.Zero(t, response.RedoCheckpointTs)
+			require.Empty(t, response.Spans)
+		})
+	})
+
+	t.Run("partial redo state", func(t *testing.T) {
+		manager := newBootstrapTestManager(t)
+		manager.RedoEnable = true
+		setDispatcherManagerField(t, manager, "redoDispatcherMap", redoDispatcherMap)
+		manager.SetTableTriggerRedoDispatcher(redoDispatcher)
+
+		response := createBootstrapResponse(changefeedID, manager, 0, 123)
+		require.Zero(t, response.RedoCheckpointTs)
+		require.Empty(t, response.Spans)
+	})
+
+	t.Run("published redo state", func(t *testing.T) {
+		manager := newBootstrapTestManager(t)
+		manager.RedoEnable = true
+		setDispatcherManagerField(t, manager, "redoDispatcherMap", redoDispatcherMap)
+		setDispatcherManagerField(t, manager, "redoSchemaIDToDispatchers", dispatcher.NewSchemaIDToDispatchers())
+		setDispatcherManagerField(t, manager, "redoSink", &redo.Sink{})
+		manager.SetTableTriggerRedoDispatcher(redoDispatcher)
+		setDispatcherManagerRedoReady(t, manager, true)
+
+		response := createBootstrapResponse(changefeedID, manager, 0, 123)
+		require.Equal(t, uint64(123), response.RedoCheckpointTs)
+		require.Len(t, response.Spans, 1)
+	})
+}
+
+func newBootstrapTestManager(t *testing.T) *dispatchermanager.DispatcherManager {
+	t.Helper()
+
+	manager := &dispatchermanager.DispatcherManager{}
+	setDispatcherManagerField(t, manager, "dispatcherMap", &dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]{})
+	return manager
+}
+
+func setDispatcherManagerField[T any](t *testing.T, manager *dispatchermanager.DispatcherManager, field string, value T) {
+	t.Helper()
+
+	fieldValue := reflect.ValueOf(manager).Elem().FieldByName(field)
+	require.True(t, fieldValue.IsValid(), "field %s not found", field)
+
+	reflect.NewAt(fieldValue.Type(), unsafe.Pointer(fieldValue.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+func setDispatcherManagerRedoReady(t *testing.T, manager *dispatchermanager.DispatcherManager, ready bool) {
+	t.Helper()
+
+	fieldValue := reflect.ValueOf(manager).Elem().FieldByName("redoReady")
+	require.True(t, fieldValue.IsValid(), "field redoReady not found")
+
+	readyFlag := (*atomic.Bool)(unsafe.Pointer(fieldValue.UnsafeAddr()))
+	readyFlag.Store(ready)
 }

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -14,12 +14,9 @@
 package dispatcherorchestrator
 
 import (
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/pingcap/ticdc/downstreamadapter/dispatcher"
-	"github.com/pingcap/ticdc/downstreamadapter/dispatchermanager"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/messaging"
@@ -200,87 +197,4 @@ func TestGetPendingMessageKey_SupportedTypes(t *testing.T) {
 	key, ok = getPendingMessageKey(closeReq)
 	require.True(t, ok)
 	require.Equal(t, pendingMessageKey{changefeedID: cfID, msgType: messaging.TypeMaintainerCloseRequest}, key)
-}
-
-func TestCreateBootstrapResponseSkipsRedoUntilReady(t *testing.T) {
-	t.Parallel()
-
-	changefeedID := &heartbeatpb.ChangefeedID{
-		Keyspace: "test-namespace",
-		Name:     "test-changefeed",
-	}
-	redoDispatcherID := common.NewDispatcherID()
-	redoDispatcher := dispatcher.NewRedoDispatcher(
-		redoDispatcherID,
-		common.KeyspaceDDLSpan(0),
-		123,
-		0,
-		dispatcher.NewSchemaIDToDispatchers(),
-		false,
-		false,
-		nil,
-		nil,
-	)
-	redoDispatcherMap := &dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]{}
-	redoDispatcherMap.Set(redoDispatcherID, redoDispatcher)
-	dispatcherMap := &dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]{}
-
-	t.Run("nil redo map", func(t *testing.T) {
-		manager := &fakeBootstrapResponseManager{
-			dispatcherMap: dispatcherMap,
-		}
-
-		require.NotPanics(t, func() {
-			response := createBootstrapResponse(changefeedID, manager, 0, 123)
-			require.Zero(t, response.RedoCheckpointTs)
-			require.Empty(t, response.Spans)
-		})
-	})
-
-	t.Run("partial redo state", func(t *testing.T) {
-		manager := &fakeBootstrapResponseManager{
-			dispatcherMap:     dispatcherMap,
-			redoReady:         false,
-			redoDispatcherMap: redoDispatcherMap,
-		}
-
-		response := createBootstrapResponse(changefeedID, manager, 0, 123)
-		require.Zero(t, response.RedoCheckpointTs)
-		require.Empty(t, response.Spans)
-	})
-
-	t.Run("published redo state", func(t *testing.T) {
-		manager := &fakeBootstrapResponseManager{
-			dispatcherMap:     dispatcherMap,
-			redoReady:         true,
-			redoDispatcherMap: redoDispatcherMap,
-		}
-
-		response := createBootstrapResponse(changefeedID, manager, 0, 123)
-		require.Equal(t, uint64(123), response.RedoCheckpointTs)
-		require.Len(t, response.Spans, 1)
-	})
-}
-
-type fakeBootstrapResponseManager struct {
-	dispatcherMap     *dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher]
-	redoReady         bool
-	redoDispatcherMap *dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher]
-	currentOperators  sync.Map
-}
-
-func (m *fakeBootstrapResponseManager) GetDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.EventDispatcher] {
-	return m.dispatcherMap
-}
-
-func (m *fakeBootstrapResponseManager) IsRedoReady() bool {
-	return m.redoReady
-}
-
-func (m *fakeBootstrapResponseManager) GetRedoDispatcherMap() *dispatchermanager.DispatcherMap[*dispatcher.RedoDispatcher] {
-	return m.redoDispatcherMap
-}
-
-func (m *fakeBootstrapResponseManager) GetCurrentOperatorMap() *sync.Map {
-	return &m.currentOperators
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4402

The integration case fail_over_ddl_mix_with_syncpoint can fail because check_logs catches a data race in dispatcher manager bootstrap, even when sync_diff passes.

### What is changed and how it works?

This PR separates redo configuration from redo runtime readiness publication:
- keep `RedoEnable` immutable as changefeed configuration state
- add an atomic `redoReady` flag and publish it only after `redoSink`, `redoDispatcherMap`, and `redoSchemaIDToDispatchers` are fully initialized
- gate `isRedoDispatcherManagerReady()` on that atomic publication before reading redo component pointers
- add focused regression tests, including a `go test -race` case for the original read/write interleaving

### Check List

#### Tests

- Unit test

Verified with:
- `GOCACHE=/tmp/gocache GOTMPDIR=/tmp/gotmp go test -race ./downstreamadapter/dispatchermanager -run TestIsRedoDispatcherManagerReady -count=1`
- `GOCACHE=/tmp/gocache GOTMPDIR=/tmp/gotmp go test ./downstreamadapter/dispatchermanager -run TestIsRedoDispatcherManagerReady -count=1`
- `GOCACHE=/tmp/gocache GOTMPDIR=/tmp/gotmp go test ./downstreamadapter/dispatchermanager -run TestPreCheckForSchedulerHandler -count=1`

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only replaces an unsafe readiness publication path with an atomic flag check and does not change external behavior or APIs.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix a data race in dispatcher manager redo readiness publication during bootstrap and failover.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redo readiness and gating redesigned: internal redo state is encapsulated and redo behavior is only used when explicitly ready; added public status checks to query redo enablement and readiness.

* **Tests**
  * Added extensive tests covering redo readiness, concurrent mutation scenarios, publication gating, and bootstrap behavior to ensure redo is skipped until fully available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->