### PR TITLE
event: assert DDLEvent.NotSync survives Marshal Unmarshal

### DIFF
--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -104,6 +104,10 @@ type DDLEvent struct {
 	// to ensure the new truncated table can be handled correctly.
 	// If the DDL involves multiple tables, this field is not effective.
 	// The multiple table DDL event will be handled by filtering querys and table infos.
+	// NOTE: The `msg` tag is a legacy tag kept for backward compatibility.
+	// DDLEventVersion1 still marshals the struct with encoding/json, so changing this
+	// field to `json:"not_sync"` would change the wire key from `NotSync` to
+	// `not_sync` and break mixed-version DDLEvent interoperability.
 	NotSync bool `msg:"not_sync"`
 }
 

--- a/pkg/common/event/ddl_event_test.go
+++ b/pkg/common/event/ddl_event_test.go
@@ -41,6 +41,9 @@ func TestDDLEvent(t *testing.T) {
 		Query:        ddlJob.Query,
 		TableInfo:    common.WrapTableInfo(ddlJob.SchemaName, ddlJob.BinlogInfo.TableInfo),
 		FinishedTs:   ddlJob.BinlogInfo.FinishedTS,
+		// NotSync must survive Marshal/Unmarshal because it controls whether dispatchers
+		// should forward this DDL to downstream sinks.
+		NotSync: true,
 		BlockedTableNames: []SchemaTableName{
 			{SchemaName: ddlJob.SchemaName, TableName: ddlJob.TableName},
 		},
@@ -78,6 +81,7 @@ func TestDDLEvent(t *testing.T) {
 	require.Equal(t, ddlEvent.FinishedTs, reverseEvent.FinishedTs)
 	require.Equal(t, ddlEvent.Err, reverseEvent.Err)
 	require.Equal(t, ddlEvent.BlockedTableNames, reverseEvent.BlockedTableNames)
+	require.Equal(t, ddlEvent.NotSync, reverseEvent.NotSync)
 
 	// Test unsupported version in Marshal
 	mockDDLVersion1 := 99


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #4419

### What is changed and how it works?
- Add a Marshal/Unmarshal round-trip assertion for `DDLEvent.NotSync`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DDL event handling to properly preserve synchronization state during serialization, ensuring data consistency in event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->