### PR TITLE
redo: update the duration in collect redo meta

### DIFF
--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -95,7 +95,7 @@ func initRedoComponet(
 
 func (e *DispatcherManager) NewTableTriggerRedoDispatcher(id *heartbeatpb.DispatcherID, startTs uint64, newChangefeed bool) error {
 	if e.GetTableTriggerRedoDispatcher() != nil {
-		log.Error("table trigger redo dispatcher existed!")
+		return errors.ErrChangefeedInitTableTriggerDispatcherFailed.FastGenByArgs("table trigger redo dispatcher existed!")
 	}
 	infos := map[common.DispatcherID]dispatcherCreateInfo{}
 	dispatcherID := common.NewDispatcherIDFromPB(id)
@@ -295,7 +295,7 @@ func (e *DispatcherManager) SetRedoResolvedTs(resolvedTs uint64) bool {
 }
 
 func (e *DispatcherManager) collectRedoMeta(ctx context.Context) error {
-	ticker := time.NewTicker(time.Duration(*e.config.Consistent.FlushIntervalInMs))
+	ticker := time.NewTicker(time.Duration(*e.config.Consistent.FlushIntervalInMs) * time.Millisecond)
 	defer ticker.Stop()
 	mc := appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter)
 	var preResolvedTs uint64


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4432

### What is changed and how it works?
- Error Handling Improvement: The NewTableTriggerRedoDispatcher function now returns a specific typed error (ErrChangefeedInitTableTriggerDispatcherFailed) instead of just logging an error when a table trigger redo dispatcher already exists. This allows for more robust error handling and clearer indication of the failure cause.
- Redo Meta Collection Timing Fix: The collectRedoMeta function's ticker duration calculation was corrected. Previously, FlushIntervalInMs was interpreted as nanoseconds, but it is now explicitly converted to milliseconds, ensuring the ticker operates at the intended frequency.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to return typed errors instead of logging during dispatcher initialization failures
  * Fixed timing calculation in metadata collection to correctly interpret millisecond duration values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->