### PR TITLE
eventcollector: update commitTs dedup state after filtering valid events

### DIFF
--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -395,15 +395,6 @@ func (d *dispatcherStat) applyCommitTsState(state commitTsState) {
 	d.gotSyncpointOnTS.Store(state.gotSyncpointOnTS)
 }
 
-func (d *dispatcherStat) newCommitTsStateCallback(epoch uint64, state commitTsState) func() {
-	return func() {
-		if d.epoch.Load() == epoch {
-			d.applyCommitTsState(state)
-		}
-		d.wake()
-	}
-}
-
 func (d *dispatcherStat) isFromCurrentEpoch(event dispatcher.DispatcherEvent) bool {
 	if event.GetType() == commonEvent.TypeBatchDMLEvent {
 		batchDML := event.Event.(*commonEvent.BatchDMLEvent)
@@ -482,9 +473,9 @@ func (d *dispatcherStat) handleBatchDataEvents(events []dispatcher.DispatcherEve
 	if len(validEvents) == 0 {
 		return false
 	}
-	epoch := d.epoch.Load()
 	state := d.buildCommitTsState(validEvents)
-	return d.target.HandleEvents(validEvents, d.newCommitTsStateCallback(epoch, state))
+	d.applyCommitTsState(state)
+	return d.target.HandleEvents(validEvents, func() { d.wake() })
 }
 
 // handleSingleDataEvents processes single DDL, SyncPoint or BatchDML events with the following algorithm:
@@ -527,16 +518,16 @@ func (d *dispatcherStat) handleSingleDataEvents(events []dispatcher.DispatcherEv
 		if ddl.TableInfo != nil {
 			d.tableInfo.Store(ddl.TableInfo)
 		}
-		epoch := d.epoch.Load()
 		state := d.buildCommitTsState(events)
-		return d.target.HandleEvents(events, d.newCommitTsStateCallback(epoch, state))
+		d.applyCommitTsState(state)
+		return d.target.HandleEvents(events, func() { d.wake() })
 	} else {
 		if !d.shouldForwardEventByCommitTs(events[0]) {
 			return false
 		}
-		epoch := d.epoch.Load()
 		state := d.buildCommitTsState(events)
-		return d.target.HandleEvents(events, d.newCommitTsStateCallback(epoch, state))
+		d.applyCommitTsState(state)
+		return d.target.HandleEvents(events, func() { d.wake() })
 	}
 }
 

--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -310,9 +310,9 @@ func (d *dispatcherStat) verifyEventSequence(event dispatcher.DispatcherEvent) b
 	return true
 }
 
