### PR TITLE
version: remove hard-coded max version guard for new architecture

### DIFF
--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -41,14 +41,14 @@ var (
 	minPDVersion = semver.New("7.5.0-alpha")
 	// maxPDVersion is the version of the maximum compatible PD.
 	// Compatible versions are in [minPDVersion, maxPDVersion)
-	maxPDVersion = semver.New("15.0.0")
+	maxPDVersion = semver.New("9999.0.0")
 
 	// MinTiKVVersion is the version of the minimal compatible TiKV.
 	// The min version should be 7.5 for new arch.
 	MinTiKVVersion = semver.New("7.5.0-alpha")
 	// maxTiKVVersion is the version of the maximum compatible TiKV.
 	// Compatible versions are in [MinTiKVVersion, maxTiKVVersion)
-	maxTiKVVersion = semver.New("15.0.0")
+	maxTiKVVersion = semver.New("9999.0.0")
 
 	// New Arch Starts From 9.0.0,
 	// we use the minimal release version as default.
@@ -58,7 +58,7 @@ var (
 	MinTiCDCVersion = semver.New("7.5.0-alpha")
 	// MaxTiCDCVersion is the version of the maximum allowed TiCDC version.
 	// for version `x.y.z`, max allowed `x+2.0.0`
-	MaxTiCDCVersion = semver.New("15.0.0-alpha")
+	MaxTiCDCVersion = semver.New("9999.0.0-alpha")
 )
 
 var versionHash = regexp.MustCompile("-[0-9]+-g[0-9a-f]{7,}(-dev)?")

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -56,8 +56,8 @@ var (
 
 	// MinTiCDCVersion is the version of the minimal allowed TiCDC version.
 	MinTiCDCVersion = semver.New("7.5.0-alpha")
-	// MaxTiCDCVersion is the version of the maximum allowed TiCDC version.
-	// for version `x.y.z`, max allowed `x+2.0.0`
+	// MaxTiCDCVersion is the sentinel upper bound for TiCDC compatibility checks.
+	// 9999 keeps future TiCDC versions accepted while preserving an explicit upper bound.
 	MaxTiCDCVersion = semver.New("9999.0.0-alpha")
 )
 

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -413,16 +413,27 @@ func TestCheckTiCDCVersion(t *testing.T) {
 	err = CheckTiCDCVersion(versions)
 	require.NoError(t, err)
 
+	// Versions that used to be above the hard-coded maximum are accepted now; the
+	// 9999 sentinel keeps this check from blocking future TiCDC releases.
 	versions = map[string]struct{}{
 		"v7.5.0":        {},
 		"v15.0.0-alpha": {},
 	}
 	err = CheckTiCDCVersion(versions)
-	require.Regexp(t, "TiCDC .* not supported, only support version less than.*", err)
+	require.NoError(t, err)
 
 	versions = map[string]struct{}{
 		"v7.5.0":  {},
 		"v15.0.0": {},
+	}
+	err = CheckTiCDCVersion(versions)
+	require.NoError(t, err)
+
+	// The configured sentinel upper bound itself is still rejected, so the range
+	// check remains active even though practical future versions are allowed.
+	versions = map[string]struct{}{
+		"v7.5.0":                       {},
+		"v" + MaxTiCDCVersion.String(): {},
 	}
 	err = CheckTiCDCVersion(versions)
 	require.Regexp(t, "TiCDC .* not supported, only support version less than.*", err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4681

The new-architecture repo still hard-codes the max compatible versions for PD, TiKV and TiCDC. This can reject future upstream versions even when there is no known incompatibility.

### What is changed and how it works?

Replace the hard-coded max compatible versions in `pkg/version/check.go` with large sentinel values:

- `9999.0.0` for PD and TiKV
- `9999.0.0-alpha` for TiCDC

This keeps the existing minimum-version guard and avoids blocking newer versions only because of the artificial upper bound.

### Check List

#### Tests

- Manual test

#### Questions

##### Will it cause performance regression or break compatibility?

No. It only removes the artificial upper bound from the version check. The minimum compatible version checks stay unchanged.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with much newer PD, TiKV, and TiCDC cluster component versions by widening the allowed upper bounds, while maintaining existing minimum version requirements. This reduces erroneous version-rejection for modern deployments and smooths upgrades to newer component releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->