### PR TITLE
cmek split 5/8: server wiring and app context service lookup

### DIFF
--- a/pkg/common/context/app_context.go
+++ b/pkg/common/context/app_context.go
@@ -63,3 +63,15 @@ func GetService[T any](name string) T {
 	v, _ := GetGlobalContext().serviceMap.Load(name)
 	return v.(T)
 }
+
+// TryGetService attempts to get a service by name.
+// Returns the service and true if found, or zero value and false if not found.
+func TryGetService[T any](name string) (T, bool) {
+	v, ok := GetGlobalContext().serviceMap.Load(name)
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	t, ok := v.(T)
+	return t, ok
+}

--- a/pkg/common/context/app_context.go
+++ b/pkg/common/context/app_context.go
@@ -34,6 +34,7 @@ const (
 	DispatcherDynamicStream = "DispatcherDynamicStream"
 	MaintainerManager       = "MaintainerManager"
 	DispatcherOrchestrator  = "DispatcherOrchestrator"
+	EncryptionManager       = "EncryptionManager"
 	DefaultPDClock          = "PDClock-0"
 	PDAPIClient             = "PDAPIClient"
 	RegionCache             = "RegionCache"

--- a/pkg/common/context/app_context_test.go
+++ b/pkg/common/context/app_context_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptionManagerServiceName(t *testing.T) {
+	GetGlobalContext().serviceMap.Delete(EncryptionManager)
+	t.Cleanup(func() {
+		GetGlobalContext().serviceMap.Delete(EncryptionManager)
+	})
+
+	SetService(EncryptionManager, 42)
+
+	value, ok := TryGetService[int](EncryptionManager)
+	require.True(t, ok)
+	require.Equal(t, 42, value)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -302,7 +302,7 @@ func (c *server) setPreServices(ctx context.Context) error {
 			return errors.Trace(err)
 		}
 
-		appctx.SetService("EncryptionManager", encryption.NewEncryptionManager(metaManager))
+		appctx.SetService(appctx.EncryptionManager, encryption.NewEncryptionManager(metaManager))
 		if closeable, ok := metaManager.(common.Closeable); ok {
 			c.preServices = append(c.preServices, closeable)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -286,12 +286,12 @@ func (c *server) setPreServices(ctx context.Context) error {
 	if conf != nil && conf.Encryption != nil && conf.Encryption.EnableEncryption {
 		tikvClient, err := encryption.NewTiKVEncryptionHTTPClient(c.pdClient, c.security)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		kmsClient, err := kms.NewClient(conf.Encryption)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if closeable, ok := kmsClient.(common.Closeable); ok {
 			c.preServices = append(c.preServices, closeable)
@@ -299,7 +299,7 @@ func (c *server) setPreServices(ctx context.Context) error {
 
 		metaManager := encryption.NewEncryptionMetaManager(tikvClient, kmsClient)
 		if err := metaManager.Start(ctx); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		appctx.SetService(appctx.EncryptionManager, encryption.NewEncryptionManager(metaManager))

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,8 @@ import (
 	"github.com/pingcap/ticdc/pkg/common"
 	appctx "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/encryption"
+	"github.com/pingcap/ticdc/pkg/encryption/kms"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/etcd"
 	"github.com/pingcap/ticdc/pkg/eventservice"
@@ -279,6 +281,32 @@ func (c *server) setPreServices(ctx context.Context) error {
 	keyspaceManager := keyspace.NewManager(c.pdEndpoints)
 	appctx.SetService(appctx.KeyspaceManager, keyspaceManager)
 	c.preServices = append(c.preServices, keyspaceManager)
+
+	conf := config.GetGlobalServerConfig()
+	if conf != nil && conf.Debug != nil && conf.Debug.Encryption != nil && conf.Debug.Encryption.EnableEncryption {
+		tikvClient, err := encryption.NewTiKVEncryptionHTTPClient(c.pdClient, c.security)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		kmsClient, err := kms.NewClient(conf.Debug.Encryption)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if closeable, ok := kmsClient.(common.Closeable); ok {
+			c.preServices = append(c.preServices, closeable)
+		}
+
+		metaManager := encryption.NewEncryptionMetaManager(tikvClient, kmsClient)
+		if err := metaManager.Start(ctx); err != nil {
+			return errors.Trace(err)
+		}
+
+		appctx.SetService("EncryptionManager", encryption.NewEncryptionManager(metaManager))
+		if closeable, ok := metaManager.(common.Closeable); ok {
+			c.preServices = append(c.preServices, closeable)
+		}
+	}
 
 	log.Info("pre services all set", zap.Any("preServicesNum", len(c.preServices)))
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -283,13 +283,13 @@ func (c *server) setPreServices(ctx context.Context) error {
 	c.preServices = append(c.preServices, keyspaceManager)
 
 	conf := config.GetGlobalServerConfig()
-	if conf != nil && conf.Debug != nil && conf.Debug.Encryption != nil && conf.Debug.Encryption.EnableEncryption {
+	if conf != nil && conf.Encryption != nil && conf.Encryption.EnableEncryption {
 		tikvClient, err := encryption.NewTiKVEncryptionHTTPClient(c.pdClient, c.security)
 		if err != nil {
 			return errors.Trace(err)
 		}
 
-		kmsClient, err := kms.NewClient(conf.Debug.Encryption)
+		kmsClient, err := kms.NewClient(conf.Encryption)
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #3943

This is split PR **5/8** from #3955.

### What is changed and how it works?

This PR wires encryption manager into runtime service lifecycle:

- Add `TryGetService` in app context for optional service lookup.
- Initialize TiKV metadata client + KMS client + encryption managers in server startup when CMEK is enabled.
- Register encryption manager into app context and close lifecycle resources correctly.

This PR is the lifecycle bridge between encryption core and storage modules.

### Check List

#### Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

#### Questions

##### Will it cause performance regression or break compatibility?

No regression when CMEK is disabled. When enabled, additional manager initialization is expected.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
