### PR TITLE
tests: print upstream table schema before creating changefeed

### DIFF
--- a/tests/integration_tests/correctness_for_shared_column_schema/run.sh
+++ b/tests/integration_tests/correctness_for_shared_column_schema/run.sh
@@ -8,6 +8,38 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
+function print_upstream_table_schemas_before_changefeed() {
+	echo "[$(date)] print upstream table schemas before creating changefeed"
+
+	local listTablesSQL
+	listTablesSQL="SELECT CONCAT('SHOW CREATE TABLE \`', TABLE_SCHEMA, '\`.\`', TABLE_NAME, '\`;')
+FROM information_schema.tables
+WHERE TABLE_TYPE = 'BASE TABLE'
+  AND LOWER(TABLE_SCHEMA) NOT IN (
+    'information_schema',
+    'performance_schema',
+    'metrics_schema',
+    'inspection_schema',
+    'inspection_result',
+    'cluster_info',
+    'mysql',
+    'sys'
+  )
+ORDER BY TABLE_SCHEMA, TABLE_NAME;"
+
+	local showCreateTableSQLs
+	showCreateTableSQLs=$(mysql -uroot -h${UP_TIDB_HOST} -P${UP_TIDB_PORT} --default-character-set utf8mb4 -N -e "$listTablesSQL")
+	if [ -z "$showCreateTableSQLs" ]; then
+		echo "[$(date)] no upstream user tables found before creating changefeed"
+		return
+	fi
+
+	while IFS= read -r showCreateSQL; do
+		[ -z "$showCreateSQL" ] && continue
+		run_sql "$showCreateSQL" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	done <<<"$showCreateTableSQLs"
+}
+
 function run() {
 	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 	stop_tidb_cluster
@@ -33,6 +65,7 @@ function run() {
 		;;
 	*) SINK_URI="mysql://normal:123456@127.0.0.1:3306/" ;;
 	esac
+	print_upstream_table_schemas_before_changefeed
 	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI"
 	case $SINK_TYPE in
 	kafka) run_kafka_consumer $WORK_DIR $SINK_URI ;;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #none

### What is changed and how it works?

This PR adds schema diagnostics for the
`correctness_for_shared_column_schema` integration test.

- Add `print_upstream_table_schemas_before_changefeed` in
  `tests/integration_tests/correctness_for_shared_column_schema/run.sh`.
- Before creating the changefeed, query all upstream non-system base tables
  from `information_schema.tables` and run `SHOW CREATE TABLE` for each table.
- This prints the exact upstream table definitions in test logs, which helps
  debug cases where CI reports missing unique keys unexpectedly.

### Check List

#### Tests

- Manual test (add detailed scripts or steps below)
  - `bash -n tests/integration_tests/correctness_for_shared_column_schema/run.sh`

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for changefeed validation with improved schema diagnostics and upstream table verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->