### PR TITLE
coordinator: avoid cdc hang on recvMessages

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -163,8 +163,7 @@ func (c *coordinator) recvMessages(ctx context.Context, msg *messaging.TargetMes
 	select {
 	case <-ctx.Done():
 		return context.Cause(ctx)
-	default:
-		c.eventCh.In() <- &Event{message: msg}
+	case c.eventCh.In() <- &Event{message: msg}:
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4440

### What is changed and how it works?
Coordinator Message Handling: Modified the recvMessages function in the coordinator to prevent potential hangs. The change involves updating the select statement to directly attempt sending messages to the eventCh rather than using a default case, ensuring proper synchronization and avoiding blocking.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling reliability by ensuring proper synchronization when processing incoming messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->