### PR TITLE
coordinator,gc: delete stale cluster service safepoint

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/server/watcher"
 	"github.com/pingcap/ticdc/utils/chann"
-	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -363,7 +362,23 @@ func (c *coordinator) CreateChangefeed(ctx context.Context, info *config.ChangeF
 }
 
 func (c *coordinator) RemoveChangefeed(ctx context.Context, id common.ChangeFeedID) (uint64, error) {
-	return c.controller.RemoveChangefeed(ctx, id)
+	checkpointTs, err := c.controller.RemoveChangefeed(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+	if c.controller.calculateGlobalGCSafepoint() != math.MaxUint64 {
+		return checkpointTs, nil
+	}
+
+	// Delete the cluster-level safepoint as soon as the last changefeed is gone.
+	// This closes the window where the final coordinator could exit before the
+	// next periodic GC reconcile tick gets a chance to clean it up.
+	if err := c.tryDeleteGlobalGCSafepoint(ctx); err != nil {
+		log.Warn("failed to delete global gc safepoint after removing last changefeed",
+			zap.String("changefeed", id.String()),
+			zap.Error(err))
+	}
+	return checkpointTs, nil
 }
 
 func (c *coordinator) PauseChangefeed(ctx context.Context, id common.ChangeFeedID) error {
@@ -425,12 +440,19 @@ func (c *coordinator) sendMessages(msgs []*messaging.TargetMessage) {
 	}
 }
 
+func (c *coordinator) tryDeleteGlobalGCSafepoint(ctx context.Context) error {
+	if !kerneltype.IsClassic() {
+		return nil
+	}
+	return errors.Trace(c.gcManager.TryDeleteServiceGCSafepoint(ctx))
+}
+
 func (c *coordinator) updateGlobalGcSafepoint(ctx context.Context) error {
 	minCheckpointTs := c.controller.calculateGlobalGCSafepoint()
-	// check if the upstream has a changefeed, if not we should update the gc safepoint
 	if minCheckpointTs == math.MaxUint64 {
-		ts := c.pdClock.CurrentTime()
-		minCheckpointTs = oracle.GoTimeToTS(ts)
+		// Once there is no changefeed left, TiCDC should remove the cluster-level
+		// service safepoint instead of refreshing it to "now - 1".
+		return c.tryDeleteGlobalGCSafepoint(ctx)
 	}
 	// When the changefeed starts up, CDC will do a snapshot read at
 	// (checkpointTs - 1) from TiKV, so (checkpointTs - 1) should be an upper

--- a/coordinator/create_changefeed_gc_test.go
+++ b/coordinator/create_changefeed_gc_test.go
@@ -15,7 +15,6 @@ package coordinator
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -75,49 +74,6 @@ func newTestCoordinatorWithGCManager(
 		gcCleaner: gccleaner.New(nil, "test-gc-service"),
 	}
 	return co, changefeedDB
-}
-
-type recordingGCManager struct {
-	mu        sync.Mutex
-	updatedTs []common.Ts
-	deleted   int
-}
-
-func (m *recordingGCManager) TryUpdateServiceGCSafepoint(ctx context.Context, checkpointTs common.Ts) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.updatedTs = append(m.updatedTs, checkpointTs)
-	return nil
-}
-
-func (m *recordingGCManager) TryDeleteServiceGCSafepoint(ctx context.Context) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.deleted++
-	return nil
-}
-
-func (m *recordingGCManager) CheckStaleCheckpointTs(keyspaceID uint32, changefeedID common.ChangeFeedID, checkpointTs common.Ts) error {
-	return nil
-}
-
-func (m *recordingGCManager) TryUpdateKeyspaceGCBarrier(ctx context.Context, keyspaceID uint32, keyspaceName string, checkpointTs common.Ts) error {
-	return nil
-}
-
-func (m *recordingGCManager) DeleteCount() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.deleted
-}
-
-func (m *recordingGCManager) UpdatedTs() []common.Ts {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	updated := make([]common.Ts, len(m.updatedTs))
-	copy(updated, m.updatedTs)
-	return updated
 }
 
 func TestCreateChangefeedDoesNotUpdateGCSafepoint(t *testing.T) {
@@ -272,7 +228,7 @@ func TestConcurrentDeleteLastChangefeedAndCreateNewOneKeepsExpectedGCSafepoint(t
 	for i := 0; i < 5; i++ {
 		ctrl := gomock.NewController(t)
 		backend := mock_changefeed.NewMockBackend(ctrl)
-		gcManager := &recordingGCManager{}
+		gcManager := gc.NewMockManager(ctrl)
 
 		co, changefeedDB := newTestCoordinatorWithGCManager(t, backend, gcManager)
 
@@ -303,6 +259,13 @@ func TestConcurrentDeleteLastChangefeedAndCreateNewOneKeepsExpectedGCSafepoint(t
 			CreateChangefeed(gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
+		gcManager.EXPECT().
+			TryDeleteServiceGCSafepoint(gomock.Any()).
+			Times(0)
+		gcManager.EXPECT().
+			TryUpdateServiceGCSafepoint(gomock.Any(), common.Ts(newInfo.StartTs-1)).
+			Return(nil).
+			Times(1)
 
 		cpCh := make(chan uint64, 1)
 		errCh := make(chan error, 1)
@@ -323,9 +286,7 @@ func TestConcurrentDeleteLastChangefeedAndCreateNewOneKeepsExpectedGCSafepoint(t
 
 		require.NoError(t, <-errCh)
 		require.Equalf(t, uint64(101), <-cpCh, "iteration %d", i)
-		require.Equalf(t, 0, gcManager.DeleteCount(), "iteration %d", i)
 
 		require.NoError(t, co.updateGCSafepoint(context.Background()))
-		require.Equalf(t, []common.Ts{common.Ts(newInfo.StartTs - 1)}, gcManager.UpdatedTs(), "iteration %d", i)
 	}
 }

--- a/coordinator/create_changefeed_gc_test.go
+++ b/coordinator/create_changefeed_gc_test.go
@@ -16,6 +16,7 @@ package coordinator
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pingcap/ticdc/coordinator/changefeed"
@@ -147,4 +148,74 @@ func TestUpdateGCSafepointCallsGCManagerUpdate(t *testing.T) {
 	require.NotNil(t, cf)
 	require.Equal(t, config.StateNormal, cf.GetInfo().State)
 	require.Nil(t, cf.GetInfo().Error)
+}
+
+func TestUpdateGCSafepointDeletesServiceSafepointWhenNoChangefeed(t *testing.T) {
+	if !kerneltype.IsClassic() {
+		t.Skip("classic mode only")
+	}
+
+	ctrl := gomock.NewController(t)
+	backend := mock_changefeed.NewMockBackend(ctrl)
+	gcManager := gc.NewMockManager(ctrl)
+
+	co, _ := newTestCoordinatorWithGCManager(t, backend, gcManager)
+
+	gcManager.EXPECT().
+		TryDeleteServiceGCSafepoint(gomock.Any()).
+		Return(nil).
+		Times(1)
+	gcManager.EXPECT().
+		TryUpdateServiceGCSafepoint(gomock.Any(), gomock.Any()).
+		Times(0)
+
+	require.NoError(t, co.updateGCSafepoint(context.Background()))
+}
+
+func TestRemoveLastChangefeedDeletesServiceSafepointImmediately(t *testing.T) {
+	if !kerneltype.IsClassic() {
+		t.Skip("classic mode only")
+	}
+
+	ctrl := gomock.NewController(t)
+	backend := mock_changefeed.NewMockBackend(ctrl)
+	gcManager := gc.NewMockManager(ctrl)
+
+	co, changefeedDB := newTestCoordinatorWithGCManager(t, backend, gcManager)
+
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	cf := changefeed.NewChangefeed(cfID, &config.ChangeFeedInfo{
+		ChangefeedID: cfID,
+		Config:       config.GetDefaultReplicaConfig(),
+		State:        config.StateNormal,
+		SinkURI:      "mysql://127.0.0.1:3306",
+	}, 101, true)
+	changefeedDB.AddReplicatingMaintainer(cf, "node1")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			op := co.controller.operatorController.GetOperator(cfID)
+			if op != nil {
+				op.OnTaskRemoved()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	backend.EXPECT().
+		SetChangefeedProgress(gomock.Any(), cfID, config.ProgressRemoving).
+		Return(nil).
+		Times(1)
+	gcManager.EXPECT().
+		TryDeleteServiceGCSafepoint(gomock.Any()).
+		Return(nil).
+		Times(1)
+
+	cp, err := co.RemoveChangefeed(context.Background(), cfID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(101), cp)
+	<-done
 }

--- a/coordinator/create_changefeed_gc_test.go
+++ b/coordinator/create_changefeed_gc_test.go
@@ -15,6 +15,7 @@ package coordinator
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -74,6 +75,49 @@ func newTestCoordinatorWithGCManager(
 		gcCleaner: gccleaner.New(nil, "test-gc-service"),
 	}
 	return co, changefeedDB
+}
+
+type recordingGCManager struct {
+	mu        sync.Mutex
+	updatedTs []common.Ts
+	deleted   int
+}
+
+func (m *recordingGCManager) TryUpdateServiceGCSafepoint(ctx context.Context, checkpointTs common.Ts) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.updatedTs = append(m.updatedTs, checkpointTs)
+	return nil
+}
+
+func (m *recordingGCManager) TryDeleteServiceGCSafepoint(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deleted++
+	return nil
+}
+
+func (m *recordingGCManager) CheckStaleCheckpointTs(keyspaceID uint32, changefeedID common.ChangeFeedID, checkpointTs common.Ts) error {
+	return nil
+}
+
+func (m *recordingGCManager) TryUpdateKeyspaceGCBarrier(ctx context.Context, keyspaceID uint32, keyspaceName string, checkpointTs common.Ts) error {
+	return nil
+}
+
+func (m *recordingGCManager) DeleteCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.deleted
+}
+
+func (m *recordingGCManager) UpdatedTs() []common.Ts {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	updated := make([]common.Ts, len(m.updatedTs))
+	copy(updated, m.updatedTs)
+	return updated
 }
 
 func TestCreateChangefeedDoesNotUpdateGCSafepoint(t *testing.T) {
@@ -192,17 +236,12 @@ func TestRemoveLastChangefeedDeletesServiceSafepointImmediately(t *testing.T) {
 	}, 101, true)
 	changefeedDB.AddReplicatingMaintainer(cf, "node1")
 
-	done := make(chan struct{})
+	cpCh := make(chan uint64, 1)
+	errCh := make(chan error, 1)
 	go func() {
-		defer close(done)
-		for {
-			op := co.controller.operatorController.GetOperator(cfID)
-			if op != nil {
-				op.OnTaskRemoved()
-				return
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
+		cp, err := co.RemoveChangefeed(context.Background(), cfID)
+		cpCh <- cp
+		errCh <- err
 	}()
 
 	backend.EXPECT().
@@ -214,8 +253,79 @@ func TestRemoveLastChangefeedDeletesServiceSafepointImmediately(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	cp, err := co.RemoveChangefeed(context.Background(), cfID)
-	require.NoError(t, err)
-	require.Equal(t, uint64(101), cp)
-	<-done
+	var op interface{ OnTaskRemoved() }
+	require.Eventually(t, func() bool {
+		op = co.controller.operatorController.GetOperator(cfID)
+		return op != nil
+	}, 5*time.Second, 10*time.Millisecond)
+	op.OnTaskRemoved()
+
+	require.NoError(t, <-errCh)
+	require.Equal(t, uint64(101), <-cpCh)
+}
+
+func TestConcurrentDeleteLastChangefeedAndCreateNewOneKeepsExpectedGCSafepoint(t *testing.T) {
+	if !kerneltype.IsClassic() {
+		t.Skip("classic mode only")
+	}
+
+	for i := 0; i < 5; i++ {
+		ctrl := gomock.NewController(t)
+		backend := mock_changefeed.NewMockBackend(ctrl)
+		gcManager := &recordingGCManager{}
+
+		co, changefeedDB := newTestCoordinatorWithGCManager(t, backend, gcManager)
+
+		oldID := common.NewChangeFeedIDWithName("old", common.DefaultKeyspaceName)
+		oldCF := changefeed.NewChangefeed(oldID, &config.ChangeFeedInfo{
+			ChangefeedID: oldID,
+			Config:       config.GetDefaultReplicaConfig(),
+			State:        config.StateNormal,
+			SinkURI:      "mysql://127.0.0.1:3306",
+		}, 101, true)
+		changefeedDB.AddReplicatingMaintainer(oldCF, "node1")
+
+		newID := common.NewChangeFeedIDWithName("new", common.DefaultKeyspaceName)
+		newInfo := &config.ChangeFeedInfo{
+			ChangefeedID: newID,
+			StartTs:      205,
+			State:        config.StateNormal,
+			Config:       config.GetDefaultReplicaConfig(),
+			SinkURI:      "kafka://127.0.0.1:9092",
+			KeyspaceID:   1,
+		}
+
+		backend.EXPECT().
+			SetChangefeedProgress(gomock.Any(), oldID, config.ProgressRemoving).
+			Return(nil).
+			Times(1)
+		backend.EXPECT().
+			CreateChangefeed(gomock.Any(), gomock.Any()).
+			Return(nil).
+			Times(1)
+
+		cpCh := make(chan uint64, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			cp, err := co.RemoveChangefeed(context.Background(), oldID)
+			cpCh <- cp
+			errCh <- err
+		}()
+
+		var op interface{ OnTaskRemoved() }
+		require.Eventually(t, func() bool {
+			op = co.controller.operatorController.GetOperator(oldID)
+			return op != nil
+		}, 5*time.Second, 10*time.Millisecond)
+
+		require.NoError(t, co.CreateChangefeed(context.Background(), newInfo))
+		op.OnTaskRemoved()
+
+		require.NoError(t, <-errCh)
+		require.Equalf(t, uint64(101), <-cpCh, "iteration %d", i)
+		require.Equalf(t, 0, gcManager.DeleteCount(), "iteration %d", i)
+
+		require.NoError(t, co.updateGCSafepoint(context.Background()))
+		require.Equalf(t, []common.Ts{common.Ts(newInfo.StartTs - 1)}, gcManager.UpdatedTs(), "iteration %d", i)
+	}
 }

--- a/coordinator/ensure_gc_cleanup_async_test.go
+++ b/coordinator/ensure_gc_cleanup_async_test.go
@@ -37,6 +37,10 @@ func (noopGCManager) TryUpdateServiceGCSafepoint(ctx context.Context, checkpoint
 	return nil
 }
 
+func (noopGCManager) TryDeleteServiceGCSafepoint(ctx context.Context) error {
+	return nil
+}
+
 func (noopGCManager) CheckStaleCheckpointTs(keyspaceID uint32, changefeedID common.ChangeFeedID, checkpointTs common.Ts) error {
 	return nil
 }

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -36,6 +36,8 @@ import (
 type Manager interface {
 	// TryUpdateServiceGCSafepoint tries to update TiCDC service GC safepoint.
 	TryUpdateServiceGCSafepoint(ctx context.Context, checkpointTs common.Ts) error
+	// TryDeleteServiceGCSafepoint removes the TiCDC service GC safepoint when no changefeed needs it.
+	TryDeleteServiceGCSafepoint(ctx context.Context) error
 	CheckStaleCheckpointTs(keyspaceID uint32, changefeedID common.ChangeFeedID, checkpointTs common.Ts) error
 	// TryUpdateKeyspaceGCBarrier tries to update gc barrier of a keyspace
 	TryUpdateKeyspaceGCBarrier(ctx context.Context, keyspaceID uint32, keyspaceName string, checkpointTs common.Ts) error
@@ -107,6 +109,23 @@ func (m *gcManager) TryUpdateServiceGCSafepoint(
 	m.lastSafePointTs.Store(minServiceGCSafepoint)
 	minServiceGCSafePointGauge.Set(float64(oracle.ExtractPhysical(minServiceGCSafepoint)))
 	cdcGCSafePointGauge.Set(float64(oracle.ExtractPhysical(checkpointTs)))
+	return nil
+}
+
+func (m *gcManager) TryDeleteServiceGCSafepoint(ctx context.Context) error {
+	if err := UnifyDeleteGcSafepoint(ctx, m.pdClient, 0, m.gcServiceID); err != nil {
+		log.Warn("delete service gc safepoint failed",
+			zap.String("serviceID", m.gcServiceID),
+			zap.Error(err))
+		return errors.WrapError(errors.ErrUpdateServiceSafepointFailed, err)
+	}
+
+	// Clear the cached GC state right away so a later changefeed does not inherit
+	// stale "TiCDC is still blocking GC" state after the service safepoint is gone.
+	m.isTiCDCBlockGC.Store(false)
+	m.lastSafePointTs.Store(0)
+	minServiceGCSafePointGauge.Set(0)
+	cdcGCSafePointGauge.Set(0)
 	return nil
 }
 

--- a/pkg/txnutil/gc/gc_manager_mock.go
+++ b/pkg/txnutil/gc/gc_manager_mock.go
@@ -49,6 +49,20 @@ func (mr *MockManagerMockRecorder) CheckStaleCheckpointTs(keyspaceID, changefeed
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckStaleCheckpointTs", reflect.TypeOf((*MockManager)(nil).CheckStaleCheckpointTs), keyspaceID, changefeedID, checkpointTs)
 }
 
+// TryDeleteServiceGCSafepoint mocks base method.
+func (m *MockManager) TryDeleteServiceGCSafepoint(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TryDeleteServiceGCSafepoint", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TryDeleteServiceGCSafepoint indicates an expected call of TryDeleteServiceGCSafepoint.
+func (mr *MockManagerMockRecorder) TryDeleteServiceGCSafepoint(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryDeleteServiceGCSafepoint", reflect.TypeOf((*MockManager)(nil).TryDeleteServiceGCSafepoint), ctx)
+}
+
 // TryUpdateKeyspaceGCBarrier mocks base method.
 func (m *MockManager) TryUpdateKeyspaceGCBarrier(ctx context.Context, keyspaceID uint32, keyspaceName string, checkpointTs common.Ts) error {
 	m.ctrl.T.Helper()

--- a/pkg/txnutil/gc/gc_manager_test.go
+++ b/pkg/txnutil/gc/gc_manager_test.go
@@ -19,6 +19,7 @@ package gc
 import (
 	"context"
 	stderrors "errors"
+	"math"
 	"testing"
 	"time"
 
@@ -95,4 +96,34 @@ func TestTryUpdateServiceGCSafepointDoesNotReturnSnapshotLost(t *testing.T) {
 	errCode, ok := cerrors.RFCCode(err)
 	require.True(t, ok)
 	require.Equal(t, cerrors.ErrSnapshotLostByGC.RFCCode(), errCode)
+}
+
+func TestTryDeleteServiceGCSafepointClearsCachedState(t *testing.T) {
+	appcontext.SetService(appcontext.DefaultPDClock, pdutil.NewClock4Test())
+
+	updateCalls := 0
+	var deletedTTL int64
+	var deletedSafePoint uint64
+	pdClient := &MockPDClient{
+		UpdateServiceGCSafePointFunc: func(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+			updateCalls++
+			deletedTTL = ttl
+			deletedSafePoint = safePoint
+			return safePoint, nil
+		},
+	}
+
+	m := NewManager("test-service", pdClient).(*gcManager)
+	m.lastSafePointTs.Store(123)
+	m.isTiCDCBlockGC.Store(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	require.NoError(t, m.TryDeleteServiceGCSafepoint(ctx))
+	require.Equal(t, 1, updateCalls)
+	require.Equal(t, int64(0), deletedTTL)
+	require.Equal(t, uint64(math.MaxUint64), deletedSafePoint)
+	require.Zero(t, m.lastSafePointTs.Load())
+	require.False(t, m.isTiCDCBlockGC.Load())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4610

After the last changefeed is removed, TiCDC can still leave the cluster-level
service GC safepoint behind in PD. In the current code:

- the periodic reconcile path refreshes the safepoint to `currentTSO - 1`
  instead of deleting it when no changefeed remains;
- removing the last changefeed does not trigger an immediate cleanup, so the
  last coordinator can exit before the next GC tick and preserve the stale
  safepoint entry.

### What is changed and how it works?

- add `TryDeleteServiceGCSafepoint` to the GC manager and clear the cached GC
  state once the safepoint is deleted;
- change the classic-mode reconcile path to delete the cluster-level service GC
  safepoint when there is no remaining changefeed;
- make `RemoveChangefeed` issue a best-effort immediate delete after removing
  the last changefeed, which closes the shutdown window before the next GC tick;
- add regression tests for the no-changefeed reconcile path, the immediate
  delete after removing the last changefeed, and the GC manager cache reset.

### Check List

#### Tests

- Unit test

Relevant verification:

- `make fmt`
- `go test ./pkg/txnutil/gc`
- `go test ./coordinator -run 'TestCreateChangefeedDoesNotUpdateGCSafepoint|TestUpdateGCSafepointCallsGCManagerUpdate|TestUpdateGCSafepointDeletesServiceSafepointWhenNoChangefeed|TestRemoveLastChangefeedDeletesServiceSafepointImmediately' -count=1`
- `go test ./coordinator/changefeed -run TestCalculateGCSafepoint -count=1`

Note:

- `go test ./coordinator -count=1` fails on this branch and on a clean
  `upstream/master` baseline because an existing coordinator test reuses fixed
  port `127.0.0.1:28300`.

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only affects the zero-changefeed cleanup path and reuses the
existing safepoint delete API.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix a bug where TiCDC could leave a stale cluster-level service GC safepoint in PD after the last changefeed was removed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of cluster-level garbage-collection safepoints when the last changefeed is removed, reducing stale safepoints and avoiding blocking errors in classic kernel deployments.
  * Ensured GC state resets correctly after safepoint deletion to prevent lingering GC blocks.

* **Tests**
  * Added tests covering safepoint deletion, concurrent changefeed removal/creation, and related edge cases to increase reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->