-// filterAndUpdateEventByCommitTs verifies if the event's commit timestamp is valid.
-// Note: this function must be called on every event received.
-func (d *dispatcherStat) filterAndUpdateEventByCommitTs(event dispatcher.DispatcherEvent) bool {
+// shouldForwardEventByCommitTs verifies if the event's commit timestamp is valid.
+// Note: this function must be called on every event received before forwarding it.
+func (d *dispatcherStat) shouldForwardEventByCommitTs(event dispatcher.DispatcherEvent) bool {
 	shouldIgnore := false
 	if event.GetCommitTs() < d.lastEventCommitTs.Load() {
 		shouldIgnore = true
@@ -338,18 +338,29 @@ func (d *dispatcherStat) filterAndUpdateEventByCommitTs(event dispatcher.Dispatc
 			zap.Uint64("sentCommitTs", d.lastEventCommitTs.Load()))
 		return false
 	}
-	if event.GetCommitTs() > d.lastEventCommitTs.Load() {
+	return true
+}
+
+type commitTsState struct {
+	lastEventCommitTs uint64
+	gotDDLOnTs        bool
+	gotSyncpointOnTS  bool
+	hasStateUpdate    bool
+}
+
+func advanceCommitTsState(state commitTsState, event dispatcher.DispatcherEvent) commitTsState {
+	if event.GetCommitTs() > state.lastEventCommitTs {
 		// if the commit ts is larger than the last sent commit ts,
 		// we need to reset the DDL and SyncPoint flags.
-		d.gotDDLOnTs.Store(false)
-		d.gotSyncpointOnTS.Store(false)
+		state.gotDDLOnTs = false
+		state.gotSyncpointOnTS = false
 	}
 
 	switch event.GetType() {
 	case commonEvent.TypeDDLEvent:
-		d.gotDDLOnTs.Store(true)
+		state.gotDDLOnTs = true
 	case commonEvent.TypeSyncPointEvent:
-		d.gotSyncpointOnTS.Store(true)
+		state.gotSyncpointOnTS = true
 	}
 
 	switch event.GetType() {
@@ -357,10 +368,40 @@ func (d *dispatcherStat) filterAndUpdateEventByCommitTs(event dispatcher.Dispatc
 		commonEvent.TypeDMLEvent,
 		commonEvent.TypeBatchDMLEvent,
 		commonEvent.TypeSyncPointEvent:
-		d.lastEventCommitTs.Store(event.GetCommitTs())
+		state.lastEventCommitTs = event.GetCommitTs()
+		state.hasStateUpdate = true
 	}
+	return state
+}
 
-	return true
+func (d *dispatcherStat) buildCommitTsState(events []dispatcher.DispatcherEvent) commitTsState {
+	state := commitTsState{
+		lastEventCommitTs: d.lastEventCommitTs.Load(),
+		gotDDLOnTs:        d.gotDDLOnTs.Load(),
+		gotSyncpointOnTS:  d.gotSyncpointOnTS.Load(),
+	}
+	for _, event := range events {
+		state = advanceCommitTsState(state, event)
+	}
+	return state
+}
+
+func (d *dispatcherStat) applyCommitTsState(state commitTsState) {
+	if !state.hasStateUpdate {
+		return
+	}
+	d.lastEventCommitTs.Store(state.lastEventCommitTs)
+	d.gotDDLOnTs.Store(state.gotDDLOnTs)
+	d.gotSyncpointOnTS.Store(state.gotSyncpointOnTS)
+}
+
+func (d *dispatcherStat) newCommitTsStateCallback(epoch uint64, state commitTsState) func() {
+	return func() {
+		if d.epoch.Load() == epoch {
+			d.applyCommitTsState(state)
+		}
+		d.wake()
+	}
 }
 
 func (d *dispatcherStat) isFromCurrentEpoch(event dispatcher.DispatcherEvent) bool {
@@ -403,7 +444,7 @@ func (d *dispatcherStat) handleBatchDataEvents(events []dispatcher.DispatcherEve
 		if event.GetType() == commonEvent.TypeResolvedEvent {
 			validEvents = append(validEvents, event)
 		} else if event.GetType() == commonEvent.TypeDMLEvent {
-			if d.filterAndUpdateEventByCommitTs(event) {
+			if d.shouldForwardEventByCommitTs(event) {
 				validEvents = append(validEvents, event)
 			}
 		} else if event.GetType() == commonEvent.TypeBatchDMLEvent {
@@ -427,7 +468,7 @@ func (d *dispatcherStat) handleBatchDataEvents(events []dispatcher.DispatcherEve
 				dml.TableInfo.InitPrivateFields()
 				dml.TableInfoVersion = tableInfoVersion
 				dmlEvent := dispatcher.NewDispatcherEvent(event.From, dml)
-				if d.filterAndUpdateEventByCommitTs(dmlEvent) {
+				if d.shouldForwardEventByCommitTs(dmlEvent) {
 					validEvents = append(validEvents, dmlEvent)
 				}
 			}
@@ -441,7 +482,9 @@ func (d *dispatcherStat) handleBatchDataEvents(events []dispatcher.DispatcherEve
 	if len(validEvents) == 0 {
 		return false
 	}
-	return d.target.HandleEvents(validEvents, func() { d.wake() })
+	epoch := d.epoch.Load()
+	state := d.buildCommitTsState(validEvents)
+	return d.target.HandleEvents(validEvents, d.newCommitTsStateCallback(epoch, state))
 }
 
 // handleSingleDataEvents processes single DDL, SyncPoint or BatchDML events with the following algorithm:
@@ -476,7 +519,7 @@ func (d *dispatcherStat) handleSingleDataEvents(events []dispatcher.DispatcherEv
 		return false
 	}
 	if events[0].GetType() == commonEvent.TypeDDLEvent {
-		if !d.filterAndUpdateEventByCommitTs(events[0]) {
+		if !d.shouldForwardEventByCommitTs(events[0]) {
 			return false
 		}
 		ddl := events[0].Event.(*commonEvent.DDLEvent)
@@ -484,12 +527,16 @@ func (d *dispatcherStat) handleSingleDataEvents(events []dispatcher.DispatcherEv
 		if ddl.TableInfo != nil {
 			d.tableInfo.Store(ddl.TableInfo)
 		}
-		return d.target.HandleEvents(events, func() { d.wake() })
+		epoch := d.epoch.Load()
+		state := d.buildCommitTsState(events)
+		return d.target.HandleEvents(events, d.newCommitTsStateCallback(epoch, state))
 	} else {
-		if !d.filterAndUpdateEventByCommitTs(events[0]) {
+		if !d.shouldForwardEventByCommitTs(events[0]) {
 			return false
 		}
-		return d.target.HandleEvents(events, func() { d.wake() })
+		epoch := d.epoch.Load()
+		state := d.buildCommitTsState(events)
+		return d.target.HandleEvents(events, d.newCommitTsStateCallback(epoch, state))
 	}
 }
 

--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -341,58 +341,43 @@ func (d *dispatcherStat) shouldForwardEventByCommitTs(event dispatcher.Dispatche
 	return true
 }
 
-type commitTsState struct {
-	lastEventCommitTs uint64
-	gotDDLOnTs        bool
-	gotSyncpointOnTS  bool
-	hasStateUpdate    bool
-}
+func (d *dispatcherStat) updateCommitTsStateByEvents(events []dispatcher.DispatcherEvent) {
+	lastEventCommitTs := d.lastEventCommitTs.Load()
+	gotDDLOnTs := d.gotDDLOnTs.Load()
+	gotSyncpointOnTS := d.gotSyncpointOnTS.Load()
+	hasStateUpdate := false
 
-func advanceCommitTsState(state commitTsState, event dispatcher.DispatcherEvent) commitTsState {
-	if event.GetCommitTs() > state.lastEventCommitTs {
-		// if the commit ts is larger than the last sent commit ts,
-		// we need to reset the DDL and SyncPoint flags.
-		state.gotDDLOnTs = false
-		state.gotSyncpointOnTS = false
-	}
-
-	switch event.GetType() {
-	case commonEvent.TypeDDLEvent:
-		state.gotDDLOnTs = true
-	case commonEvent.TypeSyncPointEvent:
-		state.gotSyncpointOnTS = true
-	}
-
-	switch event.GetType() {
-	case commonEvent.TypeDDLEvent,
-		commonEvent.TypeDMLEvent,
-		commonEvent.TypeBatchDMLEvent,
-		commonEvent.TypeSyncPointEvent:
-		state.lastEventCommitTs = event.GetCommitTs()
-		state.hasStateUpdate = true
-	}
-	return state
-}
-
-func (d *dispatcherStat) buildCommitTsState(events []dispatcher.DispatcherEvent) commitTsState {
-	state := commitTsState{
-		lastEventCommitTs: d.lastEventCommitTs.Load(),
-		gotDDLOnTs:        d.gotDDLOnTs.Load(),
-		gotSyncpointOnTS:  d.gotSyncpointOnTS.Load(),
-	}
 	for _, event := range events {
-		state = advanceCommitTsState(state, event)
-	}
-	return state
-}
+		if event.GetCommitTs() > lastEventCommitTs {
+			// if the commit ts is larger than the last sent commit ts,
+			// we need to reset the DDL and SyncPoint flags.
+			gotDDLOnTs = false
+			gotSyncpointOnTS = false
+		}
 
-func (d *dispatcherStat) applyCommitTsState(state commitTsState) {
-	if !state.hasStateUpdate {
+		switch event.GetType() {
+		case commonEvent.TypeDDLEvent:
+			gotDDLOnTs = true
+		case commonEvent.TypeSyncPointEvent:
+			gotSyncpointOnTS = true
+		}
+
+		switch event.GetType() {
+		case commonEvent.TypeDDLEvent,
+			commonEvent.TypeDMLEvent,
+			commonEvent.TypeBatchDMLEvent,
+			commonEvent.TypeSyncPointEvent:
+			lastEventCommitTs = event.GetCommitTs()
+			hasStateUpdate = true
+		}
+	}
+
+	if !hasStateUpdate {
 		return
 	}
-	d.lastEventCommitTs.Store(state.lastEventCommitTs)
-	d.gotDDLOnTs.Store(state.gotDDLOnTs)
-	d.gotSyncpointOnTS.Store(state.gotSyncpointOnTS)
+	d.lastEventCommitTs.Store(lastEventCommitTs)
+	d.gotDDLOnTs.Store(gotDDLOnTs)
+	d.gotSyncpointOnTS.Store(gotSyncpointOnTS)
 }
 
 func (d *dispatcherStat) isFromCurrentEpoch(event dispatcher.DispatcherEvent) bool {
@@ -473,8 +458,7 @@ func (d *dispatcherStat) handleBatchDataEvents(events []dispatcher.DispatcherEve
 	if len(validEvents) == 0 {
 		return false
 	}
-	state := d.buildCommitTsState(validEvents)
-	d.applyCommitTsState(state)
+	d.updateCommitTsStateByEvents(validEvents)
 	return d.target.HandleEvents(validEvents, func() { d.wake() })
 }
 
@@ -518,15 +502,13 @@ func (d *dispatcherStat) handleSingleDataEvents(events []dispatcher.DispatcherEv
 		if ddl.TableInfo != nil {
 			d.tableInfo.Store(ddl.TableInfo)
 		}
-		state := d.buildCommitTsState(events)
-		d.applyCommitTsState(state)
+		d.updateCommitTsStateByEvents(events)
 		return d.target.HandleEvents(events, func() { d.wake() })
 	} else {
 		if !d.shouldForwardEventByCommitTs(events[0]) {
 			return false
 		}
-		state := d.buildCommitTsState(events)
-		d.applyCommitTsState(state)
+		d.updateCommitTsStateByEvents(events)
 		return d.target.HandleEvents(events, func() { d.wake() })
 	}
 }

--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -488,24 +488,18 @@ func (d *dispatcherStat) handleSingleDataEvents(events []dispatcher.DispatcherEv
 		d.reset(d.connState.getEventServiceID())
 		return false
 	}
+	if !d.shouldForwardEventByCommitTs(events[0]) {
+		return false
+	}
 	if events[0].GetType() == commonEvent.TypeDDLEvent {
-		if !d.shouldForwardEventByCommitTs(events[0]) {
-			return false
-		}
 		ddl := events[0].Event.(*commonEvent.DDLEvent)
 		d.tableInfoVersion.Store(ddl.FinishedTs)
 		if ddl.TableInfo != nil {
 			d.tableInfo.Store(ddl.TableInfo)
 		}
-		d.updateCommitTsStateByEvents(events)
-		return d.target.HandleEvents(events, func() { d.wake() })
-	} else {
-		if !d.shouldForwardEventByCommitTs(events[0]) {
-			return false
-		}
-		d.updateCommitTsStateByEvents(events)
-		return d.target.HandleEvents(events, func() { d.wake() })
 	}
+	d.updateCommitTsStateByEvents(events)
+	return d.target.HandleEvents(events, func() { d.wake() })
 }
 
 func (d *dispatcherStat) handleDataEvents(events ...dispatcher.DispatcherEvent) bool {

--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -345,7 +345,6 @@ func (d *dispatcherStat) updateCommitTsStateByEvents(events []dispatcher.Dispatc
 	lastEventCommitTs := d.lastEventCommitTs.Load()
 	gotDDLOnTs := d.gotDDLOnTs.Load()
 	gotSyncpointOnTS := d.gotSyncpointOnTS.Load()
-	hasStateUpdate := false
 
 	for _, event := range events {
 		if event.GetCommitTs() > lastEventCommitTs {
@@ -368,13 +367,9 @@ func (d *dispatcherStat) updateCommitTsStateByEvents(events []dispatcher.Dispatc
 			commonEvent.TypeBatchDMLEvent,
 			commonEvent.TypeSyncPointEvent:
 			lastEventCommitTs = event.GetCommitTs()
-			hasStateUpdate = true
 		}
 	}
 
-	if !hasStateUpdate {
-		return
-	}
 	d.lastEventCommitTs.Store(lastEventCommitTs)
 	d.gotDDLOnTs.Store(gotDDLOnTs)
 	d.gotSyncpointOnTS.Store(gotSyncpointOnTS)

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -1252,7 +1252,7 @@ func TestHandleBatchDMLEvent(t *testing.T) {
 	}
 }
 
-func TestHandleBatchDataEventsDoesNotAdvanceCommitTsWhenDispatcherFiltersAll(t *testing.T) {
+func TestHandleBatchDataEventsDoesNotAdvanceCommitTsWhenNoValidEvents(t *testing.T) {
 	t.Parallel()
 
 	mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
@@ -1271,7 +1271,7 @@ func TestHandleBatchDataEventsDoesNotAdvanceCommitTsWhenDispatcherFiltersAll(t *
 				eventType: commonEvent.TypeDMLEvent,
 				seq:       2,
 				epoch:     10,
-				commitTs:  100,
+				commitTs:  40,
 			},
 			From: createNodeID("service1"),
 		},

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -339,7 +339,7 @@ func TestVerifyEventSequence(t *testing.T) {
 	}
 }
 
-func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
+func TestShouldForwardEventByCommitTs(t *testing.T) {
 	tests := []struct {
 		name              string
 		lastEventCommitTs uint64
@@ -347,9 +347,6 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 		gotSyncpointOnTS  bool
 		event             dispatcher.DispatcherEvent
 		expectedResult    bool
-		expectedDDLOnTs   bool
-		expectedSyncOnTs  bool
-		expectedCommitTs  uint64
 	}{
 		{
 			name:              "event with commit ts less than last commit ts",
@@ -360,10 +357,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  90,
 				},
 			},
-			expectedResult:   false,
-			expectedDDLOnTs:  false,
-			expectedSyncOnTs: false,
-			expectedCommitTs: 100,
+			expectedResult: false,
 		},
 		{
 			name:              "DDL event with same commit ts and already got DDL",
@@ -375,10 +369,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  100,
 				},
 			},
-			expectedResult:   false,
-			expectedDDLOnTs:  true,
-			expectedSyncOnTs: false,
-			expectedCommitTs: 100,
+			expectedResult: false,
 		},
 		{
 			name:              "DDL event with same commit ts and not got DDL",
@@ -390,10 +381,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  100,
 				},
 			},
-			expectedResult:   true,
-			expectedDDLOnTs:  true,
-			expectedSyncOnTs: false,
-			expectedCommitTs: 100,
+			expectedResult: true,
 		},
 		{
 			name:              "SyncPoint event with same commit ts and already got SyncPoint",
@@ -405,10 +393,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  101,
 				},
 			},
-			expectedResult:   false,
-			expectedDDLOnTs:  false,
-			expectedSyncOnTs: true,
-			expectedCommitTs: 101,
+			expectedResult: false,
 		},
 		{
 			name:              "SyncPoint event with same commit ts and not got SyncPoint",
@@ -420,10 +405,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  101,
 				},
 			},
-			expectedResult:   true,
-			expectedDDLOnTs:  false,
-			expectedSyncOnTs: true,
-			expectedCommitTs: 101,
+			expectedResult: true,
 		},
 
 		{
@@ -437,10 +419,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  110,
 				},
 			},
-			expectedResult:   true,
-			expectedDDLOnTs:  false,
-			expectedSyncOnTs: false,
-			expectedCommitTs: 110,
+			expectedResult: true,
 		},
 		{
 			name:              "BatchDML event with larger commit ts",
@@ -455,10 +434,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					},
 				},
 			},
