### PR TITLE
etcd: fix cluster-id prefix collision

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -202,14 +202,7 @@ func (c *CDCEtcdClientImpl) GetAllCDCInfo(ctx context.Context) ([]*mvccpb.KeyVal
 	if err != nil {
 		return nil, errors.WrapError(errors.ErrPDEtcdAPIError, err)
 	}
-	kvs := make([]*mvccpb.KeyValue, 0, len(resp.Kvs))
-	for _, kv := range resp.Kvs {
-		if !hasPathPrefix(string(kv.Key), BaseKey(c.ClusterID)) {
-			continue
-		}
-		kvs = append(kvs, kv)
-	}
-	return kvs, nil
+	return resp.Kvs, nil
 }
 
 // CheckMultipleCDCClusterExist checks if other cdc clusters exists,
@@ -255,9 +248,6 @@ func (c *CDCEtcdClientImpl) GetChangefeedInfoAndStatus(ctx context.Context) (rev
 	statusMap = make(map[common.ChangeFeedDisplayName]*mvccpb.KeyValue, 0)
 	infoMap = make(map[common.ChangeFeedDisplayName]*mvccpb.KeyValue, 0)
 	for _, kv := range resp.Kvs {
-		if !hasPathPrefix(string(kv.Key), BaseKey(c.ClusterID)) {
-			continue
-		}
 		ks, cf, isStatus, isChangefeed := extractChangefeedKeySuffix(string(kv.Key))
 		if !isChangefeed {
 			continue

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -181,7 +181,7 @@ func (c *CDCEtcdClientImpl) Close() error {
 
 // ClearAllCDCInfo delete all keys created by CDC
 func (c *CDCEtcdClientImpl) ClearAllCDCInfo(ctx context.Context) error {
-	_, err := c.Client.Delete(ctx, BaseKey(c.ClusterID), clientv3.WithPrefix())
+	_, err := c.Client.Delete(ctx, clusterPrefix(c.ClusterID), clientv3.WithPrefix())
 	return errors.WrapError(errors.ErrPDEtcdAPIError, err)
 }
 
@@ -197,11 +197,19 @@ func (c *CDCEtcdClientImpl) GetEtcdClient() Client {
 
 // GetAllCDCInfo get all keys created by CDC
 func (c *CDCEtcdClientImpl) GetAllCDCInfo(ctx context.Context) ([]*mvccpb.KeyValue, error) {
-	resp, err := c.Client.Get(ctx, BaseKey(c.ClusterID), clientv3.WithPrefix())
+	prefix := clusterPrefix(c.ClusterID)
+	resp, err := c.Client.Get(ctx, prefix, clientv3.WithPrefix())
 	if err != nil {
 		return nil, errors.WrapError(errors.ErrPDEtcdAPIError, err)
 	}
-	return resp.Kvs, nil
+	kvs := make([]*mvccpb.KeyValue, 0, len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		if !hasPathPrefix(string(kv.Key), BaseKey(c.ClusterID)) {
+			continue
+		}
+		kvs = append(kvs, kv)
+	}
+	return kvs, nil
 }
 
 // CheckMultipleCDCClusterExist checks if other cdc clusters exists,
@@ -215,14 +223,14 @@ func (c *CDCEtcdClientImpl) CheckMultipleCDCClusterExist(ctx context.Context) er
 	}
 	for _, kv := range resp.Kvs {
 		key := string(kv.Key)
-		if strings.HasPrefix(key, BaseKey(DefaultCDCClusterID)) ||
-			strings.HasPrefix(key, migrateBackupPrefix) {
+		if hasPathPrefix(key, BaseKey(DefaultCDCClusterID)) ||
+			hasPathPrefix(key, migrateBackupPrefix) {
 			continue
 		}
 		// skip the reserved cluster id
 		isReserved := false
 		for _, reserved := range config.ReservedClusterIDs {
-			if strings.HasPrefix(key, BaseKey(reserved)) {
+			if hasPathPrefix(key, BaseKey(reserved)) {
 				isReserved = true
 				break
 			}
@@ -237,7 +245,7 @@ func (c *CDCEtcdClientImpl) CheckMultipleCDCClusterExist(ctx context.Context) er
 
 // GetChangefeedInfoAndStatus returns kv revision and a map mapping from changefeedID to changefeed info and status
 func (c *CDCEtcdClientImpl) GetChangefeedInfoAndStatus(ctx context.Context) (revision int64, statusMap map[common.ChangeFeedDisplayName]*mvccpb.KeyValue, infoMap map[common.ChangeFeedDisplayName]*mvccpb.KeyValue, err error) {
-	allDataPrefix := BaseKey(c.ClusterID)
+	allDataPrefix := clusterPrefix(c.ClusterID)
 	// TODO tenfyzhong 2025-09-30 17:00:57 We should obtain data by page
 	resp, err := c.Client.Get(ctx, allDataPrefix, clientv3.WithPrefix())
 	if err != nil {
@@ -247,6 +255,9 @@ func (c *CDCEtcdClientImpl) GetChangefeedInfoAndStatus(ctx context.Context) (rev
 	statusMap = make(map[common.ChangeFeedDisplayName]*mvccpb.KeyValue, 0)
 	infoMap = make(map[common.ChangeFeedDisplayName]*mvccpb.KeyValue, 0)
 	for _, kv := range resp.Kvs {
+		if !hasPathPrefix(string(kv.Key), BaseKey(c.ClusterID)) {
+			continue
+		}
 		ks, cf, isStatus, isChangefeed := extractChangefeedKeySuffix(string(kv.Key))
 		if !isChangefeed {
 			continue

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -204,14 +204,6 @@ func TestCDCEtcdClientImpl_GetChangefeedInfoAndStatus(t *testing.T) {
 							Key:   []byte("/tidb/cdc/cluster-id/keyspace1/changefeed1/info/changefeed2"),
 							Value: []byte("{}"),
 						},
-						{
-							Key:   []byte("/tidb/cdc/cluster-id-index/keyspace1/changefeed/status/changefeed4"),
-							Value: []byte("{}"),
-						},
-						{
-							Key:   []byte("/tidb/cdc/cluster-id-index/keyspace1/changefeed/info/changefeed4"),
-							Value: []byte("{}"),
-						},
 					},
 					More:  false,
 					Count: 0,
@@ -292,10 +284,6 @@ func TestCDCEtcdClientImpl_GetAllCDCInfo(t *testing.T) {
 			Kvs: []*mvccpb.KeyValue{
 				{
 					Key:   []byte("/tidb/cdc/cluster-id/default/changefeed/info/changefeed1"),
-					Value: []byte("{}"),
-				},
-				{
-					Key:   []byte("/tidb/cdc/cluster-id-index/default/changefeed/info/changefeed2"),
 					Value: []byte("{}"),
 				},
 			},

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -142,7 +142,7 @@ func TestCDCEtcdClientImpl_GetChangefeedInfoAndStatus(t *testing.T) {
 			name: "get changefeeds failed",
 			fields: func(ctx context.Context, ctrl *gomock.Controller) fields {
 				client := NewMockClient(ctrl)
-				client.EXPECT().Get(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/cluster-id"), gomock.Any()).Return(nil, errors.New("etcd failed")).Times(1)
+				client.EXPECT().Get(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/cluster-id/"), gomock.Any()).Return(nil, errors.New("etcd failed")).Times(1)
 				return fields{
 					Client:        client,
 					ClusterID:     "cluster-id",
@@ -163,7 +163,7 @@ func TestCDCEtcdClientImpl_GetChangefeedInfoAndStatus(t *testing.T) {
 			name: "get changefeeds success",
 			fields: func(ctx context.Context, ctrl *gomock.Controller) fields {
 				client := NewMockClient(ctrl)
-				client.EXPECT().Get(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/cluster-id"), gomock.Any()).Return(&clientv3.GetResponse{
+				client.EXPECT().Get(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/cluster-id/"), gomock.Any()).Return(&clientv3.GetResponse{
 					Header: &etcdserverpb.ResponseHeader{
 						Revision: 3,
 					},
@@ -202,6 +202,14 @@ func TestCDCEtcdClientImpl_GetChangefeedInfoAndStatus(t *testing.T) {
 						},
 						{
 							Key:   []byte("/tidb/cdc/cluster-id/keyspace1/changefeed1/info/changefeed2"),
+							Value: []byte("{}"),
+						},
+						{
+							Key:   []byte("/tidb/cdc/cluster-id-index/keyspace1/changefeed/status/changefeed4"),
+							Value: []byte("{}"),
+						},
+						{
+							Key:   []byte("/tidb/cdc/cluster-id-index/keyspace1/changefeed/info/changefeed4"),
 							Value: []byte("{}"),
 						},
 					},
@@ -268,6 +276,103 @@ func TestCDCEtcdClientImpl_GetChangefeedInfoAndStatus(t *testing.T) {
 			require.Equal(t, tt.wantRevision, gotRevision)
 			require.EqualValues(t, tt.wantStatusMap, gotStatusMap)
 			require.EqualValues(t, tt.wantInfoMap, gotInfoMap)
+		})
+	}
+}
+
+func TestCDCEtcdClientImpl_GetAllCDCInfo(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockClient(ctrl)
+	client.EXPECT().
+		Get(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/cluster-id/"), gomock.Any()).
+		Return(&clientv3.GetResponse{
+			Kvs: []*mvccpb.KeyValue{
+				{
+					Key:   []byte("/tidb/cdc/cluster-id/default/changefeed/info/changefeed1"),
+					Value: []byte("{}"),
+				},
+				{
+					Key:   []byte("/tidb/cdc/cluster-id-index/default/changefeed/info/changefeed2"),
+					Value: []byte("{}"),
+				},
+			},
+		}, nil).
+		Times(1)
+
+	etcdClient := &CDCEtcdClientImpl{Client: client, ClusterID: "cluster-id"}
+	kvs, err := etcdClient.GetAllCDCInfo(ctx)
+	require.NoError(t, err)
+	require.Len(t, kvs, 1)
+	require.Equal(t, []byte("/tidb/cdc/cluster-id/default/changefeed/info/changefeed1"), kvs[0].Key)
+}
+
+func TestCDCEtcdClientImpl_ClearAllCDCInfo(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockClient(ctrl)
+	client.EXPECT().
+		Delete(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/cluster-id/"), gomock.Any()).
+		Return(&clientv3.DeleteResponse{}, nil).
+		Times(1)
+
+	etcdClient := &CDCEtcdClientImpl{Client: client, ClusterID: "cluster-id"}
+	require.NoError(t, etcdClient.ClearAllCDCInfo(ctx))
+}
+
+func TestCDCEtcdClientImpl_CheckMultipleCDCClusterExist(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		kvs       []*mvccpb.KeyValue
+		assertion require.ErrorAssertionFunc
+	}{
+		{
+			name: "only default cluster exists",
+			kvs: []*mvccpb.KeyValue{
+				{Key: []byte("/tidb/cdc/default/default/changefeed/info/changefeed1")},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "default prefix collision should be treated as another cluster",
+			kvs: []*mvccpb.KeyValue{
+				{Key: []byte("/tidb/cdc/default-index/default/changefeed/info/changefeed1")},
+			},
+			assertion: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, cerrors.ErrMultipleCDCClustersExist.Equal(err))
+			},
+		},
+		{
+			name: "reserved prefix collision should be treated as another cluster",
+			kvs: []*mvccpb.KeyValue{
+				{Key: []byte("/tidb/cdc/owner-index/default/changefeed/info/changefeed1")},
+			},
+			assertion: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, cerrors.ErrMultipleCDCClustersExist.Equal(err))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := NewMockClient(ctrl)
+			client.EXPECT().
+				Get(gomock.Eq(ctx), gomock.Eq("/tidb/cdc/"), gomock.Any(), gomock.Any()).
+				Return(&clientv3.GetResponse{Kvs: tt.kvs}, nil).
+				Times(1)
+
+			etcdClient := &CDCEtcdClientImpl{Client: client, ClusterID: "cluster-id"}
+			err := etcdClient.CheckMultipleCDCClusterExist(ctx)
+			tt.assertion(t, err)
 		})
 	}
 }

--- a/pkg/etcd/etcdkey.go
+++ b/pkg/etcd/etcdkey.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	cdcKeyRoot = "/tidb/cdc"
+
 	// Note that tidb-dashboard depends on this prefix to filter out TiCDC keys.
 	// Ref: https://github.com/pingcap/tidb-dashboard/blob/1f39ee09c5352adbf23af8ec7e15020147ef9ca4/pkg/utils/topology/ticdc.go#L23
 	metaPrefix = "/__cdc_meta__"
@@ -107,7 +109,7 @@ type CDCKey struct {
 // Note that tidb-dashboard depends on this prefix to filter out TiCDC keys.
 // Ref: https://github.com/pingcap/tidb-dashboard/blob/1f39ee09c5352adbf23af8ec7e15020147ef9ca4/pkg/utils/topology/ticdc.go#L22
 func BaseKey(clusterID string) string {
-	return fmt.Sprintf("/tidb/cdc/%s", clusterID)
+	return fmt.Sprintf("%s/%s", cdcKeyRoot, clusterID)
 }
 
 // NewCDCBaseKey is used for keys added by New Arch TiCDC
@@ -120,15 +122,30 @@ func NewCDCBaseKey(clusterID string) string {
 
 // KeyspacePrefix returns the etcd prefix of changefeed data
 func KeyspacePrefix(clusterID, keyspace string) string {
-	return BaseKey(clusterID) + "/" + keyspace
+	return fmt.Sprintf("%s/%s", BaseKey(clusterID), keyspace)
+}
+
+func pathPrefix(prefix string) string {
+	if strings.HasSuffix(prefix, "/") {
+		return prefix
+	}
+	return fmt.Sprintf("%s/", prefix)
+}
+
+func clusterPrefix(clusterID string) string {
+	return pathPrefix(BaseKey(clusterID))
+}
+
+func hasPathPrefix(key, prefix string) bool {
+	return key == prefix || strings.HasPrefix(key, pathPrefix(prefix))
 }
 
 // Parse parses the given etcd key
 func (k *CDCKey) Parse(clusterID, key string) error {
-	if !strings.HasPrefix(key, BaseKey(clusterID)) {
+	if !strings.HasPrefix(key, clusterPrefix(clusterID)) {
 		return errors.ErrInvalidEtcdKey.GenWithStackByArgs(key)
 	}
-	key = key[len("/tidb/cdc"):]
+	key = key[len(cdcKeyRoot):]
 	parts := strings.Split(key, "/")
 	k.ClusterID = parts[1]
 	key = key[len(k.ClusterID)+1:]

--- a/pkg/etcd/etcdkey_test.go
+++ b/pkg/etcd/etcdkey_test.go
@@ -149,6 +149,9 @@ func TestEtcdKeyParseError(t *testing.T) {
 	}, {
 		key:   "/tidb/cdc/default/default/abcd",
 		error: true,
+	}, {
+		key:   "/tidb/cdc/default-index/default/changefeed/info/changefeed-1",
+		error: true,
 	}}
 	for _, tc := range testCases {
 		k := new(CDCKey)

--- a/tests/integration_tests/multi_cdc_cluster/run.sh
+++ b/tests/integration_tests/multi_cdc_cluster/run.sh
@@ -26,12 +26,22 @@ function run() {
 	# run one cdc cluster
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --cluster-id "test1" --addr "127.0.0.1:8300" --logsuffix mult_cdc.server1
 	# run another cdc cluster
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --cluster-id "test2" --addr "127.0.0.1:8301" --logsuffix mult_cdc.server2
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --cluster-id "test11" --addr "127.0.0.1:8301" --logsuffix mult_cdc.server2
 
 	SINK_URI="mysql://normal:123456@127.0.0.1:3306/"
 
-	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --server "http://127.0.0.1:8300" --config="$CUR/conf/changefeed1.toml"
-	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --server "http://127.0.0.1:8301" --config="$CUR/conf/changefeed2.toml"
+	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --server "http://127.0.0.1:8300" --config="$CUR/conf/changefeed1.toml" --changefeed-id "test1"
+	cdc_cli_changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --server "http://127.0.0.1:8301" --config="$CUR/conf/changefeed2.toml" --changefeed-id "test2"
+
+	ensure 20 "curl --silent --show-error --fail --user ticdc:ticdc_secret 'http://127.0.0.1:8300/api/v2/changefeeds?keyspace=${KEYSPACE_NAME}' | jq -e '.total == 1 and .items[0].id == \"test1\"' >/dev/null"
+	ensure 20 "curl --silent --show-error --fail --user ticdc:ticdc_secret 'http://127.0.0.1:8301/api/v2/changefeeds?keyspace=${KEYSPACE_NAME}' | jq -e '.total == 1 and .items[0].id == \"test2\"' >/dev/null"
+
+	cdc_pid_1=$(get_cdc_pid 127.0.0.1 8300)
+	kill_cdc_pid $cdc_pid_1
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --cluster-id "test1" --addr "127.0.0.1:8300" --logsuffix mult_cdc.server1
+
+	ensure 20 "curl --silent --show-error --fail --user ticdc:ticdc_secret 'http://127.0.0.1:8300/api/v2/changefeeds?keyspace=${KEYSPACE_NAME}' | jq -e '.total == 1 and .items[0].id == \"test1\"' >/dev/null"
+	ensure 20 "curl --silent --show-error --fail --user ticdc:ticdc_secret 'http://127.0.0.1:8301/api/v2/changefeeds?keyspace=${KEYSPACE_NAME}' | jq -e '.total == 1 and .items[0].id == \"test2\"' >/dev/null"
 
 	# same dml for table multi_cdc1
 	run_sql "INSERT INTO test.multi_cdc1(id, val) VALUES (1, 1);"


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4756

### What is changed and how it works?
Use "/" as a suffix to distinguish two clusters.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
fix cluster-id prefix collision to avoid changefeed duplicate
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent CDC key-prefix handling and more reliable cluster-scoped key operations to prevent cross-cluster interference.

* **Tests**
  * Added unit tests for CDC key operations, retrieval, clearing, and multi-cluster detection.
  * Enhanced integration tests to validate changefeed IDs, persistence, and behavior after server restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->