### PR TITLE
tests: disable same_upstream_downstream in release-8.5 CI

### DIFF
--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -44,7 +44,10 @@ mysql_groups=(
 	# G05
 	'vector simple partition_table fail_over_ddl_F conflict_key_generated_column wide_table'
 	# G06
-	'http_api http_api_compatibility http_api_tls http_api_tls_old_arch fail_over_ddl_G synced_status same_upstream_downstream'
+	# NOTE: same_upstream_downstream is temporarily disabled on release-8.5 CI because TiDB 8.5.x
+	# does not write `cluster_id` into `mysql.tidb` (tidb#59511 not cherry-picked). Re-enable it
+	# after TiDB release-8.5 has `mysql.tidb.cluster_id`.
+	'http_api http_api_compatibility http_api_tls http_api_tls_old_arch fail_over_ddl_G synced_status'
 	# G07
 	'http_api_tls_with_user_auth fail_over_ddl_H changefeed_update_config synced_status_with_redo'
 	# G08


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4422

### What is changed and how it works?

Temporarily disable the `same_upstream_downstream` integration test in `release-8.5` CI, because TiDB 8.5.x (release-8.5 line) does not write `cluster_id` into `mysql.tidb` (pingcap/tidb#59511 was not cherry-picked to release-8.5). Re-enable it after TiDB release-8.5 has `mysql.tidb.cluster_id`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Manual test

Manual test steps:
- `bash -n tests/integration_tests/run_light_it_in_ci.sh`

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
