### PR TITLE
logpuller: optimize resolved-ts dispatch allocations

### DIFF
--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -301,23 +301,6 @@ func (s *regionRequestWorker) dispatchResolvedTsEvent(resolvedTsEvent *cdcpb.Res
 	// Avoid allocating a huge states slice when resolvedTsEvent.Regions is large.
 	// Push resolved-ts events in batches to reduce peak memory usage and improve GC behavior.
 	const resolvedTsStateBatchSize = 1024
-	if len(resolvedTsEvent.Regions) == 1 {
-		regionID := resolvedTsEvent.Regions[0]
-		if state := s.getRegionState(subscriptionID, regionID); state != nil {
-			s.client.pushRegionEventToDS(subscriptionID, regionEvent{
-				resolvedTs: resolvedTsEvent.Ts,
-				states:     []*regionFeedState{state},
-			})
-			return
-		}
-		log.Warn("region request worker receives a resolved ts event for an untracked region",
-			zap.Uint64("workerID", s.workerID),
-			zap.Uint64("subscriptionID", uint64(subscriptionID)),
-			zap.Uint64("regionID", regionID),
-			zap.Uint64("resolvedTs", resolvedTsEvent.Ts))
-		return
-	}
-
 	capHint := len(resolvedTsEvent.Regions)
 	if capHint > resolvedTsStateBatchSize {
 		capHint = resolvedTsStateBatchSize

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -339,7 +339,11 @@ func (s *regionRequestWorker) dispatchResolvedTsEvent(resolvedTsEvent *cdcpb.Res
 			if len(resolvedStates) >= resolvedTsStateBatchSize {
 				flush()
 				if i+1 < len(resolvedTsEvent.Regions) {
-					resolvedStates = make([]*regionFeedState, 0, resolvedTsStateBatchSize)
+					capHint = len(resolvedTsEvent.Regions) - (i + 1)
+					if capHint > resolvedTsStateBatchSize {
+						capHint = resolvedTsStateBatchSize
+					}
+					resolvedStates = make([]*regionFeedState, 0, capHint)
 				}
 			}
 			continue

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -301,23 +301,46 @@ func (s *regionRequestWorker) dispatchResolvedTsEvent(resolvedTsEvent *cdcpb.Res
 	// Avoid allocating a huge states slice when resolvedTsEvent.Regions is large.
 	// Push resolved-ts events in batches to reduce peak memory usage and improve GC behavior.
 	const resolvedTsStateBatchSize = 1024
-	resolvedStates := make([]*regionFeedState, 0, resolvedTsStateBatchSize)
+	if len(resolvedTsEvent.Regions) == 1 {
+		regionID := resolvedTsEvent.Regions[0]
+		if state := s.getRegionState(subscriptionID, regionID); state != nil {
+			s.client.pushRegionEventToDS(subscriptionID, regionEvent{
+				resolvedTs: resolvedTsEvent.Ts,
+				states:     []*regionFeedState{state},
+			})
+			return
+		}
+		log.Warn("region request worker receives a resolved ts event for an untracked region",
+			zap.Uint64("workerID", s.workerID),
+			zap.Uint64("subscriptionID", uint64(subscriptionID)),
+			zap.Uint64("regionID", regionID),
+			zap.Uint64("resolvedTs", resolvedTsEvent.Ts))
+		return
+	}
+
+	capHint := len(resolvedTsEvent.Regions)
+	if capHint > resolvedTsStateBatchSize {
+		capHint = resolvedTsStateBatchSize
+	}
+	resolvedStates := make([]*regionFeedState, 0, capHint)
 	flush := func() {
 		if len(resolvedStates) == 0 {
 			return
 		}
-		states := resolvedStates
 		s.client.pushRegionEventToDS(subscriptionID, regionEvent{
 			resolvedTs: resolvedTsEvent.Ts,
-			states:     states,
+			states:     resolvedStates,
 		})
-		resolvedStates = make([]*regionFeedState, 0, resolvedTsStateBatchSize)
+		resolvedStates = nil
 	}
-	for _, regionID := range resolvedTsEvent.Regions {
+	for i, regionID := range resolvedTsEvent.Regions {
 		if state := s.getRegionState(subscriptionID, regionID); state != nil {
 			resolvedStates = append(resolvedStates, state)
 			if len(resolvedStates) >= resolvedTsStateBatchSize {
 				flush()
+				if i+1 < len(resolvedTsEvent.Regions) {
+					resolvedStates = make([]*regionFeedState, 0, resolvedTsStateBatchSize)
+				}
 			}
 			continue
 		}

--- a/logservice/logpuller/region_request_worker_test.go
+++ b/logservice/logpuller/region_request_worker_test.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/cdcpb"
+	"github.com/pingcap/ticdc/utils/dynstream"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +66,171 @@ func TestClearPendingRegionsReleaseSlotForPreFetchedRegion(t *testing.T) {
 	require.Len(t, regions, 1)
 	require.Nil(t, worker.preFetchForConnecting)
 	require.Equal(t, 0, worker.requestCache.getPendingCount())
+}
+
+type pushedResolvedEvent struct {
+	subscriptionID SubscriptionID
+	resolvedTs     uint64
+	statesCount    int
+}
+
+type mockRegionEventDynamicStream struct {
+	pushCount   int
+	totalStates int
+	pushed      []pushedResolvedEvent
+}
+
+func (m *mockRegionEventDynamicStream) Start() {}
+
+func (m *mockRegionEventDynamicStream) Close() {}
+
+func (m *mockRegionEventDynamicStream) Push(path SubscriptionID, event regionEvent) {
+	m.pushCount++
+	m.totalStates += len(event.states)
+	m.pushed = append(m.pushed, pushedResolvedEvent{
+		subscriptionID: path,
+		resolvedTs:     event.resolvedTs,
+		statesCount:    len(event.states),
+	})
+}
+
+func (m *mockRegionEventDynamicStream) Wake(SubscriptionID) {}
+
+func (m *mockRegionEventDynamicStream) Feedback() <-chan dynstream.Feedback[int, SubscriptionID, *subscribedSpan] {
+	return nil
+}
+
+func (m *mockRegionEventDynamicStream) AddPath(SubscriptionID, *subscribedSpan, ...dynstream.AreaSettings) error {
+	return nil
+}
+
+func (m *mockRegionEventDynamicStream) RemovePath(SubscriptionID) error {
+	return nil
+}
+
+func (m *mockRegionEventDynamicStream) Release(SubscriptionID) {}
+
+func (m *mockRegionEventDynamicStream) SetAreaSettings(int, dynstream.AreaSettings) {}
+
+func (m *mockRegionEventDynamicStream) GetMetrics() dynstream.Metrics[int, SubscriptionID] {
+	return dynstream.Metrics[int, SubscriptionID]{}
+}
+
+func newDispatchResolvedTsTestWorker(regionCount int) (*regionRequestWorker, *mockRegionEventDynamicStream, *cdcpb.ResolvedTs) {
+	ds := &mockRegionEventDynamicStream{}
+	worker := &regionRequestWorker{
+		client: &subscriptionClient{
+			metrics: sharedClientMetrics{
+				batchResolvedSize: prometheus.ObserverFunc(func(float64) {}),
+			},
+			ds: ds,
+		},
+	}
+	worker.requestedRegions.subscriptions = map[SubscriptionID]regionFeedStates{
+		1: make(regionFeedStates, regionCount),
+	}
+	regions := make([]uint64, regionCount)
+	for i := 0; i < regionCount; i++ {
+		regionID := uint64(i + 1)
+		regions[i] = regionID
+		worker.requestedRegions.subscriptions[1][regionID] = &regionFeedState{
+			requestID: 1,
+		}
+	}
+
+	return worker, ds, &cdcpb.ResolvedTs{
+		RequestId: 1,
+		Ts:        100,
+		Regions:   regions,
+	}
+}
+
+func dispatchResolvedTsEventLegacyForBenchmark(s *regionRequestWorker, resolvedTsEvent *cdcpb.ResolvedTs) {
+	subscriptionID := SubscriptionID(resolvedTsEvent.RequestId)
+	const resolvedTsStateBatchSize = 1024
+	resolvedStates := make([]*regionFeedState, 0, resolvedTsStateBatchSize)
+	flush := func() {
+		if len(resolvedStates) == 0 {
+			return
+		}
+		states := resolvedStates
+		s.client.pushRegionEventToDS(subscriptionID, regionEvent{
+			resolvedTs: resolvedTsEvent.Ts,
+			states:     states,
+		})
+		resolvedStates = make([]*regionFeedState, 0, resolvedTsStateBatchSize)
+	}
+	for _, regionID := range resolvedTsEvent.Regions {
+		if state := s.getRegionState(subscriptionID, regionID); state != nil {
+			resolvedStates = append(resolvedStates, state)
+			if len(resolvedStates) >= resolvedTsStateBatchSize {
+				flush()
+			}
+		}
+	}
+	flush()
+}
+
+func benchmarkDispatchResolvedTsEvent(b *testing.B, regionCount int, useLegacy bool) {
+	worker, ds, event := newDispatchResolvedTsTestWorker(regionCount)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if useLegacy {
+			dispatchResolvedTsEventLegacyForBenchmark(worker, event)
+		} else {
+			worker.dispatchResolvedTsEvent(event)
+		}
+	}
+	b.StopTimer()
+	if ds.pushCount == 0 {
+		b.Fatal("expected at least one push")
+	}
+}
+
+func TestDispatchResolvedTsEventSingleRegionFastPath(t *testing.T) {
+	worker, ds, event := newDispatchResolvedTsTestWorker(1)
+	worker.dispatchResolvedTsEvent(event)
+
+	require.Equal(t, 1, ds.pushCount)
+	require.Equal(t, 1, ds.totalStates)
+	require.Len(t, ds.pushed, 1)
+	require.Equal(t, 1, ds.pushed[0].statesCount)
+	require.Equal(t, uint64(100), ds.pushed[0].resolvedTs)
+	require.Equal(t, SubscriptionID(1), ds.pushed[0].subscriptionID)
+}
+
+func TestDispatchResolvedTsEventBatchSplitForLargeRegions(t *testing.T) {
+	worker, ds, event := newDispatchResolvedTsTestWorker(2050)
+	worker.dispatchResolvedTsEvent(event)
+
+	require.Equal(t, 2050, ds.totalStates)
+	require.Len(t, ds.pushed, 3)
+	require.Equal(t, 1024, ds.pushed[0].statesCount)
+	require.Equal(t, 1024, ds.pushed[1].statesCount)
+	require.Equal(t, 2, ds.pushed[2].statesCount)
+}
+
+func BenchmarkDispatchResolvedTsEventSingleRegionLegacy(b *testing.B) {
+	benchmarkDispatchResolvedTsEvent(b, 1, true)
+}
+
+func BenchmarkDispatchResolvedTsEventSingleRegionCurrent(b *testing.B) {
+	benchmarkDispatchResolvedTsEvent(b, 1, false)
+}
+
+func BenchmarkDispatchResolvedTsEventLargeBatchLegacy(b *testing.B) {
+	benchmarkDispatchResolvedTsEvent(b, 4096, true)
+}
+
+func BenchmarkDispatchResolvedTsEventLargeBatchCurrent(b *testing.B) {
+	benchmarkDispatchResolvedTsEvent(b, 4096, false)
+}
+
+func BenchmarkDispatchResolvedTsEventSmallBatchLegacy(b *testing.B) {
+	benchmarkDispatchResolvedTsEvent(b, 16, true)
+}
+
+func BenchmarkDispatchResolvedTsEventSmallBatchCurrent(b *testing.B) {
+	benchmarkDispatchResolvedTsEvent(b, 16, false)
 }

--- a/logservice/logpuller/region_request_worker_test.go
+++ b/logservice/logpuller/region_request_worker_test.go
@@ -188,7 +188,7 @@ func benchmarkDispatchResolvedTsEvent(b *testing.B, regionCount int, useLegacy b
 	}
 }
 
-func TestDispatchResolvedTsEventSingleRegionFastPath(t *testing.T) {
+func TestDispatchResolvedTsEventSingleRegion(t *testing.T) {
 	worker, ds, event := newDispatchResolvedTsTestWorker(1)
 	worker.dispatchResolvedTsEvent(event)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4697 

### What is changed and how it works?

  - Added a **single-region fast path**:
    - If `len(resolvedTsEvent.Regions) == 1`, directly push one-state event.
  - Changed initial `resolvedStates` capacity to:
    - `capHint = min(len(resolvedTsEvent.Regions), resolvedTsStateBatchSize)`
  - Kept large-batch protection:
    - `resolvedTsStateBatchSize` remains `1024`.
  - Removed redundant allocation pattern:
    - After `flush`, do not always allocate a new slice.
    - Allocate the next batch buffer only when there are remaining regions to process.
  - Added tests and benchmarks in `region_request_worker_test.go`:
    - Single-region fast-path behavior
    - Large-batch split behavior
    - Legacy vs current benchmark comparisons

**Benchmark Command**

```bash
mkdir -p /tmp/go-cache /tmp/go-tmp && \
GOCACHE=/tmp/go-cache GOTMPDIR=/tmp/go-tmp \
go test ./logservice/logpuller \
  -run '^$' \
  -bench 'BenchmarkDispatchResolvedTsEvent' \
  -benchmem \
  -count=5
```

**Average Comparison (5 runs)**

| Scenario | Legacy ns/op | Current ns/op | ns/op Change | Speedup | Legacy B/op | Current B/op | B/op Change | Legacy allocs/op | Current allocs/op | allocs Change |
|:--|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
| SingleRegion | 664.94 | 30.19 | -95.46% | 22.02x | 19074 | 137 | -99.28% | 2.00 | 1.00 | -50.00% |
| SmallBatch | 658.94 | 148.20 | -77.51% | 4.45x | 19071 | 256 | -98.66% | 2.00 | 1.00 | -50.00% |
| LargeBatch | 36325.80 | 36532.80 | +0.57% | 0.99x | 47899 | 38424 | -19.78% | 5.00 | 4.00 | -20.00% |

- `SingleRegion` and `SmallBatch` show major CPU and allocation improvements.
- `LargeBatch` keeps bounded memory behavior and reduces allocations; `ns/op` is roughly flat (+0.57%).


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
  Reduce CPU and allocation overhead in log puller by optimizing resolved-ts event dispatch for small batches.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved resolved-timestamp dispatch: smarter pre-sizing, buffer reuse, and adaptive batching for single-region fast path and large multi-region splits, reducing allocations and improving throughput.

* **Tests**
  * Added unit tests and benchmarks validating single-region fast-path, large-set batch-splitting, and performance comparisons against the legacy dispatcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->