### PR TITLE
pkg/eventservice: use checkpointTs as dispatcher runtime lower bound

### DIFF
--- a/pkg/eventservice/dispatcher_stat.go
+++ b/pkg/eventservice/dispatcher_stat.go
@@ -51,8 +51,7 @@ type dispatcherStat struct {
 	messageWorkerIndex int
 	info               DispatcherInfo
 	filter             filter.Filter
-	// the start ts of the dispatcher
-	startTs uint64
+
 	// startTableInfo is the table info at the `startTs` of the dispatcher
 	startTableInfo *common.TableInfo
 	// The epoch of the dispatcher.
@@ -146,7 +145,6 @@ func newDispatcherStat(
 		messageWorkerIndex: (common.GID)(id).Hash(messageWorkerCount),
 		info:               info,
 		filter:             info.GetFilter(),
-		startTs:            info.GetStartTs(),
 		epoch:              info.GetEpoch(),
 		startTableInfo:     startTableInfo,
 		txnAtomicity:       info.GetTxnAtomicity(),
@@ -163,12 +161,7 @@ func newDispatcherStat(
 	}
 	startTs := info.GetStartTs()
 	dispStat.receivedResolvedTs.Store(startTs)
-	dispStat.checkpointTs.Store(startTs)
-
-	dispStat.sentResolvedTs.Store(startTs)
-
-	dispStat.lastScannedCommitTs.Store(startTs)
-	dispStat.lastScannedStartTs.Store(0)
+	dispStat.resetLowerBound(startTs)
 	dispStat.lastReadySendTime.Store(0)
 	dispStat.readyInterval.Store(1)
 	dispStat.resetScanLimit()
@@ -212,6 +205,13 @@ func (a *dispatcherStat) updateSentResolvedTs(resolvedTs uint64) {
 func (a *dispatcherStat) updateScanRange(txnCommitTs, txnStartTs uint64) {
 	a.lastScannedCommitTs.Store(txnCommitTs)
 	a.lastScannedStartTs.Store(txnStartTs)
+}
+
+func (a *dispatcherStat) resetLowerBound(checkpointTs uint64) {
+	a.checkpointTs.Store(checkpointTs)
+	a.sentResolvedTs.Store(checkpointTs)
+	a.lastScannedCommitTs.Store(checkpointTs)
+	a.lastScannedStartTs.Store(0)
 }
 
 // onResolvedTs try to update the resolved ts of the dispatcher.

--- a/pkg/eventservice/dispatcher_stat_test.go
+++ b/pkg/eventservice/dispatcher_stat_test.go
@@ -49,7 +49,6 @@ func TestNewDispatcherStat(t *testing.T) {
 	require.Equal(t, info.GetID(), stat.id)
 	require.Equal(t, 0, stat.scanWorkerIndex)
 	require.Equal(t, 0, stat.messageWorkerIndex)
-	require.Equal(t, startTs, stat.startTs)
 	require.Equal(t, uint64(0), stat.epoch)
 	require.True(t, stat.enableSyncPoint)
 	require.Equal(t, info.nextSyncPoint, stat.nextSyncPoint.Load())
@@ -57,6 +56,7 @@ func TestNewDispatcherStat(t *testing.T) {
 	require.Equal(t, startTs, stat.receivedResolvedTs.Load())
 	require.Equal(t, startTs, stat.checkpointTs.Load())
 	require.Equal(t, startTs, stat.sentResolvedTs.Load())
+	require.Equal(t, startTs, stat.lastScannedCommitTs.Load())
 }
 
 func TestDispatcherStatResolvedTs(t *testing.T) {

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -536,7 +536,7 @@ func (c *eventBroker) sendHandshakeIfNeed(task scanTask) {
 	}
 
 	remoteID := node.ID(task.info.GetServerID())
-	event := event.NewHandshakeEvent(task.id, task.startTs, task.epoch, task.startTableInfo)
+	event := event.NewHandshakeEvent(task.id, task.checkpointTs.Load(), task.epoch, task.startTableInfo)
 	log.Info("send handshake event to dispatcher",
 		zap.Stringer("changefeedID", task.changefeedStat.changefeedID),
 		zap.Stringer("dispatcherID", task.id),
@@ -1167,6 +1167,7 @@ func (c *eventBroker) resetDispatcher(dispatcherInfo DispatcherInfo) error {
 
 	newStat := newDispatcherStat(dispatcherInfo, uint64(len(c.taskChan)), uint64(len(c.messageCh)), tableInfo, status)
 	newStat.copyStatistics(oldStat)
+	newStat.resetLowerBound(newCheckpointTs)
 
 	for {
 		if statPtr.CompareAndSwap(oldStat, newStat) {

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -353,7 +353,7 @@ func TestCURDDispatcher(t *testing.T) {
 	cfStatus, ok = broker.changefeedMap.Load(dispInfo.GetChangefeedID())
 	require.True(t, ok, "changefeedStatus should still exist after resetting")
 	require.False(t, cfStatus.(*changefeedStatus).isEmpty(), "changefeedStatus should not be empty after resetting")
-	require.Equal(t, disp.startTs, dispInfo.GetStartTs())
+	require.Equal(t, disp.checkpointTs.Load(), dispInfo.GetStartTs())
 
 	// Case 3: Remove a dispatcher.
 	broker.removeDispatcher(dispInfo)
@@ -382,7 +382,7 @@ func TestResetDispatcher(t *testing.T) {
 	require.NotNil(t, dispPtr)
 	oldStat := dispPtr.Load()
 	require.Equal(t, uint64(0), oldStat.epoch)
-	require.Equal(t, dispInfo.startTs, oldStat.startTs)
+	require.Equal(t, dispInfo.startTs, oldStat.checkpointTs.Load())
 
 	// 3. Reset with a stale epoch.
 	staleDispInfo := newMockDispatcherInfo(t, 400, dispInfo.GetID(), 100, eventpb.ActionType_ACTION_TYPE_RESET)
@@ -409,7 +409,7 @@ func TestResetDispatcher(t *testing.T) {
 	require.True(t, oldStat.isRemoved.Load(), "old dispatcherStat should be marked as removed")
 
 	require.Equal(t, uint64(1), newStat.epoch)
-	require.Equal(t, uint64(500), newStat.startTs)
+	require.Equal(t, uint64(500), newStat.checkpointTs.Load())
 	require.Equal(t, dispInfo.GetID(), newStat.id)
 }
 
@@ -439,7 +439,6 @@ func TestResetDispatcherUsesCheckpointAsNewLowerBound(t *testing.T) {
 
 	newStat := dispPtr.Load()
 	require.NotSame(t, oldStat, newStat)
-	require.Equal(t, uint64(620), newStat.startTs)
 	require.Equal(t, uint64(620), newStat.checkpointTs.Load())
 	require.Equal(t, uint64(620), newStat.sentResolvedTs.Load())
 	require.Equal(t, uint64(620), newStat.lastScannedCommitTs.Load())
@@ -483,7 +482,7 @@ func TestResetDispatcherConcurrently(t *testing.T) {
 	// 5. Verify the final state has the max epoch.
 	finalStat := dispPtr.Load()
 	require.Equal(t, maxEpoch, finalStat.epoch, "the final epoch should be the maximum one")
-	require.Equal(t, 500+maxEpoch, finalStat.startTs, "the final startTs should correspond to the max epoch")
+	require.Equal(t, 500+maxEpoch, finalStat.checkpointTs.Load(), "the final checkpointTs should correspond to the max epoch")
 }
 
 func TestHandleResolvedTs(t *testing.T) {
@@ -714,6 +713,102 @@ func TestSendHandshakeIfNeedConcurrency(t *testing.T) {
 		require.Equal(t, 1, handshakeCount, "Expected exactly 1 handshake event")
 		require.True(t, disp.isHandshaked(), "Dispatcher should be marked as handshaked")
 	})
+}
+
+func TestSendHandshakeIfNeedUsesCheckpointTs(t *testing.T) {
+	broker, _, _, outputCh := newEventBrokerForTest()
+	defer broker.close()
+
+	info := newMockDispatcherInfoForTest(t)
+	changefeedStatus := broker.getOrSetChangefeedStatus(info.GetChangefeedID(), info.GetSyncPointInterval())
+	disp := newDispatcherStat(info, 1, 1, nil, changefeedStatus)
+	disp.epoch = 1
+	disp.checkpointTs.Store(180)
+
+	broker.sendHandshakeIfNeed(disp)
+
+	select {
+	case msg := <-outputCh:
+		handshake, ok := msg.Message[0].(*event.HandshakeEvent)
+		require.True(t, ok)
+		require.Equal(t, uint64(180), handshake.GetStartTs())
+	case <-time.After(time.Second):
+		require.Fail(t, "expected handshake event")
+	}
+}
+
+func TestResetAfterCheckpointAdvanceUsesCheckpointForHandshakeAndScan(t *testing.T) {
+	broker, _, _, outputCh := newEventBrokerForTest()
+	defer broker.close()
+
+	dispInfo := newMockDispatcherInfoForTest(t)
+	err := broker.addDispatcher(dispInfo)
+	require.NoError(t, err)
+
+	dispPtr := broker.getDispatcher(dispInfo.GetID())
+	require.NotNil(t, dispPtr)
+
+	firstResetTs := uint64(464848549221499060)
+	firstResetInfo := newMockDispatcherInfo(t, firstResetTs, dispInfo.GetID(), 100, eventpb.ActionType_ACTION_TYPE_RESET)
+	firstResetInfo.epoch = 1
+	err = broker.resetDispatcher(firstResetInfo)
+	require.NoError(t, err)
+
+	statAfterFirstReset := dispPtr.Load()
+	require.Equal(t, firstResetTs, statAfterFirstReset.checkpointTs.Load())
+
+	advancedCheckpointTs := uint64(464848549247713353)
+	broker.handleDispatcherHeartbeat(&DispatcherHeartBeatWithServerID{
+		serverID: "test-server",
+		heartbeat: &event.DispatcherHeartbeat{
+			Version:         event.DispatcherHeartbeatVersion1,
+			ClusterID:       0,
+			DispatcherCount: 1,
+			DispatcherProgresses: []event.DispatcherProgress{
+				{
+					DispatcherID: dispInfo.GetID(),
+					CheckpointTs: advancedCheckpointTs,
+				},
+			},
+		},
+	})
+
+	statAfterHeartbeat := dispPtr.Load()
+	require.Equal(t, advancedCheckpointTs, statAfterHeartbeat.checkpointTs.Load())
+
+	secondResetTs := advancedCheckpointTs - 1
+	secondResetInfo := newMockDispatcherInfo(t, secondResetTs, dispInfo.GetID(), 100, eventpb.ActionType_ACTION_TYPE_RESET)
+	secondResetInfo.epoch = 2
+	err = broker.resetDispatcher(secondResetInfo)
+	require.NoError(t, err)
+
+	statAfterSecondReset := dispPtr.Load()
+	require.Equal(t, advancedCheckpointTs, statAfterSecondReset.checkpointTs.Load())
+	require.Equal(t, advancedCheckpointTs, statAfterSecondReset.sentResolvedTs.Load())
+	require.Equal(t, advancedCheckpointTs, statAfterSecondReset.lastScannedCommitTs.Load())
+
+	for len(outputCh) > 0 {
+		<-outputCh
+	}
+
+	broker.sendHandshakeIfNeed(statAfterSecondReset)
+
+	select {
+	case msg := <-outputCh:
+		handshake, ok := msg.Message[0].(*event.HandshakeEvent)
+		require.True(t, ok)
+		require.Equal(t, advancedCheckpointTs, handshake.GetStartTs())
+	case <-time.After(time.Second):
+		require.Fail(t, "expected handshake event")
+	}
+
+	updated := statAfterSecondReset.onResolvedTs(advancedCheckpointTs + 100)
+	require.True(t, updated)
+
+	dataRange, ok := statAfterSecondReset.getDataRange()
+	require.True(t, ok)
+	require.Equal(t, advancedCheckpointTs, dataRange.CommitTsStart)
+	require.Equal(t, advancedCheckpointTs+100, dataRange.CommitTsEnd)
 }
 
 func TestAddDispatcherFailure(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #4492

event service dispatcher runtime state kept both `startTs` and `checkpointTs`
as lower-bound candidates. After a reset, heartbeat could advance checkpoint,
but handshake and the next scan could still read the stale runtime `startTs`.
That may reopen a range below the effective event store checkpoint and trigger:

```text
dataRange startTs is smaller than subscriptionStat checkpointTs, it should not happen
```

### What is changed and how it works?

- remove runtime `startTs` from `pkg/eventservice/dispatcherStat`
- use `checkpointTs` as the single runtime lower bound in event service
- use `checkpointTs` when sending handshake events
- reset post-reset lower-bound state from the clamped checkpoint value
- add a regression test that follows the failure order from the captured logs:
  `reset -> heartbeat advances checkpoint -> second reset uses resolvedTs - 1`
- add a Chinese analysis document summarizing the root cause and why using
  `checkpointTs` as the only runtime lower bound is the correct fix

### Check List

#### Tests

- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only removes stale runtime state in event service and makes
reset/handshake/scan lower-bound handling consistent with the checkpoint
already enforced by event store.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes. Added an internal design/analysis note describing the panic sequence and
the rationale for removing runtime `startTs`.

### Release note

```release-note
Fix event service dispatcher reset to use checkpointTs as the runtime lower bound and avoid scanning below the event store checkpoint after reset.
```
