### PR TITLE
metrics,scripts: sync next gen shared dashboard UID

### DIFF
--- a/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
@@ -27297,6 +27297,6 @@
   },
   "timezone": "browser",
   "title": "${DS_TEST-CLUSTER}-TiCDC-New-Arch",
-  "uid": "YiGL8hBZ0aac",
+  "uid": "zHSo4WLgHDpS",
   "version": 40
 }

--- a/scripts/generate-next-gen-metrics.sh
+++ b/scripts/generate-next-gen-metrics.sh
@@ -73,6 +73,7 @@ jq '
 ' "$NEXT_GEN_SHARED_FILE" >"$NEXT_GEN_USER_FILE"
 
 "$SED_CMD" "${SED_INPLACE_ARGS[@]}" "s/\${DS_TEST-CLUSTER}-TiCDC-New-Arch/&-KeyspaceName/" "$NEXT_GEN_USER_FILE"
+"$SED_CMD" "${SED_INPLACE_ARGS[@]}" "s/YiGL8hBZ0aac/zHSo4WLgHDpS/" "$NEXT_GEN_SHARED_FILE"
 "$SED_CMD" "${SED_INPLACE_ARGS[@]}" "s/YiGL8hBZ0aac/lGT5hED6vqTn/" "$NEXT_GEN_USER_FILE"
 require_file_contains "$NEXT_GEN_USER_FILE" "-KeyspaceName"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4775

### What is changed and how it works?

- update `scripts/generate-next-gen-metrics.sh` so it rewrites the shared-scope next-gen dashboard UID during generation
- regenerate `metrics/nextgengrafana/ticdc_new_arch_next_gen.json` with the refreshed shared dashboard UID
- keep `generate-next-gen-grafana` output reproducible under `make check`

### Check List

#### Tests

- Manual test (add detailed scripts or steps below)

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dashboard configuration identifiers in monitoring and metrics generation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->