### PR TITLE
test: stabilize signal resolved test

### DIFF
--- a/pkg/eventservice/event_broker_test.go
+++ b/pkg/eventservice/event_broker_test.go
@@ -1484,7 +1484,12 @@ func TestProcessTableTriggerDispatcherSendsSignalResolvedWhenNoForwardRangeAndNo
 
 	changefeed := broker.getOrSetChangefeedStatus(info.GetChangefeedID(), info.GetSyncPointInterval())
 	dispatcher := newDispatcherStat(info, 1, 1, nil, changefeed)
-	dispatcher.lastSentResolvedTsTime.Store(time.Now().Add(-defaultSendResolvedTsInterval - time.Second))
+	// Keep the test focused on the signal resolved path instead of coupling it with
+	// the separate handshake behavior.
+	dispatcher.seq.Store(1)
+	// Use the zero time to bypass the rate limit deterministically without depending
+	// on wall clock timing.
+	dispatcher.lastSentResolvedTsTime.Store(time.Time{})
 
 	dispatcherPtr := &atomic.Pointer[dispatcherStat]{}
 	dispatcherPtr.Store(dispatcher)
@@ -1497,12 +1502,10 @@ func TestProcessTableTriggerDispatcherSendsSignalResolvedWhenNoForwardRangeAndNo
 
 	broker.processTableTriggerDispatcher(context.Background(), dispatcher.id, dispatcher)
 
-	require.Equal(t, 2, len(broker.messageCh[dispatcher.messageWorkerIndex]))
-	first := <-broker.messageCh[dispatcher.messageWorkerIndex]
-	second := <-broker.messageCh[dispatcher.messageWorkerIndex]
-	require.Equal(t, event.TypeHandshakeEvent, first.msgType)
-	require.Equal(t, event.TypeResolvedEvent, second.msgType)
-	require.Equal(t, ts10, second.resolvedTsEvent.ResolvedTs)
+	require.Equal(t, 1, len(broker.messageCh[dispatcher.messageWorkerIndex]))
+	msg := <-broker.messageCh[dispatcher.messageWorkerIndex]
+	require.Equal(t, event.TypeResolvedEvent, msg.msgType)
+	require.Equal(t, ts10, msg.resolvedTsEvent.ResolvedTs)
 	require.Equal(t, ts10, dispatcher.sentResolvedTs.Load())
 	require.Equal(t, ts20, dispatcher.nextSyncPoint.Load())
 }


### PR DESCRIPTION
### What problem does this PR solve?

The table trigger signal resolved test is brittle because it validates two behaviors that are outside the scenario described by the test name:

- it depends on the dispatcher still being unhandshaked and therefore expects a `HandshakeEvent`
- it uses wall clock time to bypass the resolved-ts rate limiter

That makes the test sensitive to benign changes in handshake timing or rate-limit related setup, even though the behavior under test is only the signal resolved path when there is no forward range and the dispatcher is not in the syncpoint commit stage.

Issue Number: close #4772

### What is changed and how it works?

This PR narrows the test scope to the behavior it is supposed to verify.

- mark the dispatcher as already handshaked so the test does not depend on handshake ordering
- set `lastSentResolvedTsTime` to zero time so the rate-limit bypass is deterministic instead of wall-clock based
- assert only the emitted resolved event and the related watermark state

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced event broker signal resolution test to run with deterministic dispatcher state and improved assertion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->