### PR TITLE
dynstream: fix removed-path memory accounting after RemovePath

### DIFF
--- a/utils/dynstream/event_queue.go
+++ b/utils/dynstream/event_queue.go
@@ -122,8 +122,16 @@ func (q *eventQueue[A, P, T, D, H]) popEvents(buf []T) ([]T, *pathInfo[A, P, T, 
 		if signal.eventCount == 0 {
 			log.Panic("signal event count is zero")
 		}
-		if path.blocking.Load() || path.removed.Load() {
-			// The path is blocking or removed, we should ignore the signal completely.
+		if path.removed.Load() {
+			// A removed path can still receive stale in-flight signals/events.
+			// Clear the path queue and reconcile memory before dropping the signal.
+			q.releasePath(path)
+			q.totalPendingLength.Add(-int64(signal.eventCount))
+			q.signalQueue.PopFront()
+			continue
+		}
+		if path.blocking.Load() {
+			// The path is blocking, we should ignore the signal completely.
 			// Since when it is waked, a signal event will be added to the queue.
 			q.totalPendingLength.Add(-int64(signal.eventCount))
 			q.signalQueue.PopFront()

--- a/utils/dynstream/memory_control.go
+++ b/utils/dynstream/memory_control.go
@@ -98,6 +98,11 @@ func (as *areaMemStat[A, P, T, D, H]) appendEvent(
 	event eventWrap[A, P, T, D, H],
 	handler H,
 ) bool {
+	// The removed flag can flip between handleLoop's removed check and appendEvent call.
+	// Guard here to avoid accounting events for a removed path.
+	if path.removed.Load() {
+		return false
+	}
 	defer as.updateAreaPauseState(path)
 	as.lastAppendEventTime.Store(time.Now())
 
@@ -335,11 +340,13 @@ func (m *memControl[A, P, T, D, H]) addPathToArea(path *pathInfo[A, P, T, D, H],
 // This method is called after the path is removed.
 func (m *memControl[A, P, T, D, H]) removePathFromArea(path *pathInfo[A, P, T, D, H]) {
 	area := path.areaMemStat
-	area.decPendingSize(path, int64(path.pendingSize.Load()))
+	pendingSize := path.pendingSize.Swap(0)
+	area.decPendingSize(path, pendingSize)
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	area.pathMap.Delete(path.path)
 	area.pathCount.Add(-1)
 	if area.pathCount.Load() == 0 {
 		delete(m.areaStatMap, area.area)

--- a/utils/dynstream/memory_control_test.go
+++ b/utils/dynstream/memory_control_test.go
@@ -57,6 +57,54 @@ func TestMemControlAddRemovePath(t *testing.T) {
 	require.Empty(t, mc.areaStatMap)
 }
 
+func TestRemovePathLateAppendDoesNotPolluteAreaPendingSize(t *testing.T) {
+	mc, path := setupTestComponents()
+	settings := AreaSettings{
+		maxPendingSize:   1000,
+		feedbackInterval: time.Second,
+		algorithm:        MemoryControlForPuller,
+	}
+	feedbackChan := make(chan Feedback[int, string, any], 10)
+	mc.addPathToArea(path, settings, feedbackChan)
+
+	handler := &mockHandler{}
+	eq := newEventQueue(Option{BatchCount: 4}, handler)
+	eq.initPath(path)
+
+	appendEvent := func(id int, size int) {
+		eq.appendEvent(eventWrap[int, string, *mockEvent, any, *mockHandler]{
+			pathInfo:  path,
+			event:     &mockEvent{id: id, path: path.path},
+			eventType: DefaultEventType,
+			eventSize: size,
+		})
+	}
+
+	// Append one event before path removal.
+	appendEvent(1, 10)
+	require.Equal(t, int64(10), path.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, int64(10), path.pendingSize.Load())
+
+	// Remove path and deduct the current pending size immediately.
+	path.removed.Store(true)
+	mc.removePathFromArea(path)
+	require.Equal(t, int64(0), path.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, int64(0), path.pendingSize.Load())
+
+	// Simulate a stale in-flight append that races with RemovePath.
+	appendEvent(2, 7)
+
+	buf := make([]*mockEvent, 0)
+	events, _, _ := eq.popEvents(buf)
+	require.Len(t, events, 0)
+
+	// Removed-path events must not leave stale memory accounting behind.
+	require.Equal(t, int64(0), path.areaMemStat.totalPendingSize.Load())
+	require.Equal(t, int64(0), path.pendingSize.Load())
+	require.Equal(t, 0, path.pendingQueue.Length())
+	require.Equal(t, int64(0), eq.totalPendingLength.Load())
+}
+
 func TestAreaMemStatAppendEvent(t *testing.T) {
 	mc, path1 := setupTestComponents()
 	settings := AreaSettings{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4644 

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix RemovePath memory accounting drift.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of removed paths in event processing to prevent stale operations from polluting memory accounting.
  * Fixed race condition where in-flight operations targeting removed paths could incorrectly increment memory counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->