-			expectedResult:   true,
-			expectedDDLOnTs:  false,
-			expectedSyncOnTs: false,
-			expectedCommitTs: 110,
+			expectedResult: true,
 		},
 		{
 			name:              "Resolved event with larger commit ts",
@@ -471,10 +447,7 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 					commitTs:  110,
 				},
 			},
-			expectedResult:   true,
-			expectedDDLOnTs:  false,
-			expectedSyncOnTs: false,
-			expectedCommitTs: 100, // Resolved event should not update lastEventCommitTs
+			expectedResult: true,
 		},
 	}
 
@@ -487,13 +460,44 @@ func TestFilterAndUpdateEventByCommitTs(t *testing.T) {
 			stat.gotDDLOnTs.Store(tt.gotDDLOnTs)
 			stat.gotSyncpointOnTS.Store(tt.gotSyncpointOnTS)
 
-			result := stat.filterAndUpdateEventByCommitTs(tt.event)
+			result := stat.shouldForwardEventByCommitTs(tt.event)
 			require.Equal(t, tt.expectedResult, result)
-			require.Equal(t, tt.expectedDDLOnTs, stat.gotDDLOnTs.Load())
-			require.Equal(t, tt.expectedSyncOnTs, stat.gotSyncpointOnTS.Load())
-			require.Equal(t, tt.expectedCommitTs, stat.lastEventCommitTs.Load())
+			require.Equal(t, tt.gotDDLOnTs, stat.gotDDLOnTs.Load())
+			require.Equal(t, tt.gotSyncpointOnTS, stat.gotSyncpointOnTS.Load())
+			require.Equal(t, tt.lastEventCommitTs, stat.lastEventCommitTs.Load())
 		})
 	}
