### PR TITLE
test: fix data race in maintainer unit test

### DIFF
--- a/maintainer/maintainer_manager_test.go
+++ b/maintainer/maintainer_manager_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,11 +57,25 @@ func newTestNodeWithListener(t *testing.T) (*node.Info, net.Listener) {
 	return n, lis
 }
 
+func runCancelable(t *testing.T, ctx context.Context, run func(context.Context) error) {
+	t.Helper()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx)
+	}()
+
+	t.Cleanup(func() {
+		require.ErrorIs(t, <-errCh, context.Canceled)
+	})
+}
+
 // This is a integration test for maintainer manager, it may consume a lot of time.
 // scale out/in close, add/remove tables
 func TestMaintainerSchedulesNodeChanges(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	selfNode, selfLis := newTestNodeWithListener(t)
 	etcdClient := newMockEtcdClient(string(selfNode.ID))
 	nodeManager := watcher.NewNodeManager(nil, etcdClient)
@@ -105,13 +120,9 @@ func TestMaintainerSchedulesNodeChanges(t *testing.T) {
 		&heartbeatpb.CoordinatorBootstrapRequest{Version: 1})
 	msg.From = msg.To
 	manager.onCoordinatorBootstrapRequest(msg)
-	go func() {
-		_ = manager.Run(ctx)
-	}()
+	runCancelable(t, ctx, manager.Run)
 	dispManager := MockDispatcherManager(mc, selfNode.ID)
-	go func() {
-		_ = dispManager.Run(ctx)
-	}()
+	runCancelable(t, ctx, dispManager.Run)
 
 	keyspaceMeta := common.DefaultKeyspace
 	if kerneltype.IsNextGen() {
@@ -295,6 +306,7 @@ func TestMaintainerSchedulesNodeChanges(t *testing.T) {
 func TestMaintainerBootstrapWithTablesReported(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	selfNode, selfLis := newTestNodeWithListener(t)
 	etcdClient := newMockEtcdClient(string(selfNode.ID))
 	nodeManager := watcher.NewNodeManager(nil, etcdClient)
@@ -336,9 +348,7 @@ func TestMaintainerBootstrapWithTablesReported(t *testing.T) {
 		&heartbeatpb.CoordinatorBootstrapRequest{Version: 1})
 	msg.From = msg.To
 	manager.onCoordinatorBootstrapRequest(msg)
-	go func() {
-		_ = manager.Run(ctx)
-	}()
+	runCancelable(t, ctx, manager.Run)
 	dispManager := MockDispatcherManager(mc, selfNode.ID)
 	// table1 and table 2 will be reported by remote
 	var remotedIds []common.DispatcherID
@@ -369,9 +379,7 @@ func TestMaintainerBootstrapWithTablesReported(t *testing.T) {
 		})
 	}
 
-	go func() {
-		_ = dispManager.Run(ctx)
-	}()
+	runCancelable(t, ctx, dispManager.Run)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	cfConfig := &config.ChangeFeedInfo{
 		ChangefeedID: cfID,
@@ -426,6 +434,7 @@ func TestMaintainerBootstrapWithTablesReported(t *testing.T) {
 func TestStopNotExistsMaintainer(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	selfNode, selfLis := newTestNodeWithListener(t)
 	etcdClient := newMockEtcdClient(string(selfNode.ID))
 	nodeManager := watcher.NewNodeManager(nil, etcdClient)
@@ -483,13 +492,9 @@ func TestStopNotExistsMaintainer(t *testing.T) {
 		&heartbeatpb.CoordinatorBootstrapRequest{Version: 1})
 	msg.From = msg.To
 	manager.onCoordinatorBootstrapRequest(msg)
-	go func() {
-		_ = manager.Run(ctx)
-	}()
+	runCancelable(t, ctx, manager.Run)
 	dispManager := MockDispatcherManager(mc, selfNode.ID)
-	go func() {
-		_ = dispManager.Run(ctx)
-	}()
+	runCancelable(t, ctx, dispManager.Run)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	_ = mc.SendCommand(messaging.NewSingleTargetMessage(selfNode.ID, messaging.MaintainerManagerTopic, &heartbeatpb.RemoveMaintainerRequest{
 		Id:      cfID.ToPB(),
@@ -509,14 +514,16 @@ func TestStopNotExistsMaintainer(t *testing.T) {
 }
 
 type dispatcherNode struct {
-	cancel            context.CancelFunc
-	mc                messaging.MessageCenter
-	dispatcherManager *mockDispatcherManager
+	cancel   context.CancelFunc
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 func (d *dispatcherNode) stop() {
-	d.mc.Close()
-	d.cancel()
+	d.stopOnce.Do(func() {
+		d.cancel()
+		<-d.done
+	})
 }
 
 func startDispatcherNode(
@@ -532,7 +539,9 @@ func startDispatcherNode(
 	nodeManager.RegisterNodeChangeHandler(node.ID, mc.OnNodeChanges)
 	ctx, cancel := context.WithCancel(ctx)
 	dispManager := MockDispatcherManager(mc, node.ID)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		var opts []grpc.ServerOption
 		grpcServer := grpc.NewServer(opts...)
 		mcs := messaging.NewMessageCenterServer(mc)
@@ -543,11 +552,9 @@ func startDispatcherNode(
 		_ = dispManager.Run(ctx)
 		grpcServer.Stop()
 	}()
-	return &dispatcherNode{
-		cancel:            cancel,
-		mc:                mc,
-		dispatcherManager: dispManager,
-	}
+	dn := &dispatcherNode{cancel: cancel, done: done}
+	t.Cleanup(dn.stop)
+	return dn
 }
 
 type mockEtcdClient struct {

--- a/maintainer/maintainer_test.go
+++ b/maintainer/maintainer_test.go
@@ -262,6 +262,7 @@ func TestMaintainerSchedule(t *testing.T) {
 	// The test intentionally avoids binding any fixed TCP ports so it can run
 	// reliably in sandboxed CI environments (and in parallel with other packages).
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	const tableSize = 100
 	tables := make([]commonEvent.Table, 0, tableSize)
@@ -342,9 +343,15 @@ func TestMaintainerSchedule(t *testing.T) {
 		return maintainer.controller.spanController.GetTaskSizeByNodeID(n.ID) == tableSize
 	}, 20*time.Second, 100*time.Millisecond)
 
-	maintainer.onRemoveMaintainer(false, false)
 	require.Eventually(t, func() bool {
-		return maintainer.tryCloseChangefeed()
+		err := mc.SendCommand(messaging.NewSingleTargetMessage(
+			n.ID,
+			messaging.MaintainerManagerTopic,
+			&heartbeatpb.RemoveMaintainerRequest{Id: cfID.ToPB()},
+		))
+		require.NoError(t, err)
+		return maintainer.removed.Load() &&
+			maintainer.scheduleState.Load() == int32(heartbeatpb.ComponentState_Stopped)
 	}, 20*time.Second, 100*time.Millisecond)
 
 	cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4332

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup and synchronization mechanisms for maintainer and dispatcher components to ensure proper goroutine management and resource release during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->