### PR TITLE
go.mod: upgrade tidb parser to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
 	github.com/pingcap/tidb v1.1.0-beta.0.20251121075944-8f2630e53d5d
 	github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7
-	github.com/pingcap/tidb/pkg/parser v0.0.0-20251121075944-8f2630e53d5d
+	github.com/pingcap/tidb/pkg/parser v0.0.0-20260409042751-e0b4e44570cd
 	github.com/pingcap/tiflow v0.0.0-20260202075306-0ea757eae77a
 	github.com/prometheus/client_golang v1.22.0
 	github.com/r3labs/diff v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -2159,6 +2159,8 @@ github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7 h1:eFu98Fbf
 github.com/pingcap/tidb-dashboard v0.0.0-20240326110213-9768844ff5d7/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20251121075944-8f2630e53d5d h1:0aVvZLLD2d4xp0dXVAhWwDD4Rw0JRBEl28/XtCg3N0s=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20251121075944-8f2630e53d5d/go.mod h1:F7q7Qh9lNJyVS5ZliB1hA4uioJN1tOfnNf9KleLZVqo=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260409042751-e0b4e44570cd h1:2ImjR/2rLqpy86ErU5b4UM0z775+NfgvQQafvldnqHE=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260409042751-e0b4e44570cd/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/pingcap/tiflow v0.0.0-20260202075306-0ea757eae77a h1:64Ojv/J7iItuzvU7hkDTSKNfAlinnyMHzGb5bgMsL40=
 github.com/pingcap/tiflow v0.0.0-20260202075306-0ea757eae77a/go.mod h1:CCKNsvvbUxQGrTbmganr9SETenogMFf2iIudHnKj6sg=
 github.com/pingcap/tipb v0.0.0-20250928030846-9fd33ded6f2c h1:tddMjEiXU0d1VlJ+yHwim4gINeHmFR9CCkitatuby2c=


### PR DESCRIPTION
Issue Number: N/A

## Background
TiCDC currently pins `github.com/pingcap/tidb/pkg/parser` to `v0.0.0-20251121075944-8f2630e53d5d`.

## Motivation
We want to move the parser dependency to the latest upstream version so TiCDC can pick up the newest parser changes without widening the dependency update beyond what is required for this task.

## Summary
- upgrade `github.com/pingcap/tidb/pkg/parser` to `v0.0.0-20260409042751-e0b4e44570cd`
- refresh `go.sum` for the new parser module checksums
- keep `github.com/pingcap/tidb` unchanged because the parser-only bump did not require a wider module update

## Testing
- `make fmt`
- `go test --tags=intest` for all packages that directly import `github.com/pingcap/tidb/pkg/parser...` except `tests/integration_tests/...`
- `go test --tags=intest ./downstreamadapter/dispatcher -run ^`

## Notes
`TestRedoBatchDMLEventsPartialFlush` in `./downstreamadapter/dispatcher` fails on both this branch and the unchanged `upstream/master` baseline, so it was treated as a pre-existing test issue rather than a regression from this parser upgrade.

### release-note
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->