+}
+
+func TestApplyCommitTsState(t *testing.T) {
+	t.Parallel()
+
+	stat := &dispatcherStat{
+		target: newMockDispatcher(common.NewDispatcherID(), 0),
+	}
+	stat.lastEventCommitTs.Store(100)
+	stat.gotDDLOnTs.Store(true)
+	stat.gotSyncpointOnTS.Store(true)
+
+	state := stat.buildCommitTsState([]dispatcher.DispatcherEvent{
+		{
+			Event: &mockEvent{
+				eventType: commonEvent.TypeResolvedEvent,
+				commitTs:  105,
+			},
+		},
+		{
+			Event: &mockEvent{
+				eventType: commonEvent.TypeDMLEvent,
+				commitTs:  110,
+			},
+		},
+	})
+	stat.applyCommitTsState(state)
+
+	require.Equal(t, uint64(110), stat.lastEventCommitTs.Load())
+	require.False(t, stat.gotDDLOnTs.Load())
+	require.False(t, stat.gotSyncpointOnTS.Load())
 }
 
 func TestHandleSignalEvent(t *testing.T) {
@@ -1246,6 +1250,35 @@ func TestHandleBatchDMLEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleBatchDataEventsDoesNotAdvanceCommitTsWhenDispatcherFiltersAll(t *testing.T) {
+	t.Parallel()
+
+	mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
+	mockDisp.handleEvents = func(events []dispatcher.DispatcherEvent, wakeCallback func()) (block bool) {
+		return false
+	}
+
+	stat := newDispatcherStat(mockDisp, nil, nil)
+	stat.lastEventCommitTs.Store(50)
+	stat.lastEventSeq.Store(1)
+	stat.epoch.Store(10)
+
+	events := []dispatcher.DispatcherEvent{
+		{
+			Event: &mockEvent{
+				eventType: commonEvent.TypeDMLEvent,
+				seq:       2,
+				epoch:     10,
+				commitTs:  100,
+			},
+			From: createNodeID("service1"),
+		},
+	}
+
+	require.False(t, stat.handleBatchDataEvents(events))
+	require.Equal(t, uint64(50), stat.lastEventCommitTs.Load())
 }
 
 func TestNewDispatcherResetRequest(t *testing.T) {

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -1139,6 +1139,98 @@ func TestHandleSingleDataEvents(t *testing.T) {
 	}
 }
 
+func TestHandleSingleDataEventsUpdatesDDLStateAndDedupsSameTsDDL(t *testing.T) {
+	t.Parallel()
+
+	mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
+	mockDisp.handleEvents = func(events []dispatcher.DispatcherEvent, wakeCallback func()) (block bool) {
+		return len(events) > 0
+	}
+
+	currentService := node.ID("service1")
+	stat := newDispatcherStat(mockDisp, newTestEventCollector(currentService), nil)
+	stat.lastEventSeq.Store(1)
+	stat.lastEventCommitTs.Store(99)
+	stat.epoch.Store(10)
+	stat.connState.setEventServiceID(currentService)
+	stat.connState.readyEventReceived.Store(true)
+
+	firstDDL := dispatcher.DispatcherEvent{
+		From: createNodeID("service1"),
+		Event: &commonEvent.DDLEvent{
+			Seq:        2,
+			Epoch:      10,
+			FinishedTs: 100,
+		},
+	}
+	secondDDL := dispatcher.DispatcherEvent{
+		From: createNodeID("service1"),
+		Event: &commonEvent.DDLEvent{
+			Seq:        3,
+			Epoch:      10,
+			FinishedTs: 100,
+		},
+	}
+
+	require.True(t, stat.handleSingleDataEvents([]dispatcher.DispatcherEvent{firstDDL}))
+	require.Equal(t, uint64(100), stat.lastEventCommitTs.Load())
+	require.True(t, stat.gotDDLOnTs.Load())
+	require.False(t, stat.gotSyncpointOnTS.Load())
+	require.Len(t, mockDisp.events, 1)
+
+	require.False(t, stat.handleSingleDataEvents([]dispatcher.DispatcherEvent{secondDDL}))
+	require.Equal(t, uint64(100), stat.lastEventCommitTs.Load())
+	require.True(t, stat.gotDDLOnTs.Load())
+	require.False(t, stat.gotSyncpointOnTS.Load())
+	require.Len(t, mockDisp.events, 1)
+}
+
+func TestHandleSingleDataEventsUpdatesSyncPointStateAndDedupsSameTsSyncPoint(t *testing.T) {
+	t.Parallel()
+
+	mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
+	mockDisp.handleEvents = func(events []dispatcher.DispatcherEvent, wakeCallback func()) (block bool) {
+		return len(events) > 0
+	}
+
+	currentService := node.ID("service1")
+	stat := newDispatcherStat(mockDisp, newTestEventCollector(currentService), nil)
+	stat.lastEventSeq.Store(1)
+	stat.lastEventCommitTs.Store(199)
+	stat.epoch.Store(10)
+	stat.connState.setEventServiceID(currentService)
+	stat.connState.readyEventReceived.Store(true)
+
+	firstSyncPoint := dispatcher.DispatcherEvent{
+		From: createNodeID("service1"),
+		Event: &commonEvent.SyncPointEvent{
+			Seq:      2,
+			Epoch:    10,
+			CommitTs: 200,
+		},
+	}
+	secondSyncPoint := dispatcher.DispatcherEvent{
+		From: createNodeID("service1"),
+		Event: &commonEvent.SyncPointEvent{
+			Seq:      3,
+			Epoch:    10,
+			CommitTs: 200,
+		},
+	}
+
+	require.True(t, stat.handleSingleDataEvents([]dispatcher.DispatcherEvent{firstSyncPoint}))
+	require.Equal(t, uint64(200), stat.lastEventCommitTs.Load())
+	require.False(t, stat.gotDDLOnTs.Load())
+	require.True(t, stat.gotSyncpointOnTS.Load())
+	require.Len(t, mockDisp.events, 1)
+
+	require.False(t, stat.handleSingleDataEvents([]dispatcher.DispatcherEvent{secondSyncPoint}))
+	require.Equal(t, uint64(200), stat.lastEventCommitTs.Load())
+	require.False(t, stat.gotDDLOnTs.Load())
+	require.True(t, stat.gotSyncpointOnTS.Load())
+	require.Len(t, mockDisp.events, 1)
+}
+
 func TestHandleBatchDMLEvent(t *testing.T) {
 	normalHandleEvents := func(events []dispatcher.DispatcherEvent, wakeCallback func()) (block bool) {
 		return len(events) > 0

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -469,7 +469,7 @@ func TestShouldForwardEventByCommitTs(t *testing.T) {
 	}
 }
 
-func TestApplyCommitTsState(t *testing.T) {
+func TestUpdateCommitTsStateByEvents(t *testing.T) {
 	t.Parallel()
 
 	stat := &dispatcherStat{
@@ -479,7 +479,7 @@ func TestApplyCommitTsState(t *testing.T) {
 	stat.gotDDLOnTs.Store(true)
 	stat.gotSyncpointOnTS.Store(true)
 
-	state := stat.buildCommitTsState([]dispatcher.DispatcherEvent{
+	stat.updateCommitTsStateByEvents([]dispatcher.DispatcherEvent{
 		{
 			Event: &mockEvent{
 				eventType: commonEvent.TypeResolvedEvent,
@@ -493,7 +493,6 @@ func TestApplyCommitTsState(t *testing.T) {
 			},
 		},
 	})
-	stat.applyCommitTsState(state)
 
 	require.Equal(t, uint64(110), stat.lastEventCommitTs.Load())
 	require.False(t, stat.gotDDLOnTs.Load())


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4581

### What is changed and how it works?

This pull request refactors the event processing within the event collector to improve the correctness and reliability of commit timestamp deduplication. By separating the event filtering logic from the state update mechanism, the system now ensures that internal state, such as the last processed commit timestamp and DDL/SyncPoint flags, is only advanced after events have been successfully validated and are ready to be dispatched. This prevents inconsistent state updates that could occur if state was modified during the filtering of individual events, particularly in scenarios involving batch processing or events that are ignored.

### Highlights

* **Refactored Commit Timestamp State Management**: The logic for updating the `lastEventCommitTs`, `gotDDLOnTs`, and `gotSyncpointOnTS` state has been decoupled from the event filtering process. State updates now occur after a batch of events has been filtered and deemed valid for forwarding.
* **Separation of Concerns in Event Filtering**: The `filterAndUpdateEventByCommitTs` function was renamed to `shouldForwardEventByCommitTs` and its responsibility was narrowed to solely determine if an event should be forwarded, without modifying any internal state. This makes the filtering a pure validation step.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event filtering is now a pure per-event gate (no per-event state mutation); commit-timestamp and related flags are computed and advanced once per processed group for correct ordering and deduplication.

* **Tests**
  * Updated and added unit tests validating the pure-gate behavior, batch vs single processing, commit-timestamp transitions, DDL/SyncPoint deduplication, and non-advancement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->