### PR TITLE
chore: replace deprecated PingCAP download domains

### DIFF
--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -20,7 +20,7 @@ If you need to specify a version, os or arch, you can use, for example: `make pr
    * [jq](https://stedolan.github.io/jq/)
    * [minio](https://github.com/minio/minio)
 
-   > You could download these binaries by yourself from [tidb-community-toolkit](https://download.pingcap.org/tidb-community-toolkit-v6.0.0-linux-amd64.tar.gz) and [tidb-community-server](https://download.pingcap.org/tidb-community-server-v6.0.0-linux-amd64.tar.gz).
+   > You could download these binaries by yourself from [tidb-community-toolkit](https://download.pingcap.com/tidb-community-toolkit-v6.0.0-linux-amd64.tar.gz) and [tidb-community-server](https://download.pingcap.com/tidb-community-server-v6.0.0-linux-amd64.tar.gz).
 
 2. These are programs/packages need be installed manually.
    * [mysql](https://dev.mysql.com/doc/mysql-installation-excerpt/5.7/en/) (the MySQL cli client,

--- a/tests/scripts/download-integration-test-binaries.sh
+++ b/tests/scripts/download-integration-test-binaries.sh
@@ -73,10 +73,10 @@ download_community_binaries() {
 	local dist="${VERSION}-${OS}-${ARCH}"
 	local tidb_file_name="tidb-community-server-$dist"
 	local tidb_tar_name="${tidb_file_name}.tar.gz"
-	local tidb_url="https://download.pingcap.org/$tidb_tar_name"
+	local tidb_url="https://download.pingcap.com/$tidb_tar_name"
 	local toolkit_file_name="tidb-community-toolkit-$dist"
 	local toolkit_tar_name="${toolkit_file_name}.tar.gz"
-	local toolkit_url="https://download.pingcap.org/$toolkit_tar_name"
+	local toolkit_url="https://download.pingcap.com/$toolkit_tar_name"
 
 	log_green "Downloading community binaries..."
 	download_file "$tidb_url" "$tidb_tar_name" "${TMP_DIR}/$tidb_tar_name"


### PR DESCRIPTION
## Summary
- replace deprecated `download.pingcap.org` references with `download.pingcap.com`
- replace deprecated `charts.pingcap.org` references with `charts.pingcap.com` where present
- keep the existing paths and protocols unchanged

## Validation
- `git diff --check`
- verified no remaining `download.pingcap.org` / `charts.pingcap.org` references in the patched branch