### PR TITLE
tests: add temporary next gen bootstrap delay

### DIFF
--- a/tests/integration_tests/_utils/start_tidb_cluster_nextgen
+++ b/tests/integration_tests/_utils/start_tidb_cluster_nextgen
@@ -343,6 +343,13 @@ check_port_available "$UP_TIKV_WORKER_HOST" "$UP_TIKV_WORKER_PORT" "Upstream TiK
 check_port_available "$DOWN_TIKV_WORKER_HOST" "$DOWN_TIKV_WORKER_PORT" "Downstream TiKV-Worker is not ready yet"
 
 ####################start TiDB####################
+# TODO: replace this fixed delay with an explicit keyspace readiness check.
+# PD health only guarantees the service is up. In next-gen bootstrap we also
+# rely on PD finishing keyspace pre-allocation before the SYSTEM TiDB starts.
+# Giving PD a short quiet window here reduces flaky startup failures in CI.
+echo "Waiting for next-gen keyspace pre-allocation to settle..."
+sleep 30
+
 touch "$OUT_DIR/upstream-tidb-system.toml"
 if [ -f "$tidb_config" ]; then
 	cat "$tidb_config" >>"$OUT_DIR/upstream-tidb-system.toml"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4438

### What is changed and how it works?

This PR adds a temporary 30 second delay in `tests/integration_tests/_utils/start_tidb_cluster_nextgen` after TiKV and TiKV-worker are ready and before the first `SYSTEM` TiDB starts.

PD health only guarantees that the service is up. In the flaky next-gen bootstrap path, giving PD a short quiet window here reduces cases where keyspace pre-allocation is still incomplete when `SYSTEM` TiDB starts.

### Check List

#### Tests

- Manual test

`bash -n tests/integration_tests/_utils/start_tidb_cluster_nextgen`

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only changes integration test bootstrap timing.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of test cluster bootstrap sequence by adding a pre-start delay, reducing CI startup flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->