### PR TITLE
schemastore: fix exchange partition name unquoting

### DIFF
--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -812,7 +812,7 @@ func buildPersistedDDLEventForExchangePartition(args buildPersistedDDLEventFuncA
 
 		// Note that partition name should be parsed from original query, not the upperQuery.
 		partName := strings.TrimSpace(event.Query[idx1:idx2])
-		partName = strings.Replace(partName, "`", "", -1)
+		partName = common.UnquoteName(partName)
 		event.Query = fmt.Sprintf("ALTER TABLE %s EXCHANGE PARTITION %s WITH TABLE %s",
 			common.QuoteSchema(event.ExtraSchemaName, event.ExtraTableName),
 			common.QuoteName(partName),

--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -3434,7 +3434,7 @@ func TestBuildPersistedDDLEventEscapesIdentifiers(t *testing.T) {
 
 	t.Run("exchange partition", func(t *testing.T) {
 		job := buildExchangePartitionJobForTest(100, 200, 300, "pt`x", []int64{301}, 1000)
-		job.Query = "ALTER TABLE `ignored`.`ignored` EXCHANGE PARTITION `p0` WITH TABLE `ignored2`.`ignored2` WITHOUT VALIDATION"
+		job.Query = "ALTER TABLE `ignored`.`ignored` EXCHANGE PARTITION `p``0` WITH TABLE `ignored2`.`ignored2` WITHOUT VALIDATION"
 
 		ddl := buildPersistedDDLEventForExchangePartition(buildPersistedDDLEventFuncArgs{
 			job: job,
@@ -3454,7 +3454,7 @@ func TestBuildPersistedDDLEventEscapesIdentifiers(t *testing.T) {
 		})
 
 		assert.Equal(t,
-			"ALTER TABLE `part``db`.`pt``x` EXCHANGE PARTITION `p0` WITH TABLE `normal``db`.`normal``t` WITHOUT VALIDATION",
+			"ALTER TABLE `part``db`.`pt``x` EXCHANGE PARTITION `p``0` WITH TABLE `normal``db`.`normal``t` WITHOUT VALIDATION",
 			ddl.Query)
 	})
 }

--- a/pkg/common/event/util.go
+++ b/pkg/common/event/util.go
@@ -153,7 +153,7 @@ func (s *EventTestHelper) DDL2Job(ddl string) *timodel.Job {
 
 		// Note that partition name should be parsed from original query, not the upperQuery.
 		partName := strings.TrimSpace(res.Query[idx1:idx2])
-		partName = strings.Replace(partName, "`", "", -1)
+		partName = common.UnquoteName(partName)
 		res.Query = fmt.Sprintf("ALTER TABLE `%s`.`%s` EXCHANGE PARTITION `%s` WITH TABLE `%s`.`%s`",
 			res.InvolvingSchemaInfo[0].Database, res.InvolvingSchemaInfo[0].Table, partName, res.SchemaName, res.TableName)
 

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -48,6 +48,14 @@ func QuoteName(name string) string {
 	return "`" + EscapeName(name) + "`"
 }
 
+// UnquoteName removes one layer of MySQL identifier quoting and unescapes doubled backticks.
+func UnquoteName(name string) string {
+	if len(name) < 2 || name[0] != '`' || name[len(name)-1] != '`' {
+		return name
+	}
+	return strings.ReplaceAll(name[1:len(name)-1], "``", "`")
+}
+
 // EscapeName replaces all "`" in name with double "`"
 func EscapeName(name string) string {
 	return strings.Replace(name, "`", "``", -1)

--- a/pkg/common/table_info_test.go
+++ b/pkg/common/table_info_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnquoteName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unquoted",
+			input:    "p0",
+			expected: "p0",
+		},
+		{
+			name:     "quoted",
+			input:    "`p0`",
+			expected: "p0",
+		},
+		{
+			name:     "quoted with escaped backtick",
+			input:    "`p``0`",
+			expected: "p`0",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, UnquoteName(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4450 

### What is changed and how it works?

This pull request resolves a bug in the handling of `EXCHANGE PARTITION` DDL statements where partition names, especially those containing escaped backticks, were not being unquoted correctly. By implementing a robust `UnquoteName` utility and applying it to the relevant DDL parsing paths, the change ensures accurate processing of schema changes, preventing potential data inconsistencies or errors in schema replication.

### Highlights

* **New Utility Function**: Introduced a new `UnquoteName` utility function in the `pkg/common` package to correctly handle MySQL identifier unquoting, including the unescaping of doubled backticks.
* **DDL Parsing Fix**: Integrated the `UnquoteName` function into the DDL handling logic for `EXCHANGE PARTITION` statements within the `schemastore` and `event` packages, ensuring proper parsing of partition names that may contain escaped backticks.
* **Improved Test Coverage**: Updated existing unit tests and added new dedicated unit tests for the `UnquoteName` function to validate its correctness across various scenarios, including unquoted, quoted, and quoted names with escaped backticks.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
