### PR TITLE
cmd/storage-consumer: gate apply by checkpoint

### DIFF
--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -65,7 +66,10 @@ type consumer struct {
 	sink            sink.Sink
 	// tableDMLIdxMap maintains a map of <dmlPathKey, fileIndexKeyMap>
 	tableDMLIdxMap map[cloudstorage.DmlPathKey]fileIndexKeyMap
-	eventsGroup    map[int64]*util.EventsGroup
+	// handledDMLIdxMap maintains the highest file indexes already applied to downstream.
+	// Keys discovered in storage remain pending until they are successfully handled.
+	handledDMLIdxMap map[cloudstorage.DmlPathKey]fileIndexKeyMap
+	eventsGroup      map[int64]*util.EventsGroup
 	// tableDDLWatermark maintains a map of <`schema`.`table`, max executed DDL table version>.
 	// DML files with smaller table versions are considered stale replays and should be ignored.
 	tableDDLWatermark map[string]uint64
@@ -152,6 +156,7 @@ func newConsumer(ctx context.Context) (*consumer, error) {
 		sink:              sink,
 		errCh:             errCh,
 		tableDMLIdxMap:    make(map[cloudstorage.DmlPathKey]fileIndexKeyMap),
+		handledDMLIdxMap:  make(map[cloudstorage.DmlPathKey]fileIndexKeyMap),
 		eventsGroup:       make(map[int64]*util.EventsGroup),
 		tableDDLWatermark: make(map[string]uint64),
 		tableDefMap:       make(map[string]map[uint64]*cloudstorage.TableDefinition),
@@ -202,15 +207,6 @@ func (c *consumer) getNewFiles(
 	tableDMLMap := make(map[cloudstorage.DmlPathKey]fileIndexRange)
 	opt := &storage.WalkOption{SubDir: ""}
 
-	origDMLIdxMap := make(map[cloudstorage.DmlPathKey]fileIndexKeyMap, len(c.tableDMLIdxMap))
-	for k, v := range c.tableDMLIdxMap {
-		m := make(fileIndexKeyMap)
-		for fileIndexKey, val := range v {
-			m[fileIndexKey] = val
-		}
-		origDMLIdxMap[k] = m
-	}
-
 	err := c.externalStorage.WalkDir(ctx, opt, func(path string, size int64) error {
 		if cloudstorage.IsSchemaFile(path) {
 			err := c.parseSchemaFilePath(ctx, path)
@@ -235,8 +231,40 @@ func (c *consumer) getNewFiles(
 		return tableDMLMap, err
 	}
 
-	tableDMLMap = diffDMLMaps(c.tableDMLIdxMap, origDMLIdxMap)
+	tableDMLMap = diffDMLMaps(c.tableDMLIdxMap, c.handledDMLIdxMap)
 	return tableDMLMap, err
+}
+
+func (c *consumer) getStableCheckpointTs(ctx context.Context) (uint64, error) {
+	data, err := c.externalStorage.ReadFile(ctx, "metadata")
+	if err != nil {
+		if os.IsNotExist(errors.Cause(err)) {
+			return 0, nil
+		}
+		return 0, errors.Trace(err)
+	}
+
+	var metadata struct {
+		CheckpointTs uint64 `json:"checkpoint-ts"`
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return 0, errors.Trace(err)
+	}
+	return metadata.CheckpointTs, nil
+}
+
+func cloneFileIndexKeyMap(src fileIndexKeyMap) fileIndexKeyMap {
+	dst := make(fileIndexKeyMap, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func (c *consumer) markDMLPathHandled(pathKey cloudstorage.DmlPathKey) {
+	if fileIndexes, ok := c.tableDMLIdxMap[pathKey]; ok {
+		c.handledDMLIdxMap[pathKey] = cloneFileIndexKeyMap(fileIndexes)
+	}
 }
 
 func (c *consumer) appendRow2Group(dml *event.DMLEvent, enableTableAcrossNodes bool) {
@@ -516,6 +544,7 @@ func (c *consumer) mustGetTableDef(key cloudstorage.SchemaPathKey) cloudstorage.
 func (c *consumer) handleNewFiles(
 	ctx context.Context,
 	dmlFileMap map[cloudstorage.DmlPathKey]fileIndexRange,
+	stableCheckpointTs uint64,
 	round uint64,
 ) error {
 	if len(dmlFileMap) == 0 {
@@ -549,12 +578,26 @@ func (c *consumer) handleNewFiles(
 		log.Info("storage consumer handle file key",
 			zap.Uint64("round", round),
 			zap.Int("order", order),
+			zap.Uint64("stableCheckpointTs", stableCheckpointTs),
 			zap.String("schema", key.Schema),
 			zap.String("table", key.Table),
 			zap.Uint64("tableVersion", key.TableVersion),
 			zap.Int64("partition", key.PartitionNum),
 			zap.String("date", key.Date),
 			zap.Int("rangeCount", len(dmlFileMap[key])))
+
+		if key.TableVersion > stableCheckpointTs {
+			log.Info("storage consumer defer file key until checkpoint catches up",
+				zap.Uint64("round", round),
+				zap.Int("order", order),
+				zap.String("schema", key.Schema),
+				zap.String("table", key.Table),
+				zap.Uint64("tableVersion", key.TableVersion),
+				zap.Uint64("stableCheckpointTs", stableCheckpointTs),
+				zap.Int64("partition", key.PartitionNum),
+				zap.String("date", key.Date))
+			continue
+		}
 
 		// if the key is a fake dml path key which is mainly used for
 		// sorting schema.json file before the dml files, then execute the ddl query.
@@ -564,6 +607,7 @@ func (c *consumer) handleNewFiles(
 					zap.String("schema", key.Schema), zap.String("table", key.Table),
 					zap.Uint64("tableVersion", key.TableVersion), zap.Uint64("ddlWatermark", ddlWatermark),
 					zap.String("query", tableDef.Query))
+				c.markDMLPathHandled(key)
 				continue
 			}
 
@@ -586,6 +630,7 @@ func (c *consumer) handleNewFiles(
 				return errors.Trace(err)
 			}
 			c.tableDDLWatermark[tableKey] = key.TableVersion
+			c.markDMLPathHandled(key)
 			// TODO: need to cleanup tableDefMap in the future.
 			log.Info("execute ddl event successfully",
 				zap.String("query", tableDef.Query),
@@ -601,6 +646,7 @@ func (c *consumer) handleNewFiles(
 				zap.String("schema", key.Schema), zap.String("table", key.Table),
 				zap.Uint64("tableVersion", key.TableVersion), zap.Uint64("ddlWatermark", ddlWatermark),
 				zap.Int64("partition", key.PartitionNum), zap.String("date", key.Date))
+			c.markDMLPathHandled(key)
 			continue
 		}
 
@@ -633,7 +679,10 @@ func (c *consumer) handleNewFiles(
 				}
 			}
 		}
-		c.flushDMLEvents(ctx, tableID)
+		if err := c.flushDMLEvents(ctx, tableID); err != nil {
+			return err
+		}
+		c.markDMLPathHandled(key)
 	}
 
 	return nil
@@ -668,15 +717,20 @@ func (c *consumer) handle(ctx context.Context) error {
 		}
 
 		round++
+		stableCheckpointTs, err := c.getStableCheckpointTs(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		dmlFileMap, err := c.getNewFiles(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		log.Info("storage consumer scan done",
 			zap.Uint64("round", round),
+			zap.Uint64("stableCheckpointTs", stableCheckpointTs),
 			zap.Int("dmlPathKeyCount", len(dmlFileMap)))
 
-		err = c.handleNewFiles(ctx, dmlFileMap, round)
+		err = c.handleNewFiles(ctx, dmlFileMap, stableCheckpointTs, round)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/storage-consumer/consumer_test.go
+++ b/cmd/storage-consumer/consumer_test.go
@@ -1,0 +1,232 @@
+//go:build intest
+// +build intest
+
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sync"
+	"testing"
+
+	"github.com/pingcap/ticdc/cmd/util"
+	"github.com/pingcap/ticdc/pkg/common"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/sink/cloudstorage"
+	codeccommon "github.com/pingcap/ticdc/pkg/sink/codec/common"
+	putil "github.com/pingcap/ticdc/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSink struct {
+	mu  sync.Mutex
+	ops []string
+}
+
+func (s *recordingSink) SinkType() common.SinkType { return common.BlackHoleSinkType }
+func (s *recordingSink) IsNormal() bool            { return true }
+
+func (s *recordingSink) AddDMLEvent(event *commonEvent.DMLEvent) {
+	s.mu.Lock()
+	s.ops = append(s.ops, fmt.Sprintf("dml:%s.%s", event.TableInfo.GetSchemaName(), event.TableInfo.GetTableName()))
+	s.mu.Unlock()
+	event.PostFlush()
+}
+
+func (s *recordingSink) FlushDMLBeforeBlock(event commonEvent.BlockEvent) error { return nil }
+
+func (s *recordingSink) WriteBlockEvent(event commonEvent.BlockEvent) error {
+	ddl, ok := event.(*commonEvent.DDLEvent)
+	if !ok {
+		return fmt.Errorf("unexpected block event type %T", event)
+	}
+	s.mu.Lock()
+	s.ops = append(s.ops, "ddl:"+ddl.Query)
+	s.mu.Unlock()
+	event.PostFlush()
+	return nil
+}
+
+func (s *recordingSink) AddCheckpointTs(ts uint64) {}
+
+func (s *recordingSink) SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStore) {}
+
+func (s *recordingSink) Close(removeChangefeed bool) {}
+
+func (s *recordingSink) Run(ctx context.Context) error { return nil }
+
+func (s *recordingSink) Operations() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.ops...)
+}
+
+func newTestConsumer(t *testing.T) (*consumer, *recordingSink) {
+	t.Helper()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	uri := fmt.Sprintf("file:///%s", dir)
+	externalStorage, err := putil.GetExternalStorageWithDefaultTimeout(ctx, uri)
+	require.NoError(t, err)
+
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.DateSeparator = putil.AddressOf(config.DateSeparatorDay.String())
+	codecCfg := codeccommon.NewConfig(config.ProtocolCsv)
+	codecCfg.Delimiter = ","
+	codecCfg.Quote = "\""
+	codecCfg.NullString = "\\N"
+	codecCfg.Terminator = "\n"
+	codecCfg.IncludeCommitTs = true
+
+	recording := &recordingSink{}
+
+	oldWidth := fileIndexWidth
+	fileIndexWidth = config.DefaultFileIndexWidth
+
+	t.Cleanup(func() {
+		fileIndexWidth = oldWidth
+		externalStorage.Close()
+	})
+
+	return &consumer{
+		replicationCfg:    replicaConfig,
+		codecCfg:          codecCfg,
+		externalStorage:   externalStorage,
+		fileExtension:     ".csv",
+		sink:              recording,
+		tableDMLIdxMap:    make(map[cloudstorage.DmlPathKey]fileIndexKeyMap),
+		handledDMLIdxMap:  make(map[cloudstorage.DmlPathKey]fileIndexKeyMap),
+		eventsGroup:       make(map[int64]*util.EventsGroup),
+		tableDDLWatermark: make(map[string]uint64),
+		tableDefMap:       make(map[string]map[uint64]*cloudstorage.TableDefinition),
+		tableIDGenerator:  &fakeTableIDGenerator{tableIDs: make(map[string]int64)},
+		errCh:             make(chan error, 1),
+	}, recording
+}
+
+func writeMetadataFile(t *testing.T, c *consumer, checkpointTs uint64) {
+	t.Helper()
+	err := c.externalStorage.WriteFile(context.Background(), "metadata", []byte(fmt.Sprintf(`{"checkpoint-ts":%d}`, checkpointTs)))
+	require.NoError(t, err)
+}
+
+func writeSchemaFile(t *testing.T, c *consumer, tableDef cloudstorage.TableDefinition) {
+	t.Helper()
+	path, err := tableDef.GenerateSchemaFilePath()
+	require.NoError(t, err)
+	data, err := tableDef.MarshalWithQuery()
+	require.NoError(t, err)
+	err = c.externalStorage.WriteFile(context.Background(), path, data)
+	require.NoError(t, err)
+}
+
+func writeDMLFile(
+	t *testing.T,
+	c *consumer,
+	pathKey cloudstorage.DmlPathKey,
+	date string,
+	content string,
+) {
+	t.Helper()
+
+	fileIndex := &cloudstorage.FileIndex{Idx: 1}
+	dataPath := pathKey.GenerateDMLFilePath(fileIndex, c.fileExtension, fileIndexWidth)
+	indexPath := path.Join(
+		pathKey.Schema,
+		pathKey.Table,
+		fmt.Sprintf("%d", pathKey.TableVersion),
+		date,
+		"meta",
+		"CDC.index",
+	)
+	err := c.externalStorage.WriteFile(context.Background(), dataPath, []byte(content))
+	require.NoError(t, err)
+	err = c.externalStorage.WriteFile(context.Background(), indexPath, []byte("CDC000001.csv\n"))
+	require.NoError(t, err)
+}
+
+func TestHandleNewFilesWaitsForStableCheckpointBeforeApplyingRenameChain(t *testing.T) {
+	ctx := context.Background()
+	consumer, recording := newTestConsumer(t)
+	schemaName := "cdc_storage_test"
+
+	helper := commonEvent.NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.DDL2Job("create database " + schemaName)
+	helper.DDL2Event(fmt.Sprintf("create table %s.table_8(id int primary key, v varchar(32))", schemaName))
+
+	renameTo108 := helper.DDL2Event(fmt.Sprintf("rename table %s.table_8 to %s.table_108", schemaName, schemaName))
+	renameBackTo8 := helper.DDL2Event(fmt.Sprintf("rename table %s.table_108 to %s.table_8", schemaName, schemaName))
+
+	var renameTo108Def cloudstorage.TableDefinition
+	renameTo108Def.FromTableInfo(schemaName, "table_108", renameTo108.TableInfo, renameTo108.FinishedTs, false)
+	renameTo108Def.Query = renameTo108.Query
+	renameTo108Def.Type = renameTo108.Type
+	var renameBackTo8Def cloudstorage.TableDefinition
+	renameBackTo8Def.FromTableInfo(schemaName, "table_8", renameBackTo8.TableInfo, renameBackTo8.FinishedTs, false)
+	renameBackTo8Def.Query = renameBackTo8.Query
+	renameBackTo8Def.Type = renameBackTo8.Type
+
+	writeSchemaFile(t, consumer, renameTo108Def)
+	writeSchemaFile(t, consumer, renameBackTo8Def)
+
+	round1Checkpoint := renameTo108.FinishedTs - 1
+	writeMetadataFile(t, consumer, round1Checkpoint)
+
+	round1Files, err := consumer.getNewFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, round1Files, 2)
+	require.NoError(t, consumer.handleNewFiles(ctx, round1Files, round1Checkpoint, 1))
+	require.Empty(t, recording.Operations())
+	require.Empty(t, consumer.handledDMLIdxMap)
+
+	dmlDate := "2026-03-10"
+	pathKey := cloudstorage.DmlPathKey{
+		SchemaPathKey: cloudstorage.SchemaPathKey{
+			Schema:       schemaName,
+			Table:        "table_108",
+			TableVersion: renameTo108.FinishedTs,
+		},
+		PartitionNum: 0,
+		Date:         dmlDate,
+	}
+	writeDMLFile(
+		t,
+		consumer,
+		pathKey,
+		dmlDate,
+		fmt.Sprintf("\"I\",\"%s\",\"%s\",%d,124,\"value\"\n",
+			"table_108", schemaName, renameTo108.FinishedTs+1),
+	)
+
+	round2Checkpoint := renameBackTo8.FinishedTs
+	writeMetadataFile(t, consumer, round2Checkpoint)
+
+	round2Files, err := consumer.getNewFiles(ctx)
+	require.NoError(t, err)
+	require.Len(t, round2Files, 3)
+	require.NoError(t, consumer.handleNewFiles(ctx, round2Files, round2Checkpoint, 2))
+	require.Equal(t, []string{
+		"ddl:" + renameTo108.Query,
+		"dml:" + schemaName + ".table_108",
+		"ddl:" + renameBackTo8.Query,
+	}, recording.Operations())
+	require.Len(t, consumer.handledDMLIdxMap, 3)
+}

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"net/http"
 	"net/url"
@@ -56,33 +57,38 @@ func init() {
 		config.DefaultFileIndexWidth, "file index width")
 	flag.BoolVar(&enableProfiling, "enable-profiling", false, "whether to enable profiling")
 	flag.StringVar(&timezone, "tz", "System", "Specify time zone of storage consumer")
-	flag.Parse()
+}
 
+func initialize() error {
 	err := logger.InitLogger(&logger.Config{
 		Level: logLevel,
 		File:  logFile,
 	})
 	if err != nil {
-		log.Error("init logger failed", zap.Error(err))
-		os.Exit(1)
+		return err
 	}
 
 	uri, err := url.Parse(upstreamURIStr)
 	if err != nil {
-		log.Error("invalid upstream-uri", zap.Error(err))
-		os.Exit(1)
+		return err
 	}
 	upstreamURI = uri
 	scheme := strings.ToLower(upstreamURI.Scheme)
 	if !config.IsStorageScheme(scheme) {
-		log.Error("invalid storage scheme, the scheme of upstream-uri must be file/s3/azblob/gcs")
-		os.Exit(1)
+		return errors.New("invalid storage scheme, the scheme of upstream-uri must be file/s3/azblob/gcs")
 	}
+	return nil
 }
 
 func main() {
 	var consumer *consumer
 	var err error
+
+	flag.Parse()
+	if err = initialize(); err != nil {
+		log.Error("failed to initialize storage consumer", zap.Error(err))
+		os.Exit(1)
+	}
 
 	if enableProfiling {
 		go func() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4430

### What is changed and how it works?

`cmd/storage-consumer` used to apply whatever a scan round happened to discover.
That is unsafe for cloud storage because storage visibility is only stable up to the
producer's `metadata.checkpoint-ts`.

In the failing `ddl_with_random_move_table` case, the consumer applied:

1. `RENAME TABLE test.table_8 TO test.table_108`
2. `RENAME TABLE test.table_108 TO test.table_8`

before a later scan round discovered an older DML file that still belonged to
`table_108`. That reordered apply across scan rounds and finally failed with
`Table 'test.table_108' doesn't exist`.

This PR fixes that by changing the consumer side only:

- read storage `metadata` every round and treat `checkpoint-ts` as the stable apply watermark
- defer schema/DML keys whose `tableVersion` is greater than the stable checkpoint
- track discovered files separately from handled files, so deferred keys stay pending across later rounds
- mark keys handled only after they are successfully applied or intentionally ignored as stale replay
- move `storage-consumer` initialization out of `init()` so the package can be tested normally
- add an `intest` regression test that reproduces the rename -> DML -> rename-back visibility gap and verifies the final apply order

With this change, the consumer waits until all files in the rename chain are
stably visible and then applies them in the correct order.

### Check List

#### Tests

- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No protocol or producer behavior is changed. The consumer may defer applying a
newly discovered file until `metadata.checkpoint-ts` reaches that table version,
which is the intended correctness fence.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix storage consumer reordering DDL and DML across scan rounds by gating apply on the storage checkpoint metadata.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced checkpoint-based processing for data operations, ensuring proper sequencing when handling complex database changes.
  * Enhanced observability with improved logging for checkpoint states and operation deferral conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->