### PR TITLE
api: remove `pdClient.Close()` for DeleteServiceGcSafePoint

### DIFF
--- a/api/v2/unsafe.go
+++ b/api/v2/unsafe.go
@@ -81,7 +81,6 @@ func (h *OpenAPIV2) DeleteServiceGcSafePoint(c *gin.Context) {
 		return
 	}
 	pdClient := h.server.GetPdClient()
-	defer pdClient.Close()
 
 	keyspaceMeta := middleware.GetKeyspaceFromContext(c)
 


### PR DESCRIPTION
Remove defer statement for pdClient.Close() to allow manual closing.

<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4638

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource management in service garbage collection safe point operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->