### PR TITLE
maintainer: keep test helper message center alive

### DIFF
--- a/maintainer/barrier_event_test.go
+++ b/maintainer/barrier_event_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestScheduleEvent(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -82,7 +82,7 @@ func TestScheduleEvent(t *testing.T) {
 }
 
 func TestResendAction(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
@@ -189,7 +189,7 @@ func TestResendAction(t *testing.T) {
 }
 
 func TestSendPassActionTypeDBIncludesWriterNode(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -236,7 +236,7 @@ func TestSendPassActionTypeDBIncludesWriterNode(t *testing.T) {
 }
 
 func TestUpdateSchemaID(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,

--- a/maintainer/barrier_test.go
+++ b/maintainer/barrier_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestOneBlockEvent(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -166,7 +166,7 @@ func TestOneBlockEvent(t *testing.T) {
 }
 
 func TestNormalBlock(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -335,7 +335,7 @@ func TestNormalBlock(t *testing.T) {
 }
 
 func TestNormalBlockWithTableTrigger(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -476,7 +476,7 @@ func TestNormalBlockWithTableTrigger(t *testing.T) {
 }
 
 func TestSchemaBlock(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nm := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nmap := nm.GetAliveNodes()
 	for key := range nmap {
@@ -652,7 +652,7 @@ func TestSchemaBlock(t *testing.T) {
 }
 
 func TestSyncPointBlock(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nm := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nmap := nm.GetAliveNodes()
 	for key := range nmap {
@@ -827,7 +827,7 @@ func TestSyncPointBlock(t *testing.T) {
 }
 
 func TestNonBlocked(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -881,7 +881,7 @@ func TestNonBlocked(t *testing.T) {
 }
 
 func TestUpdateCheckpointTs(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -936,7 +936,7 @@ func TestUpdateCheckpointTs(t *testing.T) {
 
 // TODO:Add more cases here
 func TestHandleBlockBootstrapResponse(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -1097,7 +1097,7 @@ func TestHandleBlockBootstrapResponse(t *testing.T) {
 }
 
 func TestSyncPointBlockPerf(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,
@@ -1176,7 +1176,7 @@ func TestSyncPointBlockPerf(t *testing.T) {
 // 3. The event selection logic works properly with the reallocated dispatchers
 // 4. The barrier maintains consistency when dispatcher IDs change but the same table spans are covered
 func TestBarrierEventWithDispatcherReallocation(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
@@ -1382,7 +1382,7 @@ func TestBarrierEventWithDispatcherReallocation(t *testing.T) {
 // 2. When dispatcher A enters scheduling state and table trigger event dispatcher reports DDL, DDL should not execute
 // 3. When dispatcher A finishes scheduling and reports DDL again, DDL should execute
 func TestBarrierEventWithDispatcherScheduling(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	// Setup table trigger event dispatcher (DDL dispatcher)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
@@ -1514,7 +1514,7 @@ func TestBarrierEventWithDispatcherScheduling(t *testing.T) {
 }
 
 func TestDeferAllDBBlockEventFromDDLDispatcherWhilePendingSchedule(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nm := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nmap := nm.GetAliveNodes()
 	for key := range nmap {

--- a/maintainer/maintainer_controller_test.go
+++ b/maintainer/maintainer_controller_test.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func TestSchedule(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -97,7 +97,7 @@ func TestSchedule(t *testing.T) {
 // In this case, the num of split tables is more than the num of nodes,
 // and we can select appropriate split spans to move
 func TestBalanceGroupsNewNodeAdd_SplitsTableMoreThanNodeNum(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 
@@ -228,7 +228,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableMoreThanNodeNum(t *testing.T) {
 // In this case, the num of split tables is less than the num of nodes,
 // and we should choose span to split.
 func TestBalanceGroupsNewNodeAdd_SplitsTableLessThanNodeNum(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -349,7 +349,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableLessThanNodeNum(t *testing.T) {
 
 // this test is to test the scenario that the split balance scheduler when a node is removed.
 func TestSplitBalanceGroupsWithNodeRemove(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -449,7 +449,7 @@ func TestSplitBalanceGroupsWithNodeRemove(t *testing.T) {
 }
 
 func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -1063,7 +1063,7 @@ func TestSplitTableBalanceWhenTrafficUnbalanced(t *testing.T) {
 }
 
 func TestBalance(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
@@ -1156,7 +1156,7 @@ func TestBalance(t *testing.T) {
 }
 
 func TestDefaultSpanIntoSplit(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -1312,7 +1312,7 @@ func TestDefaultSpanIntoSplit(t *testing.T) {
 }
 
 func TestStoppedWhenMoving(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
@@ -1363,7 +1363,7 @@ func TestStoppedWhenMoving(t *testing.T) {
 }
 
 func TestFinishBootstrap(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
@@ -1467,7 +1467,7 @@ func TestFinishBootstrapSkipsStaleCreateOperatorForDroppedTable(t *testing.T) {
 		// Each subtest restores bootstrap state from a dropped-table snapshot and checks that
 		// no maintainer task/operator is recreated for the stale create request.
 		t.Run(tc.name, func(t *testing.T) {
-			testutil.SetUpTestServices()
+			testutil.SetUpTestServices(t)
 			nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 			nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 
@@ -1538,7 +1538,7 @@ func TestFinishBootstrapSkipsStaleCreateOperatorForDroppedTable(t *testing.T) {
 }
 
 func TestSplitTableWhenBootstrapFinished(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}
@@ -1712,7 +1712,7 @@ func (m *mockThreadPool) SubmitFunc(_ threadpool.FuncTask, _ time.Time) *threadp
 }
 
 func TestLargeTableInitialization(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
 	nodeManager.GetAliveNodes()["node1"] = &node.Info{ID: "node1"}
 	nodeManager.GetAliveNodes()["node2"] = &node.Info{ID: "node2"}

--- a/maintainer/maintainer_test.go
+++ b/maintainer/maintainer_test.go
@@ -362,7 +362,7 @@ func TestMaintainerSchedule(t *testing.T) {
 }
 
 func TestMaintainer_GetMaintainerStatusUsesCommittedCheckpoint(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()

--- a/maintainer/replica/default_span_split_checker_test.go
+++ b/maintainer/replica/default_span_split_checker_test.go
@@ -73,7 +73,7 @@ func TestDefaultSpanSplitChecker_AddReplica(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_RemoveReplica(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -105,7 +105,7 @@ func TestDefaultSpanSplitChecker_UpdateStatus_TrafficCheck(t *testing.T) {
 		RegionCountRefreshInterval: util.AddressOf(time.Minute),
 	}
 
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	checker := newTestDefaultChecker(t, cfID, schedulerCfg)
 
@@ -154,7 +154,7 @@ func TestDefaultSpanSplitChecker_UpdateStatus_TrafficCheck(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheck(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -200,7 +200,7 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheck(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheckError(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -235,7 +235,7 @@ func TestDefaultSpanSplitChecker_UpdateStatus_RegionCheckError(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_UpdateStatus_NonWorkingStatus(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -265,7 +265,7 @@ func TestDefaultSpanSplitChecker_UpdateStatus_NonWorkingStatus(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_CheckRegionSplit(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -314,7 +314,7 @@ func TestDefaultSpanSplitChecker_CheckRegionSplit(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_Check_BatchLimit(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -350,7 +350,7 @@ func TestDefaultSpanSplitChecker_Check_BatchLimit(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_Check_EmptyResults(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -384,7 +384,7 @@ func TestDefaultSpanSplitChecker_Check_EmptyResults(t *testing.T) {
 }
 
 func TestDefaultSpanSplitChecker_Stat(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	schedulerCfg := &config.ChangefeedSchedulerConfig{

--- a/maintainer/replica/region_count_refresher_test.go
+++ b/maintainer/replica/region_count_refresher_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestNewRegionCountRefresher(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	changefeedID := common.NewChangefeedID4Test("keyspace", "test")
 
 	refresher := NewRegionCountRefresher(changefeedID, 0)

--- a/maintainer/replica/split_span_checker_test.go
+++ b/maintainer/replica/split_span_checker_test.go
@@ -115,7 +115,7 @@ func TestSplitTableSpanIntoMultiple_Properties(t *testing.T) {
 }
 
 func TestSplitSpanChecker_AddReplica(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -151,7 +151,7 @@ func TestSplitSpanChecker_AddReplica(t *testing.T) {
 }
 
 func TestSplitSpanChecker_RemoveReplica(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -196,7 +196,7 @@ func TestSplitSpanChecker_RemoveReplica(t *testing.T) {
 }
 
 func TestSplitSpanChecker_UpdateStatus_Traffic(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -273,7 +273,7 @@ func TestSplitSpanChecker_UpdateStatus_Traffic(t *testing.T) {
 }
 
 func TestSplitSpanChecker_UpdateStatus_Region(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -327,7 +327,7 @@ func TestSplitSpanChecker_UpdateStatus_Region(t *testing.T) {
 }
 
 func TestSplitSpanChecker_UpdateStatus_NonWorking(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -369,7 +369,7 @@ func TestSplitSpanChecker_UpdateStatus_NonWorking(t *testing.T) {
 }
 
 func TestSplitSpanChecker_ChooseSplitSpans_Traffic(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -425,7 +425,7 @@ func TestSplitSpanChecker_ChooseSplitSpans_Traffic(t *testing.T) {
 }
 
 func TestSplitSpanChecker_ChooseSplitSpans_Region(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -477,7 +477,7 @@ func TestSplitSpanChecker_ChooseSplitSpans_Region(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckMergeWhole_SingleNode(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -523,7 +523,7 @@ func TestSplitSpanChecker_CheckMergeWhole_SingleNode(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckMergeWhole_MultiNode(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -570,7 +570,7 @@ func TestSplitSpanChecker_CheckMergeWhole_MultiNode(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckMergeWhole_ThresholdNotMet(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -614,7 +614,7 @@ func TestSplitSpanChecker_CheckMergeWhole_ThresholdNotMet(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckBalanceTraffic_Balance(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -680,7 +680,7 @@ func TestSplitSpanChecker_CheckBalanceTraffic_Balance(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckBalanceTraffic_NoBalanceNeeded(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -727,7 +727,7 @@ func TestSplitSpanChecker_CheckBalanceTraffic_NoBalanceNeeded(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckBalanceTraffic_SplitIfNoMove(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -782,7 +782,7 @@ func TestSplitSpanChecker_CheckBalanceTraffic_SplitIfNoMove(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckBalanceTraffic_SingleNode(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -827,7 +827,7 @@ func TestSplitSpanChecker_CheckBalanceTraffic_SingleNode(t *testing.T) {
 }
 
 func TestSplitSpanChecker_CheckBalanceTraffic_TrafficFluctuation(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -900,7 +900,7 @@ func TestSplitSpanChecker_CheckBalanceTraffic_TrafficFluctuation(t *testing.T) {
 }
 
 func TestSplitSpanChecker_ChooseMergedSpans_LargeLag(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -938,7 +938,7 @@ func TestSplitSpanChecker_ChooseMergedSpans_LargeLag(t *testing.T) {
 }
 
 func TestSplitSpanChecker_ChooseMergedSpans_Continuous(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -995,7 +995,7 @@ func TestSplitSpanChecker_ChooseMergedSpans_Continuous(t *testing.T) {
 }
 
 func TestSplitSpanChecker_ChooseMoveSpans_SimpleMove(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -1064,7 +1064,7 @@ func TestSplitSpanChecker_ChooseMoveSpans_SimpleMove(t *testing.T) {
 }
 
 func TestSplitSpanChecker_ChooseMoveSpans_ExchangeMove(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -1126,7 +1126,7 @@ func TestSplitSpanChecker_ChooseMoveSpans_ExchangeMove(t *testing.T) {
 }
 
 func TestSplitSpanChecker_Check_FullFlow(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -1202,7 +1202,7 @@ func TestSplitSpanChecker_Check_FullFlow(t *testing.T) {
 }
 
 func TestSplitSpanChecker_Check_FullFlow_WriteThresholdZero(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -1278,7 +1278,7 @@ func TestSplitSpanChecker_Check_FullFlow_WriteThresholdZero(t *testing.T) {
 }
 
 func TestSplitSpanChecker_Check_FullFlow_RegionThresholdZero(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	schedulerCfg := &config.ChangefeedSchedulerConfig{
@@ -1354,7 +1354,7 @@ func TestSplitSpanChecker_Check_FullFlow_RegionThresholdZero(t *testing.T) {
 }
 
 func TestSplitSpanChecker_Check_PerformanceWithManySpans(t *testing.T) {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 
 	spanCount := 10000

--- a/maintainer/span/span_controller_test.go
+++ b/maintainer/span/span_controller_test.go
@@ -424,7 +424,7 @@ func TestMarkSpanAbsent(t *testing.T) {
 }
 
 func newControllerWithCheckerForTest(t *testing.T) *Controller {
-	testutil.SetUpTestServices()
+	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	tableTriggerEventDispatcherID := common.NewDispatcherID()
 	ddlSpan := replica.NewWorkingSpanReplication(cfID, tableTriggerEventDispatcherID,

--- a/maintainer/span/span_controller_test.go
+++ b/maintainer/span/span_controller_test.go
@@ -301,8 +301,6 @@ func TestController_Statistics(t *testing.T) {
 
 // TestBasicFunction tests the basic functionality of the controller
 func TestBasicFunction(t *testing.T) {
-	t.Parallel()
-
 	controller := newControllerWithCheckerForTest(t)
 	absent := replica.NewSpanReplication(controller.changefeedID, common.NewDispatcherID(), 1, testutil.GetTableSpanByID(4), 1, common.DefaultMode, false)
 	controller.AddAbsentReplicaSet(absent)
@@ -377,8 +375,6 @@ func TestBasicFunction(t *testing.T) {
 
 // TestReplaceReplicaSet tests the ReplaceReplicaSet functionality
 func TestReplaceReplicaSet(t *testing.T) {
-	t.Parallel()
-
 	controller := newControllerWithCheckerForTest(t)
 	// replicating and scheduling will be returned
 	replicaSpanID := common.NewDispatcherID()
@@ -405,8 +401,6 @@ func TestReplaceReplicaSet(t *testing.T) {
 
 // TestMarkSpanAbsent tests the MarkSpanAbsent functionality
 func TestMarkSpanAbsent(t *testing.T) {
-	t.Parallel()
-
 	controller := newControllerWithCheckerForTest(t)
 	// replicating and scheduling will be returned
 	replicaSpanID := common.NewDispatcherID()

--- a/maintainer/testutil/test_util.go
+++ b/maintainer/testutil/test_util.go
@@ -44,7 +44,10 @@ func GetTableSpanByID(id common.TableID) *heartbeatpb.TableSpan {
 // SetUpTestServices installs the shared test services and keeps them alive for the
 // whole test. The message center must stay open until cleanup because callers store
 // it in app context and use it after this helper returns.
-func SetUpTestServices(t testing.TB) {
+//
+// The returned node ID lets tests exercise the live local message center without
+// reaching into its internal state.
+func SetUpTestServices(t testing.TB) node.ID {
 	t.Helper()
 
 	n := node.NewInfo("", "")
@@ -64,6 +67,8 @@ func SetUpTestServices(t testing.TB) {
 
 	pdAPIClient := NewMockPDAPIClient()
 	appcontext.SetService(appcontext.PDAPIClient, pdAPIClient)
+
+	return n.ID
 }
 
 type MockCache struct {

--- a/maintainer/testutil/test_util.go
+++ b/maintainer/testutil/test_util.go
@@ -15,6 +15,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"testing"
 	"unsafe"
 
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
@@ -40,15 +41,19 @@ func GetTableSpanByID(id common.TableID) *heartbeatpb.TableSpan {
 	}
 }
 
-// InitializeTestServices sets up the node manager and message center for testing
-func SetUpTestServices() {
+// SetUpTestServices installs the shared test services and keeps them alive for the
+// whole test. The message center must stay open until cleanup because callers store
+// it in app context and use it after this helper returns.
+func SetUpTestServices(t testing.TB) {
+	t.Helper()
+
 	n := node.NewInfo("", "")
 	mockPDClock := pdutil.NewClock4Test()
 	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
 
 	mc := messaging.NewMessageCenter(context.Background(), n.ID, config.NewDefaultMessageCenterConfig(n.AdvertiseAddr), nil)
 	mc.Run(context.Background())
-	defer mc.Close()
+	t.Cleanup(mc.Close)
 	appcontext.SetService(appcontext.MessageCenter, mc)
 
 	nodeManager := watcher.NewNodeManager(nil, nil)

--- a/maintainer/testutil/test_util_test.go
+++ b/maintainer/testutil/test_util_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	appcontext "github.com/pingcap/ticdc/pkg/common/context"
+	"github.com/pingcap/ticdc/pkg/messaging"
+	"github.com/stretchr/testify/require"
+)
+
+func getMessageCenterContext(t *testing.T, mc messaging.MessageCenter) context.Context {
+	t.Helper()
+
+	value := reflect.ValueOf(mc)
+	require.Equal(t, reflect.Ptr, value.Kind())
+
+	ctxField := value.Elem().FieldByName("ctx")
+	require.True(t, ctxField.IsValid())
+	require.True(t, ctxField.CanAddr())
+
+	return *(*context.Context)(unsafe.Pointer(ctxField.UnsafeAddr()))
+}
+
+func TestSetUpTestServicesKeepsMessageCenterAlive(t *testing.T) {
+	SetUpTestServices(t)
+
+	mc := appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter)
+	ctx := getMessageCenterContext(t, mc)
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("SetUpTestServices stored a closed message center in app context")
+	default:
+	}
+}

--- a/maintainer/testutil/test_util_test.go
+++ b/maintainer/testutil/test_util_test.go
@@ -31,10 +31,9 @@ func TestSetUpTestServicesKeepsMessageCenterAlive(t *testing.T) {
 	require.NotNil(t, mc)
 
 	const topic = "message-center-lifecycle-regression"
-	handlerCalled := make(chan struct{}, 1)
+	handlerCalled := make(chan string, 1)
 	mc.RegisterHandler(topic, func(_ context.Context, msg *messaging.TargetMessage) error {
-		require.Equal(t, localNodeID, msg.To)
-		handlerCalled <- struct{}{}
+		handlerCalled <- string(msg.To)
 		return nil
 	})
 	defer mc.DeRegisterHandler(topic)
@@ -43,7 +42,8 @@ func TestSetUpTestServicesKeepsMessageCenterAlive(t *testing.T) {
 	require.NoError(t, err)
 
 	select {
-	case <-handlerCalled:
+	case receivedTarget := <-handlerCalled:
+		require.Equal(t, string(localNodeID), receivedTarget)
 	case <-time.After(time.Second):
 		t.Fatalf("SetUpTestServices stored a closed message center in app context")
 	}

--- a/maintainer/testutil/test_util_test.go
+++ b/maintainer/testutil/test_util_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The helper stores a concrete messageCenter behind the interface, and the bug is
+// specifically about whether its run context has already been canceled on return.
 func getMessageCenterContext(t *testing.T, mc messaging.MessageCenter) context.Context {
 	t.Helper()
 

--- a/maintainer/testutil/test_util_test.go
+++ b/maintainer/testutil/test_util_test.go
@@ -15,39 +15,36 @@ package testutil
 
 import (
 	"context"
-	"reflect"
 	"testing"
-	"unsafe"
+	"time"
 
+	"github.com/pingcap/ticdc/heartbeatpb"
 	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/stretchr/testify/require"
 )
 
-// The helper stores a concrete messageCenter behind the interface, and the bug is
-// specifically about whether its run context has already been canceled on return.
-func getMessageCenterContext(t *testing.T, mc messaging.MessageCenter) context.Context {
-	t.Helper()
-
-	value := reflect.ValueOf(mc)
-	require.Equal(t, reflect.Ptr, value.Kind())
-
-	ctxField := value.Elem().FieldByName("ctx")
-	require.True(t, ctxField.IsValid())
-	require.True(t, ctxField.CanAddr())
-
-	return *(*context.Context)(unsafe.Pointer(ctxField.UnsafeAddr()))
-}
-
 func TestSetUpTestServicesKeepsMessageCenterAlive(t *testing.T) {
-	SetUpTestServices(t)
+	localNodeID := SetUpTestServices(t)
 
 	mc := appcontext.GetService[messaging.MessageCenter](appcontext.MessageCenter)
-	ctx := getMessageCenterContext(t, mc)
+	require.NotNil(t, mc)
+
+	const topic = "message-center-lifecycle-regression"
+	handlerCalled := make(chan struct{}, 1)
+	mc.RegisterHandler(topic, func(_ context.Context, msg *messaging.TargetMessage) error {
+		require.Equal(t, localNodeID, msg.To)
+		handlerCalled <- struct{}{}
+		return nil
+	})
+	defer mc.DeRegisterHandler(topic)
+
+	err := mc.SendCommand(messaging.NewSingleTargetMessage(localNodeID, topic, &heartbeatpb.RemoveMaintainerRequest{}))
+	require.NoError(t, err)
 
 	select {
-	case <-ctx.Done():
+	case <-handlerCalled:
+	case <-time.After(time.Second):
 		t.Fatalf("SetUpTestServices stored a closed message center in app context")
-	default:
 	}
 }

--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -37,6 +37,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const testTableTriggerKeyspaceID uint32 = 1
+
 func newEventBrokerForTest() (*eventBroker, *mockEventStore, *mockSchemaStore, chan *messaging.TargetMessage) {
 	mockPDClock := pdutil.NewClock4Test()
 	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
@@ -1384,7 +1386,8 @@ func TestProcessTableTriggerDispatcherRespectsSyncPointBoundary(t *testing.T) {
 
 	info := newMockDispatcherInfo(t, ts5, common.NewDispatcherID(), 0, eventpb.ActionType_ACTION_TYPE_REGISTER)
 	info.epoch = 1
-	info.span = common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
+	// Next Gen rejects DefaultKeyspaceID, so table-trigger tests need a real keyspace ID.
+	info.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
 	info.enableSyncPoint = true
 	info.syncPointInterval = 10 * time.Second
 	info.nextSyncPoint = ts10
@@ -1428,7 +1431,7 @@ func TestProcessTableTriggerDispatcherNudgesCommitStageWhenNoForwardRange(t *tes
 
 	info := newMockDispatcherInfo(t, ts10, common.NewDispatcherID(), 0, eventpb.ActionType_ACTION_TYPE_REGISTER)
 	info.epoch = 1
-	info.span = common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
+	info.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
 	info.enableSyncPoint = true
 	info.syncPointInterval = 10 * time.Second
 	info.nextSyncPoint = ts10
@@ -1474,7 +1477,7 @@ func TestProcessTableTriggerDispatcherSendsSignalResolvedWhenNoForwardRangeAndNo
 
 	info := newMockDispatcherInfo(t, ts10, common.NewDispatcherID(), 0, eventpb.ActionType_ACTION_TYPE_REGISTER)
 	info.epoch = 1
-	info.span = common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
+	info.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
 	info.enableSyncPoint = true
 	info.syncPointInterval = 10 * time.Second
 	info.nextSyncPoint = ts20
@@ -1598,12 +1601,12 @@ func TestTickTableTriggerDispatchersSendsDDLEventAndResolved(t *testing.T) {
 	defer broker.close()
 
 	info := newMockDispatcherInfo(t, 300, common.NewDispatcherID(), 0, eventpb.ActionType_ACTION_TYPE_REGISTER)
-	info.span = common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
+	info.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
 	err := broker.addDispatcher(info)
 	require.NoError(t, err)
 
 	resetInfo := newMockDispatcherInfo(t, 300, info.GetID(), 0, eventpb.ActionType_ACTION_TYPE_RESET)
-	resetInfo.span = common.KeyspaceDDLSpan(common.DefaultKeyspaceID)
+	resetInfo.span = common.KeyspaceDDLSpan(testTableTriggerKeyspaceID)
 	resetInfo.epoch = 1
 	err = broker.resetDispatcher(resetInfo)
 	require.NoError(t, err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4647

`maintainer/testutil.SetUpTestServices()` built a real `messaging.MessageCenter`, started it,
stored it in app context, and then immediately closed it via `defer mc.Close()`.

That meant tests using the helper received a message center whose run context had already been
canceled by the time `SetUpTestServices()` returned.

### What is changed and how it works?

- Change `SetUpTestServices` to accept `testing.TB` and register `mc.Close()` with `t.Cleanup`
  instead of closing the message center when the helper returns.
- Add a focused regression test that proves the helper returns with a live message center in app context.
- Update maintainer tests that use the helper to pass `t`.

### Additional context

The root cause was the helper lifetime boundary, not the message center implementation itself.
`defer mc.Close()` executed as soon as the helper returned, which canceled the message center's
run context and shut down its dispatch goroutines before any caller could use it.

The fix keeps the real message center alive for the whole test and still closes it deterministically
at test cleanup. This is the smallest direct fix because it preserves the existing helper behavior
and only moves cleanup to the correct lifetime boundary.

### Check List

#### Tests

- Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. This only changes maintainer test helper lifetime management.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test harness updated: setup now accepts the current test context to ensure per-test initialization is correctly scoped.
  * Added a test verifying the messaging subsystem remains available for the duration of a test.
  * Removed parallelization from select tests so they run sequentially for more reliable behavior.
  * Adjusted event-related test data to exercise alternate keyspace handling in dispatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->