### PR TITLE
downstreamadapter: preserve remove upgrade during close

### DIFF
--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -101,7 +101,7 @@ func main() {
 	deferFunc := func() int {
 		stop()
 		if consumer != nil {
-			consumer.sink.Close(false)
+			consumer.sink.Close()
 		}
 		if err != nil && err != context.Canceled {
 			return 1

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -101,7 +101,7 @@ func main() {
 	deferFunc := func() int {
 		stop()
 		if consumer != nil {
-			consumer.sink.Close(false)
+			_ = consumer.sink.Close(false)
 		}
 		if err != nil && err != context.Canceled {
 			return 1

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -101,7 +101,7 @@ func main() {
 	deferFunc := func() int {
 		stop()
 		if consumer != nil {
-			_ = consumer.sink.Close(false)
+			consumer.sink.Close(false)
 		}
 		if err != nil && err != context.Canceled {
 			return 1

--- a/downstreamadapter/dispatcher/mock_sink_helper_test.go
+++ b/downstreamadapter/dispatcher/mock_sink_helper_test.go
@@ -72,7 +72,7 @@ func newDispatcherTestSink(t *testing.T, sinkType common.SinkType) *dispatcherTe
 	}).AnyTimes()
 	testSink.sink.EXPECT().AddCheckpointTs(gomock.Any()).AnyTimes()
 	testSink.sink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
-	testSink.sink.EXPECT().Close(gomock.Any()).AnyTimes()
+	testSink.sink.EXPECT().Close().AnyTimes()
 	testSink.sink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return testSink
 }

--- a/downstreamadapter/dispatcher/mock_sink_helper_test.go
+++ b/downstreamadapter/dispatcher/mock_sink_helper_test.go
@@ -72,7 +72,7 @@ func newDispatcherTestSink(t *testing.T, sinkType common.SinkType) *dispatcherTe
 	}).AnyTimes()
 	testSink.sink.EXPECT().AddCheckpointTs(gomock.Any()).AnyTimes()
 	testSink.sink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
-	testSink.sink.EXPECT().Close(gomock.Any()).Return(true).AnyTimes()
+	testSink.sink.EXPECT().Close(gomock.Any()).AnyTimes()
 	testSink.sink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return testSink
 }

--- a/downstreamadapter/dispatcher/mock_sink_helper_test.go
+++ b/downstreamadapter/dispatcher/mock_sink_helper_test.go
@@ -72,7 +72,7 @@ func newDispatcherTestSink(t *testing.T, sinkType common.SinkType) *dispatcherTe
 	}).AnyTimes()
 	testSink.sink.EXPECT().AddCheckpointTs(gomock.Any()).AnyTimes()
 	testSink.sink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
-	testSink.sink.EXPECT().Close(gomock.Any()).AnyTimes()
+	testSink.sink.EXPECT().Close(gomock.Any()).Return(true).AnyTimes()
 	testSink.sink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return testSink
 }

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -848,10 +848,7 @@ func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
 		e.removeChangefeedRequested.Store(true)
 	}
 	if e.closed.Load() {
-		if !e.cleanupRemovedChangefeed() {
-			return false
-		}
-		return e.isCloseComplete()
+		return e.cleanupRemovedChangefeed()
 	}
 	if e.closing.Load() {
 		return false
@@ -937,10 +934,6 @@ func (e *DispatcherManager) close() {
 	e.closed.Store(true)
 	log.Info("event dispatcher manager closed",
 		zap.Stringer("changefeedID", e.changefeedID))
-}
-
-func (e *DispatcherManager) isCloseComplete() bool {
-	return e.closed.Load() && (!e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load())
 }
 
 func (e *DispatcherManager) cleanupRemovedChangefeed() bool {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -139,8 +139,11 @@ type DispatcherManager struct {
 	// removeChangefeedCleaned records whether the remove-only cleanup has finished.
 	// closed=true only means the base close path completed; remove cleanup may still be pending.
 	removeChangefeedCleaned atomic.Bool
-	cancel                  context.CancelFunc
-	wg                      sync.WaitGroup
+	// removeChangefeedCleanupRunning prevents duplicate background cleanup runs
+	// while retries keep asking for remove semantics after the base close path ends.
+	removeChangefeedCleanupRunning atomic.Bool
+	cancel                         context.CancelFunc
+	wg                             sync.WaitGroup
 
 	// removeTaskHandles stores the task handles for async dispatcher removal
 	// map[common.DispatcherID]*threadpool.TaskHandle
@@ -848,7 +851,7 @@ func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
 		e.removeChangefeedRequested.Store(true)
 	}
 	if e.closed.Load() {
-		return e.cleanupRemovedChangefeed()
+		return e.tryScheduleRemoveChangefeedCleanup()
 	}
 	if e.closing.Load() {
 		return false
@@ -916,11 +919,6 @@ func (e *DispatcherManager) close() {
 	e.sink.Close(false)
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
 
-	if !e.cleanupRemovedChangefeed() {
-		log.Warn("remove changefeed cleanup is not finished during close",
-			zap.Stringer("changefeedID", e.changefeedID))
-	}
-
 	e.wg.Wait()
 
 	e.removeTaskHandles.Range(func(key, value interface{}) bool {
@@ -932,34 +930,57 @@ func (e *DispatcherManager) close() {
 	e.cleanMetrics()
 
 	e.closed.Store(true)
+	e.tryScheduleRemoveChangefeedCleanup()
 	log.Info("event dispatcher manager closed",
 		zap.Stringer("changefeedID", e.changefeedID))
 }
 
-func (e *DispatcherManager) cleanupRemovedChangefeed() bool {
-	if !e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load() {
+func (e *DispatcherManager) tryScheduleRemoveChangefeedCleanup() bool {
+	if !e.removeChangefeedRequested.Load() {
 		return true
+	}
+	if e.removeChangefeedCleaned.Load() {
+		return true
+	}
+	if !e.removeChangefeedCleanupRunning.CompareAndSwap(false, true) {
+		return false
+	}
+
+	go func() {
+		defer e.removeChangefeedCleanupRunning.Store(false)
+
+		if err := e.runRemoveChangefeedCleanup(); err != nil {
+			log.Warn("failed to cleanup removed changefeed",
+				zap.Stringer("changefeedID", e.changefeedID),
+				zap.Error(err))
+			return
+		}
+		e.removeChangefeedCleaned.Store(true)
+	}()
+	return false
+}
+
+func (e *DispatcherManager) runRemoveChangefeedCleanup() error {
+	if !e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load() {
+		return nil
 	}
 
 	if e.IsRedoEnabled() {
 		// Redo meta cleanup is the remove-only step for redo mode. It is safe to retry
 		// because removeChangefeedCleaned is only set after all remove-only cleanup succeeds.
-		e.closeRedoMeta(true)
+		if err := e.closeRedoMeta(true); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	if mysqlSink, ok := e.sink.(*mysql.Sink); ok {
 		// MySQL sink may still need ddl_ts cleanup after the base close path has already
 		// released the long-lived DB connection, so keep the retryable remove step here.
 		if err := mysqlSink.CleanupRemovedChangefeed(); err != nil {
-			log.Warn("failed to cleanup removed changefeed",
-				zap.Stringer("changefeedID", e.changefeedID),
-				zap.Error(err))
-			return false
+			return errors.Trace(err)
 		}
 	}
-
-	e.removeChangefeedCleaned.Store(true)
-	return true
+	return nil
 }
 
 // cleanEventDispatcher is called when the event dispatcher is removed successfully.

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -136,11 +136,13 @@ type DispatcherManager struct {
 	// removeChangefeedRequested is sticky once any close request asks for removed=true.
 	// A later removed=false request must not downgrade the final cleanup semantics.
 	removeChangefeedRequested atomic.Bool
-	// removeChangefeedCleaned records whether the remove-only cleanup has finished.
-	// closed=true only means the base close path completed; remove cleanup may still be pending.
+	// removeChangefeedCleaned records whether the best-effort remove-only cleanup has finished.
+	// It is intentionally not part of the TryClose success condition so the close contract
+	// stays compatible with the historical behavior.
 	removeChangefeedCleaned atomic.Bool
 	// removeChangefeedCleanupRunning prevents duplicate background cleanup runs
-	// while retries keep asking for remove semantics after the base close path ends.
+	// while late remove requests or retries keep asking for remove semantics after
+	// the base close path ends.
 	removeChangefeedCleanupRunning atomic.Bool
 	cancel                         context.CancelFunc
 	wg                             sync.WaitGroup
@@ -851,10 +853,11 @@ func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
 		e.removeChangefeedRequested.Store(true)
 	}
 	if e.closed.Load() {
-		return e.tryScheduleRemoveChangefeedCleanup()
+		e.tryScheduleRemoveChangefeedCleanup()
+		return true
 	}
 	if e.closing.Load() {
-		return false
+		return e.closed.Load()
 	}
 
 	e.closing.Store(true)
@@ -935,15 +938,15 @@ func (e *DispatcherManager) close() {
 		zap.Stringer("changefeedID", e.changefeedID))
 }
 
-func (e *DispatcherManager) tryScheduleRemoveChangefeedCleanup() bool {
+func (e *DispatcherManager) tryScheduleRemoveChangefeedCleanup() {
 	if !e.removeChangefeedRequested.Load() {
-		return true
+		return
 	}
 	if e.removeChangefeedCleaned.Load() {
-		return true
+		return
 	}
 	if !e.removeChangefeedCleanupRunning.CompareAndSwap(false, true) {
-		return false
+		return
 	}
 
 	go func() {
@@ -957,7 +960,6 @@ func (e *DispatcherManager) tryScheduleRemoveChangefeedCleanup() bool {
 		}
 		e.removeChangefeedCleaned.Store(true)
 	}()
-	return false
 }
 
 func (e *DispatcherManager) runRemoveChangefeedCleanup() error {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -133,8 +133,14 @@ type DispatcherManager struct {
 
 	closing atomic.Bool
 	closed  atomic.Bool
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
+	// removeChangefeedRequested is sticky once any close request asks for removed=true.
+	// A later removed=false request must not downgrade the final cleanup semantics.
+	removeChangefeedRequested atomic.Bool
+	// removeChangefeedCleaned records whether the remove-only cleanup has finished.
+	// closed=true only means the base close path completed; remove cleanup may still be pending.
+	removeChangefeedCleaned atomic.Bool
+	cancel                  context.CancelFunc
+	wg                      sync.WaitGroup
 
 	// removeTaskHandles stores the task handles for async dispatcher removal
 	// map[common.DispatcherID]*threadpool.TaskHandle
@@ -838,19 +844,25 @@ func (e *DispatcherManager) mergeEventDispatcher(dispatcherIDs []common.Dispatch
 // ==== remove and clean related functions ====
 
 func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
+	if removeChangefeed {
+		e.removeChangefeedRequested.Store(true)
+	}
 	if e.closed.Load() {
-		return true
+		if !e.cleanupRemovedChangefeed() {
+			return false
+		}
+		return e.isCloseComplete()
 	}
 	if e.closing.Load() {
-		return e.closed.Load()
+		return false
 	}
 
 	e.closing.Store(true)
-	go e.close(removeChangefeed)
+	go e.close()
 	return false
 }
 
-func (e *DispatcherManager) close(removeChangefeed bool) {
+func (e *DispatcherManager) close() {
 	log.Info("closing event dispatcher manager",
 		zap.Stringer("changefeedID", e.changefeedID))
 
@@ -902,12 +914,15 @@ func (e *DispatcherManager) close(removeChangefeed bool) {
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
 	if e.IsRedoEnabled() {
-		e.redoSink.Close(removeChangefeed)
-		// FIXME: cleanup redo log when remove the changefeed
-		e.closeRedoMeta(removeChangefeed)
+		e.redoSink.Close(false)
 	}
-	e.sink.Close(removeChangefeed)
+	e.sink.Close(false)
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
+
+	if !e.cleanupRemovedChangefeed() {
+		log.Warn("remove changefeed cleanup is not finished during close",
+			zap.Stringer("changefeedID", e.changefeedID))
+	}
 
 	e.wg.Wait()
 
@@ -922,6 +937,36 @@ func (e *DispatcherManager) close(removeChangefeed bool) {
 	e.closed.Store(true)
 	log.Info("event dispatcher manager closed",
 		zap.Stringer("changefeedID", e.changefeedID))
+}
+
+func (e *DispatcherManager) isCloseComplete() bool {
+	return e.closed.Load() && (!e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load())
+}
+
+func (e *DispatcherManager) cleanupRemovedChangefeed() bool {
+	if !e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load() {
+		return true
+	}
+
+	if e.IsRedoEnabled() {
+		// Redo meta cleanup is the remove-only step for redo mode. It is safe to retry
+		// because Cleanup() is guarded by the removeChangefeedCleaned flag below.
+		e.closeRedoMeta(true)
+	}
+
+	if cleaner, ok := e.sink.(interface{ CleanupRemovedChangefeed() error }); ok {
+		// Some sinks need extra remove-only cleanup after the common close path has
+		// already released shared resources. Keep that step explicit and retryable.
+		if err := cleaner.CleanupRemovedChangefeed(); err != nil {
+			log.Warn("failed to cleanup removed changefeed",
+				zap.Stringer("changefeedID", e.changefeedID),
+				zap.Error(err))
+			return false
+		}
+	}
+
+	e.removeChangefeedCleaned.Store(true)
+	return true
 }
 
 // cleanEventDispatcher is called when the event dispatcher is removed successfully.

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -136,11 +136,8 @@ type DispatcherManager struct {
 	// removeChangefeedRequested is sticky once any close request asks for removed=true.
 	// A later removed=false request must not downgrade the final cleanup semantics.
 	removeChangefeedRequested atomic.Bool
-	// removeChangefeedCleaned records whether the remove-only cleanup has finished.
-	// closed=true only means the base close path completed; remove cleanup may still be pending.
-	removeChangefeedCleaned atomic.Bool
-	cancel                  context.CancelFunc
-	wg                      sync.WaitGroup
+	cancel                    context.CancelFunc
+	wg                        sync.WaitGroup
 
 	// removeTaskHandles stores the task handles for async dispatcher removal
 	// map[common.DispatcherID]*threadpool.TaskHandle
@@ -848,10 +845,7 @@ func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
 		e.removeChangefeedRequested.Store(true)
 	}
 	if e.closed.Load() {
-		if !e.cleanupRemovedChangefeed() {
-			return false
-		}
-		return e.isCloseComplete()
+		return e.finishClose()
 	}
 	if e.closing.Load() {
 		return false
@@ -914,12 +908,16 @@ func (e *DispatcherManager) close() {
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
 	if e.IsRedoEnabled() {
-		e.redoSink.Close(false)
+		_ = e.redoSink.Close(false)
 	}
-	e.sink.Close(false)
+	removeChangefeed := e.removeChangefeedRequested.Load()
+	sinkClosed := e.sink.Close(removeChangefeed)
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
 
-	if !e.cleanupRemovedChangefeed() {
+	if removeChangefeed && e.IsRedoEnabled() {
+		e.closeRedoMeta(true)
+	}
+	if !sinkClosed {
 		log.Warn("remove changefeed cleanup is not finished during close",
 			zap.Stringer("changefeedID", e.changefeedID))
 	}
@@ -939,34 +937,15 @@ func (e *DispatcherManager) close() {
 		zap.Stringer("changefeedID", e.changefeedID))
 }
 
-func (e *DispatcherManager) isCloseComplete() bool {
-	return e.closed.Load() && (!e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load())
-}
-
-func (e *DispatcherManager) cleanupRemovedChangefeed() bool {
-	if !e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load() {
-		return true
-	}
-
-	if e.IsRedoEnabled() {
-		// Redo meta cleanup is the remove-only step for redo mode. It is safe to retry
-		// because Cleanup() is guarded by the removeChangefeedCleaned flag below.
+// finishClose replays any sticky remove semantics after the async close path has
+// finished. This keeps remove-only cleanup retryable without a separate manager
+// cleanup state machine for the regular sink.
+func (e *DispatcherManager) finishClose() bool {
+	removeChangefeed := e.removeChangefeedRequested.Load()
+	if removeChangefeed && e.IsRedoEnabled() {
 		e.closeRedoMeta(true)
 	}
-
-	if cleaner, ok := e.sink.(interface{ CleanupRemovedChangefeed() error }); ok {
-		// Some sinks need extra remove-only cleanup after the common close path has
-		// already released shared resources. Keep that step explicit and retryable.
-		if err := cleaner.CleanupRemovedChangefeed(); err != nil {
-			log.Warn("failed to cleanup removed changefeed",
-				zap.Stringer("changefeedID", e.changefeedID),
-				zap.Error(err))
-			return false
-		}
-	}
-
-	e.removeChangefeedCleaned.Store(true)
-	return true
+	return e.sink.Close(removeChangefeed)
 }
 
 // cleanEventDispatcher is called when the event dispatcher is removed successfully.

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -947,10 +947,10 @@ func (e *DispatcherManager) cleanupRemovedChangefeed() bool {
 		e.closeRedoMeta(true)
 	}
 
-	if cleaner, ok := e.sink.(sink.RemoveChangefeedCleaner); ok {
-		// Some sinks need an explicit remove-only cleanup step after the normal close path
-		// has already released shared resources. Keep the boundary explicit and retryable.
-		if err := cleaner.CleanupRemovedChangefeed(); err != nil {
+	if mysqlSink, ok := e.sink.(*mysql.Sink); ok {
+		// MySQL sink may still need ddl_ts cleanup after the base close path has already
+		// released the long-lived DB connection, so keep the retryable remove step here.
+		if err := mysqlSink.CleanupRemovedChangefeed(); err != nil {
 			log.Warn("failed to cleanup removed changefeed",
 				zap.Stringer("changefeedID", e.changefeedID),
 				zap.Error(err))

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -136,8 +136,11 @@ type DispatcherManager struct {
 	// removeChangefeedRequested is sticky once any close request asks for removed=true.
 	// A later removed=false request must not downgrade the final cleanup semantics.
 	removeChangefeedRequested atomic.Bool
-	cancel                    context.CancelFunc
-	wg                        sync.WaitGroup
+	// removeChangefeedCleaned records whether the remove-only cleanup has finished.
+	// closed=true only means the base close path completed; remove cleanup may still be pending.
+	removeChangefeedCleaned atomic.Bool
+	cancel                  context.CancelFunc
+	wg                      sync.WaitGroup
 
 	// removeTaskHandles stores the task handles for async dispatcher removal
 	// map[common.DispatcherID]*threadpool.TaskHandle
@@ -845,7 +848,10 @@ func (e *DispatcherManager) TryClose(removeChangefeed bool) bool {
 		e.removeChangefeedRequested.Store(true)
 	}
 	if e.closed.Load() {
-		return e.finishClose()
+		if !e.cleanupRemovedChangefeed() {
+			return false
+		}
+		return e.isCloseComplete()
 	}
 	if e.closing.Load() {
 		return false
@@ -908,16 +914,12 @@ func (e *DispatcherManager) close() {
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
 	if e.IsRedoEnabled() {
-		_ = e.redoSink.Close(false)
+		e.redoSink.Close(false)
 	}
-	removeChangefeed := e.removeChangefeedRequested.Load()
-	sinkClosed := e.sink.Close(removeChangefeed)
+	e.sink.Close(false)
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
 
-	if removeChangefeed && e.IsRedoEnabled() {
-		e.closeRedoMeta(true)
-	}
-	if !sinkClosed {
+	if !e.cleanupRemovedChangefeed() {
 		log.Warn("remove changefeed cleanup is not finished during close",
 			zap.Stringer("changefeedID", e.changefeedID))
 	}
@@ -937,15 +939,34 @@ func (e *DispatcherManager) close() {
 		zap.Stringer("changefeedID", e.changefeedID))
 }
 
-// finishClose replays any sticky remove semantics after the async close path has
-// finished. This keeps remove-only cleanup retryable without a separate manager
-// cleanup state machine for the regular sink.
-func (e *DispatcherManager) finishClose() bool {
-	removeChangefeed := e.removeChangefeedRequested.Load()
-	if removeChangefeed && e.IsRedoEnabled() {
+func (e *DispatcherManager) isCloseComplete() bool {
+	return e.closed.Load() && (!e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load())
+}
+
+func (e *DispatcherManager) cleanupRemovedChangefeed() bool {
+	if !e.removeChangefeedRequested.Load() || e.removeChangefeedCleaned.Load() {
+		return true
+	}
+
+	if e.IsRedoEnabled() {
+		// Redo meta cleanup is the remove-only step for redo mode. It is safe to retry
+		// because removeChangefeedCleaned is only set after all remove-only cleanup succeeds.
 		e.closeRedoMeta(true)
 	}
-	return e.sink.Close(removeChangefeed)
+
+	if cleaner, ok := e.sink.(sink.RemoveChangefeedCleaner); ok {
+		// Some sinks need an explicit remove-only cleanup step after the normal close path
+		// has already released shared resources. Keep the boundary explicit and retryable.
+		if err := cleaner.CleanupRemovedChangefeed(); err != nil {
+			log.Warn("failed to cleanup removed changefeed",
+				zap.Stringer("changefeedID", e.changefeedID),
+				zap.Error(err))
+			return false
+		}
+	}
+
+	e.removeChangefeedCleaned.Store(true)
+	return true
 }
 
 // cleanEventDispatcher is called when the event dispatcher is removed successfully.

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -917,9 +917,9 @@ func (e *DispatcherManager) close() {
 	log.Info("shared info closed", zap.Stringer("changefeedID", e.changefeedID))
 
 	if e.IsRedoEnabled() {
-		e.redoSink.Close(false)
+		e.redoSink.Close()
 	}
-	e.sink.Close(false)
+	e.sink.Close()
 	log.Info("sink closed", zap.Stringer("changefeedID", e.changefeedID))
 
 	e.wg.Wait()

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_redo.go
@@ -257,16 +257,19 @@ func (e *DispatcherManager) cleanRedoDispatcher(id common.DispatcherID, schemaID
 	)
 }
 
-func (e *DispatcherManager) closeRedoMeta(removeChangefeed bool) {
+func (e *DispatcherManager) closeRedoMeta(removeChangefeed bool) error {
 	if d := e.GetTableTriggerRedoDispatcher(); d != nil {
 		redoMeta := d.GetRedoMeta()
 		if redoMeta != nil {
 			redoMeta.CleanupMetrics()
 			if removeChangefeed {
-				redoMeta.Cleanup(context.Background())
+				if err := redoMeta.Cleanup(context.Background()); err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 	}
+	return nil
 }
 
 func (e *DispatcherManager) InitalizeTableTriggerRedoDispatcher(schemaInfo []*heartbeatpb.SchemaInfo) error {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -38,6 +38,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type closeTrackingSink struct {
+	closeCalls   []bool
+	cleanupCalls int
+}
+
+func (s *closeTrackingSink) SinkType() common.SinkType {
+	return common.BlackHoleSinkType
+}
+
+func (s *closeTrackingSink) IsNormal() bool {
+	return true
+}
+
+func (s *closeTrackingSink) AddDMLEvent(_ *event.DMLEvent) {}
+
+func (s *closeTrackingSink) FlushDMLBeforeBlock(_ event.BlockEvent) error {
+	return nil
+}
+
+func (s *closeTrackingSink) WriteBlockEvent(event.BlockEvent) error {
+	return nil
+}
+
+func (s *closeTrackingSink) AddCheckpointTs(uint64) {}
+
+func (s *closeTrackingSink) SetTableSchemaStore(_ *event.TableSchemaStore) {}
+
+func (s *closeTrackingSink) Close(removeChangefeed bool) {
+	s.closeCalls = append(s.closeCalls, removeChangefeed)
+}
+
+func (s *closeTrackingSink) Run(context.Context) error {
+	return nil
+}
+
+func (s *closeTrackingSink) BatchCount() int {
+	return 0
+}
+
+func (s *closeTrackingSink) BatchBytes() int {
+	return 0
+}
+
+func (s *closeTrackingSink) CleanupRemovedChangefeed() error {
+	s.cleanupCalls++
+	return nil
+}
+
 func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.Sink {
 	t.Helper()
 
@@ -268,6 +316,29 @@ func TestMergeDispatcherInvalidIDs(t *testing.T) {
 	// Verify no new dispatcher is created
 	_, exists := manager.dispatcherMap.Get(mergedID)
 	require.False(t, exists)
+}
+
+func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
+	trackingSink := &closeTrackingSink{}
+	manager := &DispatcherManager{
+		changefeedID:            common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName),
+		dispatcherMap:           newDispatcherMap[*dispatcher.EventDispatcher](),
+		heartbeatRequestQueue:   NewHeartbeatRequestQueue(),
+		blockStatusRequestQueue: NewBlockStatusRequestQueue(),
+		sink:                    trackingSink,
+		schemaIDToDispatchers:   dispatcher.NewSchemaIDToDispatchers(),
+		latestWatermark:         NewWatermark(0),
+		latestRedoWatermark:     NewWatermark(0),
+		config: &config.ChangefeedConfig{
+			BDRMode: true,
+		},
+	}
+	manager.closed.Store(true)
+
+	closed := manager.TryClose(true)
+	require.True(t, closed)
+	require.Empty(t, trackingSink.closeCalls)
+	require.Equal(t, 1, trackingSink.cleanupCalls)
 }
 
 func TestMergeDispatcherExistingID(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -39,8 +39,8 @@ import (
 )
 
 type closeTrackingSink struct {
-	closeCalls  []bool
-	closeResult bool
+	closeCalls   []bool
+	cleanupCalls int
 }
 
 func (s *closeTrackingSink) SinkType() common.SinkType {
@@ -65,9 +65,8 @@ func (s *closeTrackingSink) AddCheckpointTs(uint64) {}
 
 func (s *closeTrackingSink) SetTableSchemaStore(_ *event.TableSchemaStore) {}
 
-func (s *closeTrackingSink) Close(removeChangefeed bool) bool {
+func (s *closeTrackingSink) Close(removeChangefeed bool) {
 	s.closeCalls = append(s.closeCalls, removeChangefeed)
-	return s.closeResult
 }
 
 func (s *closeTrackingSink) Run(context.Context) error {
@@ -80,6 +79,11 @@ func (s *closeTrackingSink) BatchCount() int {
 
 func (s *closeTrackingSink) BatchBytes() int {
 	return 0
+}
+
+func (s *closeTrackingSink) CleanupRemovedChangefeed() error {
+	s.cleanupCalls++
+	return nil
 }
 
 func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.Sink {
@@ -97,7 +101,7 @@ func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.S
 	}).AnyTimes()
 	mockSink.EXPECT().AddCheckpointTs(gomock.Any()).AnyTimes()
 	mockSink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
-	mockSink.EXPECT().Close(gomock.Any()).Return(true).AnyTimes()
+	mockSink.EXPECT().Close(gomock.Any()).AnyTimes()
 	mockSink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return mockSink
 }
@@ -314,8 +318,8 @@ func TestMergeDispatcherInvalidIDs(t *testing.T) {
 	require.False(t, exists)
 }
 
-func TestTryCloseRemovedRequestAfterClosedUpgradesSinkClose(t *testing.T) {
-	trackingSink := &closeTrackingSink{closeResult: true}
+func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
+	trackingSink := &closeTrackingSink{}
 	manager := &DispatcherManager{
 		changefeedID:            common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName),
 		dispatcherMap:           newDispatcherMap[*dispatcher.EventDispatcher](),
@@ -333,7 +337,8 @@ func TestTryCloseRemovedRequestAfterClosedUpgradesSinkClose(t *testing.T) {
 
 	closed := manager.TryClose(true)
 	require.True(t, closed)
-	require.Equal(t, []bool{true}, trackingSink.closeCalls)
+	require.Empty(t, trackingSink.closeCalls)
+	require.Equal(t, 1, trackingSink.cleanupCalls)
 }
 
 func TestMergeDispatcherExistingID(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -292,9 +292,12 @@ func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
 	manager.closed.Store(true)
 
 	closed := manager.TryClose(true)
-	require.True(t, closed)
+	require.False(t, closed)
 	require.True(t, manager.removeChangefeedRequested.Load())
-	require.True(t, manager.removeChangefeedCleaned.Load())
+	require.Eventually(t, func() bool {
+		return manager.removeChangefeedCleaned.Load()
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, manager.TryClose(true))
 }
 
 func TestMergeDispatcherExistingID(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -272,7 +272,7 @@ func TestMergeDispatcherInvalidIDs(t *testing.T) {
 	require.False(t, exists)
 }
 
-func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
+func TestTryCloseRemovedRequestAfterClosedReturnsImmediatelyAndTriggersCleanup(t *testing.T) {
 	changefeedID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
 	mysqlConfig := mysqlcfg.New()
 	mysqlConfig.EnableDDLTs = false
@@ -291,8 +291,10 @@ func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
 	}
 	manager.closed.Store(true)
 
+	// Preserve the historical close contract: once the manager is already closed,
+	// late remove requests should not delay TryClose success.
 	closed := manager.TryClose(true)
-	require.False(t, closed)
+	require.True(t, closed)
 	require.True(t, manager.removeChangefeedRequested.Load())
 	require.Eventually(t, func() bool {
 		return manager.removeChangefeedCleaned.Load()

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -39,8 +39,8 @@ import (
 )
 
 type closeTrackingSink struct {
-	closeCalls   []bool
-	cleanupCalls int
+	closeCalls  []bool
+	closeResult bool
 }
 
 func (s *closeTrackingSink) SinkType() common.SinkType {
@@ -65,8 +65,9 @@ func (s *closeTrackingSink) AddCheckpointTs(uint64) {}
 
 func (s *closeTrackingSink) SetTableSchemaStore(_ *event.TableSchemaStore) {}
 
-func (s *closeTrackingSink) Close(removeChangefeed bool) {
+func (s *closeTrackingSink) Close(removeChangefeed bool) bool {
 	s.closeCalls = append(s.closeCalls, removeChangefeed)
+	return s.closeResult
 }
 
 func (s *closeTrackingSink) Run(context.Context) error {
@@ -79,11 +80,6 @@ func (s *closeTrackingSink) BatchCount() int {
 
 func (s *closeTrackingSink) BatchBytes() int {
 	return 0
-}
-
-func (s *closeTrackingSink) CleanupRemovedChangefeed() error {
-	s.cleanupCalls++
-	return nil
 }
 
 func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.Sink {
@@ -101,7 +97,7 @@ func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.S
 	}).AnyTimes()
 	mockSink.EXPECT().AddCheckpointTs(gomock.Any()).AnyTimes()
 	mockSink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
-	mockSink.EXPECT().Close(gomock.Any()).AnyTimes()
+	mockSink.EXPECT().Close(gomock.Any()).Return(true).AnyTimes()
 	mockSink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return mockSink
 }
@@ -318,8 +314,8 @@ func TestMergeDispatcherInvalidIDs(t *testing.T) {
 	require.False(t, exists)
 }
 
-func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
-	trackingSink := &closeTrackingSink{}
+func TestTryCloseRemovedRequestAfterClosedUpgradesSinkClose(t *testing.T) {
+	trackingSink := &closeTrackingSink{closeResult: true}
 	manager := &DispatcherManager{
 		changefeedID:            common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName),
 		dispatcherMap:           newDispatcherMap[*dispatcher.EventDispatcher](),
@@ -337,8 +333,7 @@ func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
 
 	closed := manager.TryClose(true)
 	require.True(t, closed)
-	require.Empty(t, trackingSink.closeCalls)
-	require.Equal(t, 1, trackingSink.cleanupCalls)
+	require.Equal(t, []bool{true}, trackingSink.closeCalls)
 }
 
 func TestMergeDispatcherExistingID(t *testing.T) {

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -55,7 +55,7 @@ func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.S
 	}).AnyTimes()
 	mockSink.EXPECT().AddCheckpointTs(gomock.Any()).AnyTimes()
 	mockSink.EXPECT().SetTableSchemaStore(gomock.Any()).AnyTimes()
-	mockSink.EXPECT().Close(gomock.Any()).AnyTimes()
+	mockSink.EXPECT().Close().AnyTimes()
 	mockSink.EXPECT().Run(gomock.Any()).Return(nil).AnyTimes()
 	return mockSink
 }

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/ticdc/downstreamadapter/eventcollector"
 	"github.com/pingcap/ticdc/downstreamadapter/sink"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/mock"
+	"github.com/pingcap/ticdc/downstreamadapter/sink/mysql"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	appcontext "github.com/pingcap/ticdc/pkg/common/context"
@@ -33,58 +34,11 @@ import (
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
+	mysqlcfg "github.com/pingcap/ticdc/pkg/sink/mysql"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/utils/threadpool"
 	"github.com/stretchr/testify/require"
 )
-
-type closeTrackingSink struct {
-	closeCalls   []bool
-	cleanupCalls int
-}
-
-func (s *closeTrackingSink) SinkType() common.SinkType {
-	return common.BlackHoleSinkType
-}
-
-func (s *closeTrackingSink) IsNormal() bool {
-	return true
-}
-
-func (s *closeTrackingSink) AddDMLEvent(_ *event.DMLEvent) {}
-
-func (s *closeTrackingSink) FlushDMLBeforeBlock(_ event.BlockEvent) error {
-	return nil
-}
-
-func (s *closeTrackingSink) WriteBlockEvent(event.BlockEvent) error {
-	return nil
-}
-
-func (s *closeTrackingSink) AddCheckpointTs(uint64) {}
-
-func (s *closeTrackingSink) SetTableSchemaStore(_ *event.TableSchemaStore) {}
-
-func (s *closeTrackingSink) Close(removeChangefeed bool) {
-	s.closeCalls = append(s.closeCalls, removeChangefeed)
-}
-
-func (s *closeTrackingSink) Run(context.Context) error {
-	return nil
-}
-
-func (s *closeTrackingSink) BatchCount() int {
-	return 0
-}
-
-func (s *closeTrackingSink) BatchBytes() int {
-	return 0
-}
-
-func (s *closeTrackingSink) CleanupRemovedChangefeed() error {
-	s.cleanupCalls++
-	return nil
-}
 
 func newDispatcherManagerTestSink(t *testing.T, sinkType common.SinkType) sink.Sink {
 	t.Helper()
@@ -319,26 +273,28 @@ func TestMergeDispatcherInvalidIDs(t *testing.T) {
 }
 
 func TestTryCloseRemovedRequestAfterClosedTriggersCleanup(t *testing.T) {
-	trackingSink := &closeTrackingSink{}
+	changefeedID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+	mysqlConfig := mysqlcfg.New()
+	mysqlConfig.EnableDDLTs = false
+	mysqlSink := mysql.NewMySQLSink(
+		context.Background(),
+		changefeedID,
+		mysqlConfig,
+		nil,
+		false,
+		false,
+		time.Minute,
+	)
 	manager := &DispatcherManager{
-		changefeedID:            common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName),
-		dispatcherMap:           newDispatcherMap[*dispatcher.EventDispatcher](),
-		heartbeatRequestQueue:   NewHeartbeatRequestQueue(),
-		blockStatusRequestQueue: NewBlockStatusRequestQueue(),
-		sink:                    trackingSink,
-		schemaIDToDispatchers:   dispatcher.NewSchemaIDToDispatchers(),
-		latestWatermark:         NewWatermark(0),
-		latestRedoWatermark:     NewWatermark(0),
-		config: &config.ChangefeedConfig{
-			BDRMode: true,
-		},
+		changefeedID: changefeedID,
+		sink:         mysqlSink,
 	}
 	manager.closed.Store(true)
 
 	closed := manager.TryClose(true)
 	require.True(t, closed)
-	require.Empty(t, trackingSink.closeCalls)
-	require.Equal(t, 1, trackingSink.cleanupCalls)
+	require.True(t, manager.removeChangefeedRequested.Load())
+	require.True(t, manager.removeChangefeedCleaned.Load())
 }
 
 func TestMergeDispatcherExistingID(t *testing.T) {

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -119,7 +119,7 @@ func getPendingMessageKey(msg *messaging.TargetMessage) (pendingMessageKey, bool
 // handleMessages processes messages from the queue
 func (m *DispatcherOrchestrator) handleMessages() {
 	for {
-		_, msg, ok := m.msgQueue.Pop()
+		msg, ok := m.msgQueue.Pop()
 		if !ok {
 			log.Info("dispatcher orchestrator is shutting down, exit handleMessages")
 			return

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator.go
@@ -119,12 +119,11 @@ func getPendingMessageKey(msg *messaging.TargetMessage) (pendingMessageKey, bool
 // handleMessages processes messages from the queue
 func (m *DispatcherOrchestrator) handleMessages() {
 	for {
-		key, ok := m.msgQueue.Pop()
+		_, msg, ok := m.msgQueue.Pop()
 		if !ok {
 			log.Info("dispatcher orchestrator is shutting down, exit handleMessages")
 			return
 		}
-		msg := m.msgQueue.Get(key)
 
 		// Process the message
 		switch req := msg.Message[0].(type) {
@@ -146,8 +145,6 @@ func (m *DispatcherOrchestrator) handleMessages() {
 				zap.String("type", msg.Type.String()),
 				zap.Any("message", msg.Message))
 		}
-
-		m.msgQueue.Done(key)
 	}
 }
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -14,6 +14,7 @@
 package dispatcherorchestrator
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -153,7 +154,7 @@ func TestPendingMessageQueue_PopKeepsStateShapeForNextRetry(t *testing.T) {
 	state := q.pending[key]
 	q.mu.Unlock()
 	require.NotNil(t, state)
-	require.Nil(t, state.inFlight)
+	require.Equal(t, 1, reflect.TypeOf(*state).NumField())
 	require.Same(t, msg2, state.queued)
 }
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPendingMessageQueue_TryEnqueueDropsDuplicatesUntilDone(t *testing.T) {
+func TestPendingMessageQueue_TryEnqueueDropsDuplicatesOnlyWhileQueued(t *testing.T) {
 	t.Parallel()
 
 	q := newPendingMessageQueue()
@@ -42,10 +42,17 @@ func TestPendingMessageQueue_TryEnqueueDropsDuplicatesUntilDone(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, key, poppedKey)
 
-	// The key remains pending while being processed.
+	// Once the request is already in-flight, allow one queued retry for the next round.
+	require.True(t, q.TryEnqueue(key, msg))
 	require.False(t, q.TryEnqueue(key, msg))
 
 	q.Done(key)
+
+	nextKey, ok := q.Pop()
+	require.True(t, ok)
+	require.Equal(t, key, nextKey)
+	q.Done(nextKey)
+
 	require.True(t, q.TryEnqueue(key, msg))
 }
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -38,18 +38,16 @@ func TestPendingMessageQueue_TryEnqueueDropsDuplicatesOnlyWhileQueued(t *testing
 	require.True(t, q.TryEnqueue(key, msg))
 	require.False(t, q.TryEnqueue(key, msg))
 
-	poppedKey, poppedMsg, ok := q.Pop()
+	poppedMsg, ok := q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key, poppedKey)
 	require.Same(t, msg, poppedMsg)
 
 	// Once the request is popped, allow one queued retry for the next round.
 	require.True(t, q.TryEnqueue(key, msg))
 	require.False(t, q.TryEnqueue(key, msg))
 
-	nextKey, nextMsg, ok := q.Pop()
+	nextMsg, ok := q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key, nextKey)
 	require.Same(t, msg, nextMsg)
 
 	require.True(t, q.TryEnqueue(key, msg))
@@ -68,14 +66,12 @@ func TestPendingMessageQueue_OrderPreservedAcrossKeys(t *testing.T) {
 	require.True(t, q.TryEnqueue(key1, &messaging.TargetMessage{Type: key1.msgType}))
 	require.True(t, q.TryEnqueue(key2, &messaging.TargetMessage{Type: key2.msgType}))
 
-	poppedKey, poppedMsg, ok := q.Pop()
+	poppedMsg, ok := q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key1, poppedKey)
 	require.Equal(t, key1.msgType, poppedMsg.Type)
 
-	poppedKey, poppedMsg, ok = q.Pop()
+	poppedMsg, ok = q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key2, poppedKey)
 	require.Equal(t, key2.msgType, poppedMsg.Type)
 }
 
@@ -85,7 +81,7 @@ func TestPendingMessageQueue_PopReturnsAfterClose(t *testing.T) {
 	q := newPendingMessageQueue()
 	doneCh := make(chan bool, 1)
 	go func() {
-		_, _, ok := q.Pop()
+		_, ok := q.Pop()
 		doneCh <- ok
 	}()
 
@@ -124,9 +120,8 @@ func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *tes
 	require.True(t, q.TryEnqueue(key, msgFalse))
 	require.True(t, q.TryEnqueue(key, msgTrue))
 
-	poppedKey, poppedMsg, ok := q.Pop()
+	poppedMsg, ok := q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key, poppedKey)
 	require.NotNil(t, poppedMsg)
 	req := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
 	require.True(t, req.Removed)
@@ -154,9 +149,8 @@ func TestPendingMessageQueue_CloseRequestUpgradeAfterPopKeepsReturnedMessageStab
 	)
 
 	require.True(t, q.TryEnqueue(key, msgFalse))
-	poppedKey, poppedMsg, ok := q.Pop()
+	poppedMsg, ok := q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key, poppedKey)
 	require.NotNil(t, poppedMsg)
 
 	require.True(t, q.TryEnqueue(key, msgTrue))
@@ -187,9 +181,8 @@ func TestPendingMessageQueue_CloseRequestUpgradeAfterPopRequeuesNextRound(t *tes
 
 	require.True(t, q.TryEnqueue(key, msgFalse))
 
-	poppedKey, poppedMsg, ok := q.Pop()
+	poppedMsg, ok := q.Pop()
 	require.True(t, ok)
-	require.Equal(t, key, poppedKey)
 
 	require.NotNil(t, poppedMsg)
 	req := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
@@ -198,20 +191,18 @@ func TestPendingMessageQueue_CloseRequestUpgradeAfterPopRequeuesNextRound(t *tes
 	require.True(t, q.TryEnqueue(key, msgTrue))
 
 	type popResult struct {
-		key pendingMessageKey
 		msg *messaging.TargetMessage
 		ok  bool
 	}
 	resultCh := make(chan popResult, 1)
 	go func() {
-		nextKey, nextMsg, nextOK := q.Pop()
-		resultCh <- popResult{key: nextKey, msg: nextMsg, ok: nextOK}
+		nextMsg, nextOK := q.Pop()
+		resultCh <- popResult{msg: nextMsg, ok: nextOK}
 	}()
 
 	select {
 	case result := <-resultCh:
 		require.True(t, result.ok)
-		require.Equal(t, key, result.key)
 		require.NotNil(t, result.msg)
 		nextReq := result.msg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
 		require.True(t, nextReq.Removed)

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -38,20 +38,19 @@ func TestPendingMessageQueue_TryEnqueueDropsDuplicatesOnlyWhileQueued(t *testing
 	require.True(t, q.TryEnqueue(key, msg))
 	require.False(t, q.TryEnqueue(key, msg))
 
-	poppedKey, ok := q.Pop()
+	poppedKey, poppedMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key, poppedKey)
+	require.Same(t, msg, poppedMsg)
 
-	// Once the request is already in-flight, allow one queued retry for the next round.
+	// Once the request is popped, allow one queued retry for the next round.
 	require.True(t, q.TryEnqueue(key, msg))
 	require.False(t, q.TryEnqueue(key, msg))
 
-	q.Done(key)
-
-	nextKey, ok := q.Pop()
+	nextKey, nextMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key, nextKey)
-	q.Done(nextKey)
+	require.Same(t, msg, nextMsg)
 
 	require.True(t, q.TryEnqueue(key, msg))
 }
@@ -69,15 +68,15 @@ func TestPendingMessageQueue_OrderPreservedAcrossKeys(t *testing.T) {
 	require.True(t, q.TryEnqueue(key1, &messaging.TargetMessage{Type: key1.msgType}))
 	require.True(t, q.TryEnqueue(key2, &messaging.TargetMessage{Type: key2.msgType}))
 
-	poppedKey, ok := q.Pop()
+	poppedKey, poppedMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key1, poppedKey)
-	q.Done(poppedKey)
+	require.Equal(t, key1.msgType, poppedMsg.Type)
 
-	poppedKey, ok = q.Pop()
+	poppedKey, poppedMsg, ok = q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key2, poppedKey)
-	q.Done(poppedKey)
+	require.Equal(t, key2.msgType, poppedMsg.Type)
 }
 
 func TestPendingMessageQueue_PopReturnsAfterClose(t *testing.T) {
@@ -86,7 +85,7 @@ func TestPendingMessageQueue_PopReturnsAfterClose(t *testing.T) {
 	q := newPendingMessageQueue()
 	doneCh := make(chan bool, 1)
 	go func() {
-		_, ok := q.Pop()
+		_, _, ok := q.Pop()
 		doneCh <- ok
 	}()
 
@@ -118,44 +117,10 @@ func TestPendingMessageQueue_PopSkipsStaleKey(t *testing.T) {
 	q.queue.Push(staleKey)
 	require.True(t, q.TryEnqueue(validKey, validMsg))
 
-	poppedKey, ok := q.Pop()
+	poppedKey, poppedMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, validKey, poppedKey)
-	require.Same(t, validMsg, q.Get(poppedKey))
-	q.Done(poppedKey)
-}
-
-func TestPendingMessageQueue_GetOnlyReturnsInFlightMessage(t *testing.T) {
-	t.Parallel()
-
-	q := newPendingMessageQueue()
-	cfID := common.NewChangeFeedIDWithName("cf", "default")
-	key := pendingMessageKey{
-		changefeedID: cfID,
-		msgType:      messaging.TypeMaintainerBootstrapRequest,
-	}
-	msg1 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
-	msg2 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
-
-	require.True(t, q.TryEnqueue(key, msg1))
-	require.Nil(t, q.Get(key))
-
-	poppedKey, ok := q.Pop()
-	require.True(t, ok)
-	require.Equal(t, key, poppedKey)
-	require.Same(t, msg1, q.Get(key))
-
-	require.True(t, q.TryEnqueue(key, msg2))
-	require.Same(t, msg1, q.Get(key))
-
-	q.Done(key)
-	require.Nil(t, q.Get(key))
-
-	nextKey, ok := q.Pop()
-	require.True(t, ok)
-	require.Equal(t, key, nextKey)
-	require.Same(t, msg2, q.Get(key))
-	q.Done(key)
+	require.Same(t, validMsg, poppedMsg)
 }
 
 func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *testing.T) {
@@ -182,17 +147,15 @@ func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *tes
 	require.True(t, q.TryEnqueue(key, msgFalse))
 	require.True(t, q.TryEnqueue(key, msgTrue))
 
-	poppedKey, ok := q.Pop()
+	poppedKey, poppedMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key, poppedKey)
-	poppedMsg := q.Get(poppedKey)
 	require.NotNil(t, poppedMsg)
 	req := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
 	require.True(t, req.Removed)
-	q.Done(key)
 }
 
-func TestPendingMessageQueue_CloseRequestUpgradeBetweenPopAndGetKeepsInFlightStable(t *testing.T) {
+func TestPendingMessageQueue_CloseRequestUpgradeAfterPopKeepsReturnedMessageStable(t *testing.T) {
 	t.Parallel()
 
 	q := newPendingMessageQueue()
@@ -214,19 +177,17 @@ func TestPendingMessageQueue_CloseRequestUpgradeBetweenPopAndGetKeepsInFlightSta
 	)
 
 	require.True(t, q.TryEnqueue(key, msgFalse))
-	poppedKey, ok := q.Pop()
+	poppedKey, poppedMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key, poppedKey)
+	require.NotNil(t, poppedMsg)
 
 	require.True(t, q.TryEnqueue(key, msgTrue))
-	poppedMsg := q.Get(poppedKey)
-	require.NotNil(t, poppedMsg)
 	req2 := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
 	require.False(t, req2.Removed)
-	q.Done(key)
 }
 
-func TestPendingMessageQueue_CloseRequestUpgradeAfterGetRequeuesNextRound(t *testing.T) {
+func TestPendingMessageQueue_CloseRequestUpgradeAfterPopRequeuesNextRound(t *testing.T) {
 	t.Parallel()
 
 	q := newPendingMessageQueue()
@@ -249,40 +210,37 @@ func TestPendingMessageQueue_CloseRequestUpgradeAfterGetRequeuesNextRound(t *tes
 
 	require.True(t, q.TryEnqueue(key, msgFalse))
 
-	poppedKey, ok := q.Pop()
+	poppedKey, poppedMsg, ok := q.Pop()
 	require.True(t, ok)
 	require.Equal(t, key, poppedKey)
 
-	poppedMsg := q.Get(poppedKey)
 	require.NotNil(t, poppedMsg)
 	req := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
 	require.False(t, req.Removed)
 
 	require.True(t, q.TryEnqueue(key, msgTrue))
-	q.Done(poppedKey)
 
 	type popResult struct {
 		key pendingMessageKey
+		msg *messaging.TargetMessage
 		ok  bool
 	}
 	resultCh := make(chan popResult, 1)
 	go func() {
-		nextKey, nextOK := q.Pop()
-		resultCh <- popResult{key: nextKey, ok: nextOK}
+		nextKey, nextMsg, nextOK := q.Pop()
+		resultCh <- popResult{key: nextKey, msg: nextMsg, ok: nextOK}
 	}()
 
 	select {
 	case result := <-resultCh:
 		require.True(t, result.ok)
 		require.Equal(t, key, result.key)
-		nextMsg := q.Get(result.key)
-		require.NotNil(t, nextMsg)
-		nextReq := nextMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
+		require.NotNil(t, result.msg)
+		nextReq := result.msg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
 		require.True(t, nextReq.Removed)
-		q.Done(result.key)
 	case <-time.After(time.Second):
 		q.Close()
-		require.FailNow(t, "upgraded close request was not requeued after in-flight request completed")
+		require.FailNow(t, "upgraded close request was not requeued after the first pop")
 	}
 }
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -128,7 +128,7 @@ func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *tes
 	q.Done(key)
 }
 
-func TestPendingMessageQueue_CloseRequestUpgradeBetweenPopAndGet(t *testing.T) {
+func TestPendingMessageQueue_CloseRequestUpgradeBetweenPopAndGetKeepsInFlightStable(t *testing.T) {
 	t.Parallel()
 
 	q := newPendingMessageQueue()
@@ -158,8 +158,68 @@ func TestPendingMessageQueue_CloseRequestUpgradeBetweenPopAndGet(t *testing.T) {
 	poppedMsg := q.Get(poppedKey)
 	require.NotNil(t, poppedMsg)
 	req2 := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
-	require.True(t, req2.Removed)
+	require.False(t, req2.Removed)
 	q.Done(key)
+}
+
+func TestPendingMessageQueue_CloseRequestUpgradeAfterGetRequeuesNextRound(t *testing.T) {
+	t.Parallel()
+
+	q := newPendingMessageQueue()
+	cfID := common.NewChangeFeedIDWithName("cf", "default")
+	key := pendingMessageKey{
+		changefeedID: cfID,
+		msgType:      messaging.TypeMaintainerCloseRequest,
+	}
+
+	msgFalse := messaging.NewSingleTargetMessage(
+		node.ID("to"),
+		messaging.DispatcherManagerManagerTopic,
+		&heartbeatpb.MaintainerCloseRequest{ChangefeedID: cfID.ToPB(), Removed: false},
+	)
+	msgTrue := messaging.NewSingleTargetMessage(
+		node.ID("to"),
+		messaging.DispatcherManagerManagerTopic,
+		&heartbeatpb.MaintainerCloseRequest{ChangefeedID: cfID.ToPB(), Removed: true},
+	)
+
+	require.True(t, q.TryEnqueue(key, msgFalse))
+
+	poppedKey, ok := q.Pop()
+	require.True(t, ok)
+	require.Equal(t, key, poppedKey)
+
+	poppedMsg := q.Get(poppedKey)
+	require.NotNil(t, poppedMsg)
+	req := poppedMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
+	require.False(t, req.Removed)
+
+	require.True(t, q.TryEnqueue(key, msgTrue))
+	q.Done(poppedKey)
+
+	type popResult struct {
+		key pendingMessageKey
+		ok  bool
+	}
+	resultCh := make(chan popResult, 1)
+	go func() {
+		nextKey, nextOK := q.Pop()
+		resultCh <- popResult{key: nextKey, ok: nextOK}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.True(t, result.ok)
+		require.Equal(t, key, result.key)
+		nextMsg := q.Get(result.key)
+		require.NotNil(t, nextMsg)
+		nextReq := nextMsg.Message[0].(*heartbeatpb.MaintainerCloseRequest)
+		require.True(t, nextReq.Removed)
+		q.Done(result.key)
+	case <-time.After(time.Second):
+		q.Close()
+		require.FailNow(t, "upgraded close request was not requeued after in-flight request completed")
+	}
 }
 
 func TestGetPendingMessageKey_SupportedTypes(t *testing.T) {

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -14,7 +14,6 @@
 package dispatcherorchestrator
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -99,63 +98,6 @@ func TestPendingMessageQueue_PopReturnsAfterClose(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "Pop did not return after context cancel")
 	}
-}
-
-func TestPendingMessageQueue_PopSkipsStaleKey(t *testing.T) {
-	t.Parallel()
-
-	q := newPendingMessageQueue()
-	staleKey := pendingMessageKey{
-		changefeedID: common.NewChangeFeedIDWithName("stale", "default"),
-		msgType:      messaging.TypeMaintainerBootstrapRequest,
-	}
-	validKey := pendingMessageKey{
-		changefeedID: common.NewChangeFeedIDWithName("valid", "default"),
-		msgType:      messaging.TypeMaintainerBootstrapRequest,
-	}
-	validMsg := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
-
-	q.queue.Push(staleKey)
-	require.True(t, q.TryEnqueue(validKey, validMsg))
-
-	poppedKey, poppedMsg, ok := q.Pop()
-	require.True(t, ok)
-	require.Equal(t, validKey, poppedKey)
-	require.Same(t, validMsg, poppedMsg)
-}
-
-func TestPendingMessageQueue_PopKeepsStateShapeForNextRetry(t *testing.T) {
-	t.Parallel()
-
-	q := newPendingMessageQueue()
-	cfID := common.NewChangeFeedIDWithName("cf", "default")
-	key := pendingMessageKey{
-		changefeedID: cfID,
-		msgType:      messaging.TypeMaintainerBootstrapRequest,
-	}
-	msg1 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
-	msg2 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
-
-	require.True(t, q.TryEnqueue(key, msg1))
-
-	poppedKey, poppedMsg, ok := q.Pop()
-	require.True(t, ok)
-	require.Equal(t, key, poppedKey)
-	require.Same(t, msg1, poppedMsg)
-
-	q.mu.Lock()
-	_, exists := q.pending[key]
-	q.mu.Unlock()
-	require.False(t, exists)
-
-	require.True(t, q.TryEnqueue(key, msg2))
-
-	q.mu.Lock()
-	state := q.pending[key]
-	q.mu.Unlock()
-	require.NotNil(t, state)
-	require.Equal(t, 1, reflect.TypeOf(*state).NumField())
-	require.Same(t, msg2, state.queued)
 }
 
 func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *testing.T) {

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -125,6 +125,39 @@ func TestPendingMessageQueue_PopSkipsStaleKey(t *testing.T) {
 	q.Done(poppedKey)
 }
 
+func TestPendingMessageQueue_GetOnlyReturnsInFlightMessage(t *testing.T) {
+	t.Parallel()
+
+	q := newPendingMessageQueue()
+	cfID := common.NewChangeFeedIDWithName("cf", "default")
+	key := pendingMessageKey{
+		changefeedID: cfID,
+		msgType:      messaging.TypeMaintainerBootstrapRequest,
+	}
+	msg1 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
+	msg2 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
+
+	require.True(t, q.TryEnqueue(key, msg1))
+	require.Nil(t, q.Get(key))
+
+	poppedKey, ok := q.Pop()
+	require.True(t, ok)
+	require.Equal(t, key, poppedKey)
+	require.Same(t, msg1, q.Get(key))
+
+	require.True(t, q.TryEnqueue(key, msg2))
+	require.Same(t, msg1, q.Get(key))
+
+	q.Done(key)
+	require.Nil(t, q.Get(key))
+
+	nextKey, ok := q.Pop()
+	require.True(t, ok)
+	require.Equal(t, key, nextKey)
+	require.Same(t, msg2, q.Get(key))
+	q.Done(key)
+}
+
 func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *testing.T) {
 	t.Parallel()
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -101,6 +101,30 @@ func TestPendingMessageQueue_PopReturnsAfterClose(t *testing.T) {
 	}
 }
 
+func TestPendingMessageQueue_PopSkipsStaleKey(t *testing.T) {
+	t.Parallel()
+
+	q := newPendingMessageQueue()
+	staleKey := pendingMessageKey{
+		changefeedID: common.NewChangeFeedIDWithName("stale", "default"),
+		msgType:      messaging.TypeMaintainerBootstrapRequest,
+	}
+	validKey := pendingMessageKey{
+		changefeedID: common.NewChangeFeedIDWithName("valid", "default"),
+		msgType:      messaging.TypeMaintainerBootstrapRequest,
+	}
+	validMsg := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
+
+	q.queue.Push(staleKey)
+	require.True(t, q.TryEnqueue(validKey, validMsg))
+
+	poppedKey, ok := q.Pop()
+	require.True(t, ok)
+	require.Equal(t, validKey, poppedKey)
+	require.Same(t, validMsg, q.Get(poppedKey))
+	q.Done(poppedKey)
+}
+
 func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *testing.T) {
 	t.Parallel()
 

--- a/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
+++ b/downstreamadapter/dispatcherorchestrator/dispatcher_orchestrator_test.go
@@ -123,6 +123,40 @@ func TestPendingMessageQueue_PopSkipsStaleKey(t *testing.T) {
 	require.Same(t, validMsg, poppedMsg)
 }
 
+func TestPendingMessageQueue_PopKeepsStateShapeForNextRetry(t *testing.T) {
+	t.Parallel()
+
+	q := newPendingMessageQueue()
+	cfID := common.NewChangeFeedIDWithName("cf", "default")
+	key := pendingMessageKey{
+		changefeedID: cfID,
+		msgType:      messaging.TypeMaintainerBootstrapRequest,
+	}
+	msg1 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
+	msg2 := &messaging.TargetMessage{Type: messaging.TypeMaintainerBootstrapRequest}
+
+	require.True(t, q.TryEnqueue(key, msg1))
+
+	poppedKey, poppedMsg, ok := q.Pop()
+	require.True(t, ok)
+	require.Equal(t, key, poppedKey)
+	require.Same(t, msg1, poppedMsg)
+
+	q.mu.Lock()
+	_, exists := q.pending[key]
+	q.mu.Unlock()
+	require.False(t, exists)
+
+	require.True(t, q.TryEnqueue(key, msg2))
+
+	q.mu.Lock()
+	state := q.pending[key]
+	q.mu.Unlock()
+	require.NotNil(t, state)
+	require.Nil(t, state.inFlight)
+	require.Same(t, msg2, state.queued)
+}
+
 func TestPendingMessageQueue_CloseRequestRemovedTrueOverridesPendingFalse(t *testing.T) {
 	t.Parallel()
 

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -29,32 +29,25 @@ type pendingMessageKey struct {
 	msgType      messaging.IOType
 }
 
-type pendingMessageState struct {
-	// queued stores the next request waiting to be processed for this key.
-	queued *messaging.TargetMessage
-	// inFlight stores the request currently being processed for this key.
-	inFlight *messaging.TargetMessage
-}
-
 // pendingMessageQueue de-duplicates messages by (changefeedID, messageType) to prevent
 // floods of retry messages from blocking or starving other requests.
 //
-// The queue keeps at most one queued request and one in-flight request for each key.
-// Subsequent messages only compete with the queued slot. If that slot is empty, the new
-// message becomes the next request no matter whether the current request is idle or in-flight.
+// The queue keeps at most one queued request for each key.
+// Once Pop returns a request, ownership of that message moves to the caller. A later
+// retry for the same key simply becomes the next queued request.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
 // While a request is still queued, a later removed=true request replaces removed=false in
 // that queued slot so the next execution still observes the stronger semantics.
 type pendingMessageQueue struct {
 	mu      sync.Mutex
-	pending map[pendingMessageKey]*pendingMessageState
+	pending map[pendingMessageKey]*messaging.TargetMessage
 	queue   *chann.UnlimitedChannel[pendingMessageKey, any]
 }
 
 func newPendingMessageQueue() *pendingMessageQueue {
 	return &pendingMessageQueue{
-		pending: make(map[pendingMessageKey]*pendingMessageState),
+		pending: make(map[pendingMessageKey]*messaging.TargetMessage),
 		queue:   chann.NewUnlimitedChannelDefault[pendingMessageKey](),
 	}
 }
@@ -63,15 +56,9 @@ func newPendingMessageQueue() *pendingMessageQueue {
 // It returns true if the message is accepted, otherwise false.
 func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.TargetMessage) bool {
 	q.mu.Lock()
-	state, ok := q.pending[key]
-	if !ok {
-		state = &pendingMessageState{}
-		q.pending[key] = state
-	}
-
-	if state.queued != nil {
-		if shouldReplacePendingMessage(key, state.queued, msg) {
-			state.queued = msg
+	if queued, ok := q.pending[key]; ok {
+		if shouldReplacePendingMessage(key, queued, msg) {
+			q.pending[key] = msg
 			q.mu.Unlock()
 			return true
 		}
@@ -79,7 +66,7 @@ func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.T
 		return false
 	}
 
-	state.queued = msg
+	q.pending[key] = msg
 	q.mu.Unlock()
 
 	q.queue.Push(key)
@@ -106,17 +93,17 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 }
 
 // Pop blocks until a key is available or the queue is closed.
-// The returned key is removed from the queue and promoted to in-flight until Done is called.
-func (q *pendingMessageQueue) Pop() (pendingMessageKey, bool) {
+// The returned message is removed from the queue and handed to the caller immediately.
+func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage, bool) {
 	for {
 		key, ok := q.queue.Get()
 		if !ok {
-			return pendingMessageKey{}, false
+			return pendingMessageKey{}, nil, false
 		}
 
 		q.mu.Lock()
-		state := q.pending[key]
-		if state == nil || state.queued == nil {
+		msg := q.pending[key]
+		if msg == nil {
 			q.mu.Unlock()
 			// Returning false here would make the caller treat an internal stale key as shutdown.
 			// Keep draining until the underlying queue is actually closed.
@@ -125,37 +112,10 @@ func (q *pendingMessageQueue) Pop() (pendingMessageKey, bool) {
 				zap.String("messageType", key.msgType.String()))
 			continue
 		}
-		state.inFlight = state.queued
-		state.queued = nil
-		q.mu.Unlock()
-		return key, true
-	}
-}
-
-// Get returns the message currently being processed for the key.
-// Queued retries stay internal until Pop promotes them to in-flight.
-func (q *pendingMessageQueue) Get(key pendingMessageKey) *messaging.TargetMessage {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	state := q.pending[key]
-	if state == nil {
-		return nil
-	}
-	return state.inFlight
-}
-
-func (q *pendingMessageQueue) Done(key pendingMessageKey) {
-	q.mu.Lock()
-	state := q.pending[key]
-	if state == nil {
-		q.mu.Unlock()
-		return
-	}
-	state.inFlight = nil
-	if state.queued == nil {
 		delete(q.pending, key)
+		q.mu.Unlock()
+		return key, msg, true
 	}
-	q.mu.Unlock()
 }
 
 func (q *pendingMessageQueue) Close() {

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -90,19 +90,19 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 	return !oldReq.Removed && newReq.Removed
 }
 
-// Pop blocks until a key is available or the queue is closed.
-// The returned message is removed from the queue and handed to the caller immediately.
-func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage, bool) {
+// Pop blocks until a message is available or the queue is closed.
+// The queue key stays internal because callers only need the dequeued message.
+func (q *pendingMessageQueue) Pop() (*messaging.TargetMessage, bool) {
 	key, ok := q.queue.Get()
 	if !ok {
-		return pendingMessageKey{}, nil, false
+		return nil, false
 	}
 
 	q.mu.Lock()
 	msg := q.pending[key]
 	delete(q.pending, key)
 	q.mu.Unlock()
-	return key, msg, true
+	return msg, true
 }
 
 func (q *pendingMessageQueue) Close() {

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -32,17 +32,14 @@ type pendingMessageKey struct {
 type pendingMessageState struct {
 	// queued stores the next request waiting to be processed for this key.
 	queued *messaging.TargetMessage
-	// inFlight stores the request currently being handed to the caller by Pop.
-	// Pop clears it before returning so the external API no longer needs Done.
-	inFlight *messaging.TargetMessage
 }
 
 // pendingMessageQueue de-duplicates messages by (changefeedID, messageType) to prevent
 // floods of retry messages from blocking or starving other requests.
 //
 // The queue keeps at most one queued request for each key.
-// It still tracks a per-key state object so Pop can preserve the old queued -> in-flight
-// transition internally while returning the message directly to the caller.
+// The state object remains so per-key queue ownership stays explicit, but queued is the
+// only state the queue needs after Pop starts returning the message directly.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
 // While a request is still queued, a later removed=true request replaces removed=false in
@@ -107,8 +104,6 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 
 // Pop blocks until a key is available or the queue is closed.
 // The returned message is removed from the queue and handed to the caller immediately.
-// Internally, Pop still performs the queued -> in-flight -> completed transition so the
-// per-key state machine remains equivalent to the previous Pop/Get/Done flow.
 func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage, bool) {
 	for {
 		key, ok := q.queue.Get()
@@ -127,13 +122,8 @@ func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage
 				zap.String("messageType", key.msgType.String()))
 			continue
 		}
-		state.inFlight = state.queued
-		state.queued = nil
-		msg := state.inFlight
-		state.inFlight = nil
-		if state.queued == nil {
-			delete(q.pending, key)
-		}
+		msg := state.queued
+		delete(q.pending, key)
 		q.mu.Unlock()
 		return key, msg, true
 	}

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -38,8 +38,8 @@ type pendingMessageState struct {
 // floods of retry messages from blocking or starving other requests.
 //
 // The queue keeps at most one queued request and one in-flight request for each key.
-// Subsequent messages only compete with the queued slot. Once a request is already
-// in-flight, one next-round retry may wait in queued.
+// Subsequent messages only compete with the queued slot. If that slot is empty, the new
+// message becomes the next request no matter whether the current request is idle or in-flight.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
 // While a request is still queued, a later removed=true request replaces removed=false in
@@ -75,13 +75,6 @@ func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.T
 		}
 		q.mu.Unlock()
 		return false
-	}
-
-	if state.inFlight != nil {
-		state.queued = msg
-		q.mu.Unlock()
-		q.queue.Push(key)
-		return true
 	}
 
 	state.queued = msg

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -38,12 +38,12 @@ type pendingMessageState struct {
 // floods of retry messages from blocking or starving other requests.
 //
 // The queue keeps at most one queued request and one in-flight request for each key.
-// Subsequent messages with the same key are dropped unless they strengthen the queued
-// or in-flight close semantics from removed=false to removed=true.
+// Subsequent messages only compete with the queued slot. Once a request is already
+// in-flight, one next-round retry may wait in queued.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
-// If an in-flight removed=false request exists, a later removed=true request is queued for
-// the next round instead of overwriting the request the worker is already executing.
+// While a request is still queued, a later removed=true request replaces removed=false in
+// that queued slot so the next execution still observes the stronger semantics.
 type pendingMessageQueue struct {
 	mu      sync.Mutex
 	pending map[pendingMessageKey]*pendingMessageState
@@ -78,14 +78,10 @@ func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.T
 	}
 
 	if state.inFlight != nil {
-		if shouldReplacePendingMessage(key, state.inFlight, msg) {
-			state.queued = msg
-			q.mu.Unlock()
-			q.queue.Push(key)
-			return true
-		}
+		state.queued = msg
 		q.mu.Unlock()
-		return false
+		q.queue.Push(key)
+		return true
 	}
 
 	state.queued = msg

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -16,12 +16,10 @@ package dispatcherorchestrator
 import (
 	"sync"
 
-	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/utils/chann"
-	"go.uber.org/zap"
 )
 
 type pendingMessageKey struct {
@@ -29,30 +27,25 @@ type pendingMessageKey struct {
 	msgType      messaging.IOType
 }
 
-type pendingMessageState struct {
-	// queued stores the next request waiting to be processed for this key.
-	queued *messaging.TargetMessage
-}
-
 // pendingMessageQueue de-duplicates messages by (changefeedID, messageType) to prevent
 // floods of retry messages from blocking or starving other requests.
 //
 // The queue keeps at most one queued request for each key.
-// The state object remains so per-key queue ownership stays explicit, but queued is the
-// only state the queue needs after Pop starts returning the message directly.
+// Once Pop returns a message, the key leaves the pending set immediately, so the next
+// retry can queue one more request for the next processing round.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
 // While a request is still queued, a later removed=true request replaces removed=false in
 // that queued slot so the next execution still observes the stronger semantics.
 type pendingMessageQueue struct {
 	mu      sync.Mutex
-	pending map[pendingMessageKey]*pendingMessageState
+	pending map[pendingMessageKey]*messaging.TargetMessage
 	queue   *chann.UnlimitedChannel[pendingMessageKey, any]
 }
 
 func newPendingMessageQueue() *pendingMessageQueue {
 	return &pendingMessageQueue{
-		pending: make(map[pendingMessageKey]*pendingMessageState),
+		pending: make(map[pendingMessageKey]*messaging.TargetMessage),
 		queue:   chann.NewUnlimitedChannelDefault[pendingMessageKey](),
 	}
 }
@@ -61,14 +54,9 @@ func newPendingMessageQueue() *pendingMessageQueue {
 // It returns true if the message is accepted, otherwise false.
 func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.TargetMessage) bool {
 	q.mu.Lock()
-	state, ok := q.pending[key]
-	if !ok {
-		state = &pendingMessageState{}
-		q.pending[key] = state
-	}
-	if state.queued != nil {
-		if shouldReplacePendingMessage(key, state.queued, msg) {
-			state.queued = msg
+	if pendingMsg, ok := q.pending[key]; ok {
+		if shouldReplacePendingMessage(key, pendingMsg, msg) {
+			q.pending[key] = msg
 			q.mu.Unlock()
 			return true
 		}
@@ -76,7 +64,7 @@ func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.T
 		return false
 	}
 
-	state.queued = msg
+	q.pending[key] = msg
 	q.mu.Unlock()
 
 	q.queue.Push(key)
@@ -105,28 +93,16 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 // Pop blocks until a key is available or the queue is closed.
 // The returned message is removed from the queue and handed to the caller immediately.
 func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage, bool) {
-	for {
-		key, ok := q.queue.Get()
-		if !ok {
-			return pendingMessageKey{}, nil, false
-		}
-
-		q.mu.Lock()
-		state := q.pending[key]
-		if state == nil || state.queued == nil {
-			q.mu.Unlock()
-			// Returning false here would make the caller treat an internal stale key as shutdown.
-			// Keep draining until the underlying queue is actually closed.
-			log.Error("skip stale pending message key",
-				zap.Stringer("changefeedID", key.changefeedID),
-				zap.String("messageType", key.msgType.String()))
-			continue
-		}
-		msg := state.queued
-		delete(q.pending, key)
-		q.mu.Unlock()
-		return key, msg, true
+	key, ok := q.queue.Get()
+	if !ok {
+		return pendingMessageKey{}, nil, false
 	}
+
+	q.mu.Lock()
+	msg := q.pending[key]
+	delete(q.pending, key)
+	q.mu.Unlock()
+	return key, msg, true
 }
 
 func (q *pendingMessageQueue) Close() {

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -29,25 +29,33 @@ type pendingMessageKey struct {
 	msgType      messaging.IOType
 }
 
+type pendingMessageState struct {
+	// queued stores the next request waiting to be processed for this key.
+	queued *messaging.TargetMessage
+	// inFlight stores the request currently being handed to the caller by Pop.
+	// Pop clears it before returning so the external API no longer needs Done.
+	inFlight *messaging.TargetMessage
+}
+
 // pendingMessageQueue de-duplicates messages by (changefeedID, messageType) to prevent
 // floods of retry messages from blocking or starving other requests.
 //
 // The queue keeps at most one queued request for each key.
-// Once Pop returns a request, ownership of that message moves to the caller. A later
-// retry for the same key simply becomes the next queued request.
+// It still tracks a per-key state object so Pop can preserve the old queued -> in-flight
+// transition internally while returning the message directly to the caller.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
 // While a request is still queued, a later removed=true request replaces removed=false in
 // that queued slot so the next execution still observes the stronger semantics.
 type pendingMessageQueue struct {
 	mu      sync.Mutex
-	pending map[pendingMessageKey]*messaging.TargetMessage
+	pending map[pendingMessageKey]*pendingMessageState
 	queue   *chann.UnlimitedChannel[pendingMessageKey, any]
 }
 
 func newPendingMessageQueue() *pendingMessageQueue {
 	return &pendingMessageQueue{
-		pending: make(map[pendingMessageKey]*messaging.TargetMessage),
+		pending: make(map[pendingMessageKey]*pendingMessageState),
 		queue:   chann.NewUnlimitedChannelDefault[pendingMessageKey](),
 	}
 }
@@ -56,9 +64,14 @@ func newPendingMessageQueue() *pendingMessageQueue {
 // It returns true if the message is accepted, otherwise false.
 func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.TargetMessage) bool {
 	q.mu.Lock()
-	if queued, ok := q.pending[key]; ok {
-		if shouldReplacePendingMessage(key, queued, msg) {
-			q.pending[key] = msg
+	state, ok := q.pending[key]
+	if !ok {
+		state = &pendingMessageState{}
+		q.pending[key] = state
+	}
+	if state.queued != nil {
+		if shouldReplacePendingMessage(key, state.queued, msg) {
+			state.queued = msg
 			q.mu.Unlock()
 			return true
 		}
@@ -66,7 +79,7 @@ func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.T
 		return false
 	}
 
-	q.pending[key] = msg
+	state.queued = msg
 	q.mu.Unlock()
 
 	q.queue.Push(key)
@@ -94,6 +107,8 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 
 // Pop blocks until a key is available or the queue is closed.
 // The returned message is removed from the queue and handed to the caller immediately.
+// Internally, Pop still performs the queued -> in-flight -> completed transition so the
+// per-key state machine remains equivalent to the previous Pop/Get/Done flow.
 func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage, bool) {
 	for {
 		key, ok := q.queue.Get()
@@ -102,8 +117,8 @@ func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage
 		}
 
 		q.mu.Lock()
-		msg := q.pending[key]
-		if msg == nil {
+		state := q.pending[key]
+		if state == nil || state.queued == nil {
 			q.mu.Unlock()
 			// Returning false here would make the caller treat an internal stale key as shutdown.
 			// Keep draining until the underlying queue is actually closed.
@@ -112,7 +127,13 @@ func (q *pendingMessageQueue) Pop() (pendingMessageKey, *messaging.TargetMessage
 				zap.String("messageType", key.msgType.String()))
 			continue
 		}
-		delete(q.pending, key)
+		state.inFlight = state.queued
+		state.queued = nil
+		msg := state.inFlight
+		state.inFlight = nil
+		if state.queued == nil {
+			delete(q.pending, key)
+		}
 		q.mu.Unlock()
 		return key, msg, true
 	}

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -27,25 +27,32 @@ type pendingMessageKey struct {
 	msgType      messaging.IOType
 }
 
+type pendingMessageState struct {
+	// queued stores the next request waiting to be processed for this key.
+	queued *messaging.TargetMessage
+	// inFlight stores the request currently being processed for this key.
+	inFlight *messaging.TargetMessage
+}
+
 // pendingMessageQueue de-duplicates messages by (changefeedID, messageType) to prevent
 // floods of retry messages from blocking or starving other requests.
 //
-// The queue keeps the first message while it is pending or being processed. Subsequent
-// messages with the same key are dropped. This is safe because the sender periodically
-// retries until it receives a response.
+// The queue keeps at most one queued request and one in-flight request for each key.
+// Subsequent messages with the same key are dropped unless they strengthen the queued
+// or in-flight close semantics from removed=false to removed=true.
 //
 // For MaintainerCloseRequest, we treat removed=true as stronger semantics than removed=false.
-// If a pending removed=false request exists, a later removed=true request with the same key
-// will replace it to avoid missing removal-related cleanup.
+// If an in-flight removed=false request exists, a later removed=true request is queued for
+// the next round instead of overwriting the request the worker is already executing.
 type pendingMessageQueue struct {
 	mu      sync.Mutex
-	pending map[pendingMessageKey]*messaging.TargetMessage
+	pending map[pendingMessageKey]*pendingMessageState
 	queue   *chann.UnlimitedChannel[pendingMessageKey, any]
 }
 
 func newPendingMessageQueue() *pendingMessageQueue {
 	return &pendingMessageQueue{
-		pending: make(map[pendingMessageKey]*messaging.TargetMessage),
+		pending: make(map[pendingMessageKey]*pendingMessageState),
 		queue:   chann.NewUnlimitedChannelDefault[pendingMessageKey](),
 	}
 }
@@ -54,16 +61,34 @@ func newPendingMessageQueue() *pendingMessageQueue {
 // It returns true if the message is accepted, otherwise false.
 func (q *pendingMessageQueue) TryEnqueue(key pendingMessageKey, msg *messaging.TargetMessage) bool {
 	q.mu.Lock()
-	if oldMsg, ok := q.pending[key]; ok {
-		if shouldReplacePendingMessage(key, oldMsg, msg) {
-			q.pending[key] = msg
+	state, ok := q.pending[key]
+	if !ok {
+		state = &pendingMessageState{}
+		q.pending[key] = state
+	}
+
+	if state.queued != nil {
+		if shouldReplacePendingMessage(key, state.queued, msg) {
+			state.queued = msg
 			q.mu.Unlock()
 			return true
 		}
 		q.mu.Unlock()
 		return false
 	}
-	q.pending[key] = msg
+
+	if state.inFlight != nil {
+		if shouldReplacePendingMessage(key, state.inFlight, msg) {
+			state.queued = msg
+			q.mu.Unlock()
+			q.queue.Push(key)
+			return true
+		}
+		q.mu.Unlock()
+		return false
+	}
+
+	state.queued = msg
 	q.mu.Unlock()
 
 	q.queue.Push(key)
@@ -90,20 +115,49 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 }
 
 // Pop blocks until a key is available or the queue is closed.
-// The returned key is removed from the queue but remains pending until Done is called.
+// The returned key is removed from the queue and promoted to in-flight until Done is called.
 func (q *pendingMessageQueue) Pop() (pendingMessageKey, bool) {
-	return q.queue.Get()
+	key, ok := q.queue.Get()
+	if !ok {
+		return pendingMessageKey{}, false
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	state := q.pending[key]
+	if state == nil || state.queued == nil {
+		return pendingMessageKey{}, false
+	}
+	state.inFlight = state.queued
+	state.queued = nil
+	return key, true
 }
 
 func (q *pendingMessageQueue) Get(key pendingMessageKey) *messaging.TargetMessage {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return q.pending[key]
+	state := q.pending[key]
+	if state == nil {
+		return nil
+	}
+	if state.inFlight != nil {
+		return state.inFlight
+	}
+	return state.queued
 }
 
 func (q *pendingMessageQueue) Done(key pendingMessageKey) {
 	q.mu.Lock()
-	delete(q.pending, key)
+	state := q.pending[key]
+	if state == nil {
+		q.mu.Unlock()
+		return
+	}
+	state.inFlight = nil
+	if state.queued == nil {
+		delete(q.pending, key)
+	}
 	q.mu.Unlock()
 }
 

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -132,6 +132,8 @@ func (q *pendingMessageQueue) Pop() (pendingMessageKey, bool) {
 	}
 }
 
+// Get returns the message currently being processed for the key.
+// Queued retries stay internal until Pop promotes them to in-flight.
 func (q *pendingMessageQueue) Get(key pendingMessageKey) *messaging.TargetMessage {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -139,10 +141,7 @@ func (q *pendingMessageQueue) Get(key pendingMessageKey) *messaging.TargetMessag
 	if state == nil {
 		return nil
 	}
-	if state.inFlight != nil {
-		return state.inFlight
-	}
-	return state.queued
+	return state.inFlight
 }
 
 func (q *pendingMessageQueue) Done(key pendingMessageKey) {

--- a/downstreamadapter/dispatcherorchestrator/helper.go
+++ b/downstreamadapter/dispatcherorchestrator/helper.go
@@ -16,10 +16,12 @@ package dispatcherorchestrator
 import (
 	"sync"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/heartbeatpb"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/utils/chann"
+	"go.uber.org/zap"
 )
 
 type pendingMessageKey struct {
@@ -106,21 +108,28 @@ func shouldReplacePendingMessage(key pendingMessageKey, oldMsg, newMsg *messagin
 // Pop blocks until a key is available or the queue is closed.
 // The returned key is removed from the queue and promoted to in-flight until Done is called.
 func (q *pendingMessageQueue) Pop() (pendingMessageKey, bool) {
-	key, ok := q.queue.Get()
-	if !ok {
-		return pendingMessageKey{}, false
-	}
+	for {
+		key, ok := q.queue.Get()
+		if !ok {
+			return pendingMessageKey{}, false
+		}
 
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	state := q.pending[key]
-	if state == nil || state.queued == nil {
-		return pendingMessageKey{}, false
+		q.mu.Lock()
+		state := q.pending[key]
+		if state == nil || state.queued == nil {
+			q.mu.Unlock()
+			// Returning false here would make the caller treat an internal stale key as shutdown.
+			// Keep draining until the underlying queue is actually closed.
+			log.Error("skip stale pending message key",
+				zap.Stringer("changefeedID", key.changefeedID),
+				zap.String("messageType", key.msgType.String()))
+			continue
+		}
+		state.inFlight = state.queued
+		state.queued = nil
+		q.mu.Unlock()
+		return key, true
 	}
-	state.inFlight = state.queued
-	state.queued = nil
-	return key, true
 }
 
 func (q *pendingMessageQueue) Get(key pendingMessageKey) *messaging.TargetMessage {

--- a/downstreamadapter/sink/blackhole/sink.go
+++ b/downstreamadapter/sink/blackhole/sink.go
@@ -77,7 +77,7 @@ func (s *sink) AddCheckpointTs(ts uint64) {
 	log.Debug("BlackHoleSink: Checkpoint Ts Event", zap.Uint64("ts", ts))
 }
 
-func (s *sink) Close(_ bool) {}
+func (s *sink) Close() {}
 
 func (s *sink) Run(ctx context.Context) error {
 	for {

--- a/downstreamadapter/sink/blackhole/sink.go
+++ b/downstreamadapter/sink/blackhole/sink.go
@@ -77,7 +77,7 @@ func (s *sink) AddCheckpointTs(ts uint64) {
 	log.Debug("BlackHoleSink: Checkpoint Ts Event", zap.Uint64("ts", ts))
 }
 
-func (s *sink) Close(_ bool) bool { return true }
+func (s *sink) Close(_ bool) {}
 
 func (s *sink) Run(ctx context.Context) error {
 	for {

--- a/downstreamadapter/sink/blackhole/sink.go
+++ b/downstreamadapter/sink/blackhole/sink.go
@@ -77,7 +77,7 @@ func (s *sink) AddCheckpointTs(ts uint64) {
 	log.Debug("BlackHoleSink: Checkpoint Ts Event", zap.Uint64("ts", ts))
 }
 
-func (s *sink) Close(_ bool) {}
+func (s *sink) Close(_ bool) bool { return true }
 
 func (s *sink) Run(ctx context.Context) error {
 	for {

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -243,7 +243,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
 
-	cloudStorageSink.Close(false)
+	_ = cloudStorageSink.Close(false)
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
@@ -424,7 +424,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
-	cloudStorageSink.Close(false)
+	_ = cloudStorageSink.Close(false)
 
 	cancel()
 	time.Sleep(5 * time.Second)

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -243,7 +243,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
 
-	_ = cloudStorageSink.Close(false)
+	cloudStorageSink.Close(false)
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
@@ -424,7 +424,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
-	_ = cloudStorageSink.Close(false)
+	cloudStorageSink.Close(false)
 
 	cancel()
 	time.Sleep(5 * time.Second)

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -243,7 +243,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
 
-	cloudStorageSink.Close(false)
+	cloudStorageSink.Close()
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
@@ -424,7 +424,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
-	cloudStorageSink.Close(false)
+	cloudStorageSink.Close()
 
 	cancel()
 	time.Sleep(5 * time.Second)

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -491,7 +491,7 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 	return ret
 }
 
-func (s *sink) Close(_ bool) bool {
+func (s *sink) Close(_ bool) {
 	if s.dmlWriters != nil {
 		s.dmlWriters.close()
 	}
@@ -504,7 +504,6 @@ func (s *sink) Close(_ bool) bool {
 	if s.storage != nil {
 		s.storage.Close()
 	}
-	return true
 }
 
 func (s *sink) BatchCount() int {

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -491,7 +491,7 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 	return ret
 }
 
-func (s *sink) Close(_ bool) {
+func (s *sink) Close() {
 	if s.dmlWriters != nil {
 		s.dmlWriters.close()
 	}

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -491,7 +491,7 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 	return ret
 }
 
-func (s *sink) Close(_ bool) {
+func (s *sink) Close(_ bool) bool {
 	if s.dmlWriters != nil {
 		s.dmlWriters.close()
 	}
@@ -504,6 +504,7 @@ func (s *sink) Close(_ bool) {
 	if s.storage != nil {
 		s.storage.Close()
 	}
+	return true
 }
 
 func (s *sink) BatchCount() int {

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -554,7 +554,7 @@ func TestCloseBeforeRunDoesNotPanicAndCleansSpool(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
-		cloudStorageSink.Close(false)
+		_ = cloudStorageSink.Close(false)
 	})
 
 	_, err = os.Stat(spoolDir)

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -554,7 +554,7 @@ func TestCloseBeforeRunDoesNotPanicAndCleansSpool(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
-		_ = cloudStorageSink.Close(false)
+		cloudStorageSink.Close(false)
 	})
 
 	_, err = os.Stat(spoolDir)

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -554,7 +554,7 @@ func TestCloseBeforeRunDoesNotPanicAndCleansSpool(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
-		cloudStorageSink.Close(false)
+		cloudStorageSink.Close()
 	})
 
 	_, err = os.Stat(spoolDir)

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -563,7 +563,7 @@ func (s *sink) getAllTableNames(ts uint64) []*commonEvent.SchemaTableName {
 	return s.tableSchemaStore.GetAllTableNames(ts, true)
 }
 
-func (s *sink) Close(_ bool) {
+func (s *sink) Close() {
 	s.ddlProducer.Close()
 	s.dmlProducer.Close()
 	s.comp.close()

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -563,11 +563,12 @@ func (s *sink) getAllTableNames(ts uint64) []*commonEvent.SchemaTableName {
 	return s.tableSchemaStore.GetAllTableNames(ts, true)
 }
 
-func (s *sink) Close(_ bool) {
+func (s *sink) Close(_ bool) bool {
 	s.ddlProducer.Close()
 	s.dmlProducer.Close()
 	s.comp.close()
 	s.statistics.Close()
+	return true
 }
 
 func (s *sink) BatchCount() int {

--- a/downstreamadapter/sink/kafka/sink.go
+++ b/downstreamadapter/sink/kafka/sink.go
@@ -563,12 +563,11 @@ func (s *sink) getAllTableNames(ts uint64) []*commonEvent.SchemaTableName {
 	return s.tableSchemaStore.GetAllTableNames(ts, true)
 }
 
-func (s *sink) Close(_ bool) bool {
+func (s *sink) Close(_ bool) {
 	s.ddlProducer.Close()
 	s.dmlProducer.Close()
 	s.comp.close()
 	s.statistics.Close()
-	return true
 }
 
 func (s *sink) BatchCount() int {

--- a/downstreamadapter/sink/kafka/sink_test.go
+++ b/downstreamadapter/sink/kafka/sink_test.go
@@ -262,7 +262,7 @@ func TestKafkaSinkBasicFunctionality(t *testing.T) {
 		}, 5*time.Second, time.Second)
 
 	// case 2: add checkpoint ts when sink is closed and it will not block
-	kafkaSink.Close(false)
+	_ = kafkaSink.Close(false)
 	cancel()
 	kafkaSink.AddCheckpointTs(12345)
 }

--- a/downstreamadapter/sink/kafka/sink_test.go
+++ b/downstreamadapter/sink/kafka/sink_test.go
@@ -262,7 +262,7 @@ func TestKafkaSinkBasicFunctionality(t *testing.T) {
 		}, 5*time.Second, time.Second)
 
 	// case 2: add checkpoint ts when sink is closed and it will not block
-	_ = kafkaSink.Close(false)
+	kafkaSink.Close(false)
 	cancel()
 	kafkaSink.AddCheckpointTs(12345)
 }

--- a/downstreamadapter/sink/kafka/sink_test.go
+++ b/downstreamadapter/sink/kafka/sink_test.go
@@ -262,7 +262,7 @@ func TestKafkaSinkBasicFunctionality(t *testing.T) {
 		}, 5*time.Second, time.Second)
 
 	// case 2: add checkpoint ts when sink is closed and it will not block
-	kafkaSink.Close(false)
+	kafkaSink.Close()
 	cancel()
 	kafkaSink.AddCheckpointTs(12345)
 }

--- a/downstreamadapter/sink/mock/sink_mock.go
+++ b/downstreamadapter/sink/mock/sink_mock.go
@@ -89,9 +89,11 @@ func (mr *MockSinkMockRecorder) BatchCount() *gomock.Call {
 }
 
 // Close mocks base method.
-func (m *MockSink) Close(removeChangefeed bool) {
+func (m *MockSink) Close(removeChangefeed bool) bool {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close", removeChangefeed)
+	ret := m.ctrl.Call(m, "Close", removeChangefeed)
+	ret0, _ := ret[0].(bool)
+	return ret0
 }
 
 // Close indicates an expected call of Close.

--- a/downstreamadapter/sink/mock/sink_mock.go
+++ b/downstreamadapter/sink/mock/sink_mock.go
@@ -89,11 +89,9 @@ func (mr *MockSinkMockRecorder) BatchCount() *gomock.Call {
 }
 
 // Close mocks base method.
-func (m *MockSink) Close(removeChangefeed bool) bool {
+func (m *MockSink) Close(removeChangefeed bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", removeChangefeed)
-	ret0, _ := ret[0].(bool)
-	return ret0
+	m.ctrl.Call(m, "Close", removeChangefeed)
 }
 
 // Close indicates an expected call of Close.

--- a/downstreamadapter/sink/mock/sink_mock.go
+++ b/downstreamadapter/sink/mock/sink_mock.go
@@ -89,15 +89,15 @@ func (mr *MockSinkMockRecorder) BatchCount() *gomock.Call {
 }
 
 // Close mocks base method.
-func (m *MockSink) Close(removeChangefeed bool) {
+func (m *MockSink) Close() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close", removeChangefeed)
+	m.ctrl.Call(m, "Close")
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockSinkMockRecorder) Close(removeChangefeed interface{}) *gomock.Call {
+func (mr *MockSinkMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSink)(nil).Close), removeChangefeed)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSink)(nil).Close))
 }
 
 // FlushDMLBeforeBlock mocks base method.

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 	"net/url"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/pingcap/log"
@@ -69,18 +68,6 @@ type Sink struct {
 	// variable @@tidb_cdc_active_active_sync_stats and is shared by all DML writers.
 	// It is nil when disabled or unsupported by downstream.
 	activeActiveSyncStatsCollector *mysql.ActiveActiveSyncStatsCollector
-
-	// closeMu guards the close state below so Close(false) can be upgraded safely by
-	// a later Close(true) after the base close path has already run.
-	closeMu      sync.Mutex
-	closeStarted bool
-	baseClosed   bool
-	// removeRequested is sticky once any caller asks for remove semantics.
-	removeRequested bool
-	// removeCleanupInProgress prevents concurrent retries from running the
-	// remove-only cleanup more than once at the same time.
-	removeCleanupInProgress bool
-	removeCleaned           bool
 
 	removeCleanupFn func() error
 }
@@ -161,7 +148,6 @@ func NewMySQLSink(
 		enableActiveActive:             enableActiveActive,
 		activeActiveSyncStatsCollector: activeActiveSyncStatsCollector,
 	}
-	result.removeCleanupFn = result.cleanupRemovedChangefeed
 	for i := 0; i < len(result.dmlWriter); i++ {
 		result.dmlWriter[i] = mysql.NewWriter(ctx, i, db, cfg, changefeedID, stat, activeActiveSyncStatsCollector)
 	}
@@ -407,84 +393,17 @@ func (s *Sink) GetTableRecoveryInfo(
 	return newStartTsList, skipSyncpointAtStartTsList, skipDMLAsStartTsList, nil
 }
 
-func (s *Sink) Close(removeChangefeed bool) bool {
-	needBaseClose := false
-
-	s.closeMu.Lock()
+func (s *Sink) Close(removeChangefeed bool) {
+	// Keep direct callers compatible: if they choose remove semantics at the sink
+	// layer, run the remove-only cleanup before releasing the long-lived resources.
 	if removeChangefeed {
-		// Keep remove intent sticky so a later Close(true) upgrades an earlier
-		// Close(false) even after base resources have been released.
-		s.removeRequested = true
-	}
-	switch {
-	case !s.closeStarted:
-		s.closeStarted = true
-		needBaseClose = true
-	case !s.baseClosed:
-		s.closeMu.Unlock()
-		return false
-	case !s.removeRequested:
-		s.closeMu.Unlock()
-		return true
-	case s.removeCleaned || s.removeCleanupInProgress:
-		completed := s.removeCleaned
-		s.closeMu.Unlock()
-		return completed
-	default:
-		s.removeCleanupInProgress = true
-		s.closeMu.Unlock()
-		return s.runRemoveCleanupAndFinish()
-	}
-	s.closeMu.Unlock()
-
-	if needBaseClose {
-		s.closeBase()
+		if err := s.CleanupRemovedChangefeed(); err != nil {
+			log.Warn("close mysql sink, remove changefeed meet error",
+				zap.Any("changefeed", s.changefeedID.String()),
+				zap.Error(err))
+		}
 	}
 
-	s.closeMu.Lock()
-	s.baseClosed = true
-	switch {
-	case !s.removeRequested:
-		s.closeMu.Unlock()
-		return true
-	case s.removeCleaned || s.removeCleanupInProgress:
-		completed := s.removeCleaned
-		s.closeMu.Unlock()
-		return completed
-	default:
-		s.removeCleanupInProgress = true
-		s.closeMu.Unlock()
-		return s.runRemoveCleanupAndFinish()
-	}
-}
-
-func (s *Sink) runRemoveCleanup() error {
-	if s.removeCleanupFn != nil {
-		return s.removeCleanupFn()
-	}
-	return nil
-}
-
-func (s *Sink) runRemoveCleanupAndFinish() bool {
-	err := s.runRemoveCleanup()
-
-	s.closeMu.Lock()
-	s.removeCleanupInProgress = false
-	if err == nil {
-		s.removeCleaned = true
-	}
-	s.closeMu.Unlock()
-
-	if err != nil {
-		log.Warn("close mysql sink, remove changefeed meet error",
-			zap.Any("changefeed", s.changefeedID.String()),
-			zap.Error(err))
-		return false
-	}
-	return true
-}
-
-func (s *Sink) closeBase() {
 	s.conflictDetector.CloseNotifiedNodes()
 	s.ddlWriter.Close()
 	for _, w := range s.dmlWriter {
@@ -502,10 +421,13 @@ func (s *Sink) closeBase() {
 	s.statistics.Close()
 }
 
-// cleanupRemovedChangefeed removes ddl_ts state for a deleted changefeed.
+// CleanupRemovedChangefeed removes ddl_ts state for a deleted changefeed.
 // It uses a short-lived DB connection so the cleanup can still run after the
 // normal sink close path has already closed the long-lived connection.
-func (s *Sink) cleanupRemovedChangefeed() error {
+func (s *Sink) CleanupRemovedChangefeed() error {
+	if s.removeCleanupFn != nil {
+		return s.removeCleanupFn()
+	}
 	if !s.cfg.EnableDDLTs {
 		return nil
 	}

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -68,8 +68,6 @@ type Sink struct {
 	// variable @@tidb_cdc_active_active_sync_stats and is shared by all DML writers.
 	// It is nil when disabled or unsupported by downstream.
 	activeActiveSyncStatsCollector *mysql.ActiveActiveSyncStatsCollector
-
-	removeCleanupFn func() error
 }
 
 // Verify is used to verify the sink uri and config is valid
@@ -425,9 +423,6 @@ func (s *Sink) Close(removeChangefeed bool) {
 // It uses a short-lived DB connection so the cleanup can still run after the
 // normal sink close path has already closed the long-lived connection.
 func (s *Sink) CleanupRemovedChangefeed() error {
-	if s.removeCleanupFn != nil {
-		return s.removeCleanupFn()
-	}
 	if !s.cfg.EnableDDLTs {
 		return nil
 	}

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pingcap/log"
@@ -68,6 +69,20 @@ type Sink struct {
 	// variable @@tidb_cdc_active_active_sync_stats and is shared by all DML writers.
 	// It is nil when disabled or unsupported by downstream.
 	activeActiveSyncStatsCollector *mysql.ActiveActiveSyncStatsCollector
+
+	// closeMu guards the close state below so Close(false) can be upgraded safely by
+	// a later Close(true) after the base close path has already run.
+	closeMu      sync.Mutex
+	closeStarted bool
+	baseClosed   bool
+	// removeRequested is sticky once any caller asks for remove semantics.
+	removeRequested bool
+	// removeCleanupInProgress prevents concurrent retries from running the
+	// remove-only cleanup more than once at the same time.
+	removeCleanupInProgress bool
+	removeCleaned           bool
+
+	removeCleanupFn func() error
 }
 
 // Verify is used to verify the sink uri and config is valid
@@ -146,6 +161,7 @@ func NewMySQLSink(
 		enableActiveActive:             enableActiveActive,
 		activeActiveSyncStatsCollector: activeActiveSyncStatsCollector,
 	}
+	result.removeCleanupFn = result.cleanupRemovedChangefeed
 	for i := 0; i < len(result.dmlWriter); i++ {
 		result.dmlWriter[i] = mysql.NewWriter(ctx, i, db, cfg, changefeedID, stat, activeActiveSyncStatsCollector)
 	}
@@ -391,15 +407,84 @@ func (s *Sink) GetTableRecoveryInfo(
 	return newStartTsList, skipSyncpointAtStartTsList, skipDMLAsStartTsList, nil
 }
 
-func (s *Sink) Close(removeChangefeed bool) {
-	// when remove the changefeed, we need to remove the ddl ts item in the ddl worker
+func (s *Sink) Close(removeChangefeed bool) bool {
+	needBaseClose := false
+
+	s.closeMu.Lock()
 	if removeChangefeed {
-		if err := s.CleanupRemovedChangefeed(); err != nil {
-			log.Warn("close mysql sink, remove changefeed meet error",
-				zap.Any("changefeed", s.changefeedID.String()), zap.Error(err))
-		}
+		// Keep remove intent sticky so a later Close(true) upgrades an earlier
+		// Close(false) even after base resources have been released.
+		s.removeRequested = true
+	}
+	switch {
+	case !s.closeStarted:
+		s.closeStarted = true
+		needBaseClose = true
+	case !s.baseClosed:
+		s.closeMu.Unlock()
+		return false
+	case !s.removeRequested:
+		s.closeMu.Unlock()
+		return true
+	case s.removeCleaned || s.removeCleanupInProgress:
+		completed := s.removeCleaned
+		s.closeMu.Unlock()
+		return completed
+	default:
+		s.removeCleanupInProgress = true
+		s.closeMu.Unlock()
+		return s.runRemoveCleanupAndFinish()
+	}
+	s.closeMu.Unlock()
+
+	if needBaseClose {
+		s.closeBase()
 	}
 
+	s.closeMu.Lock()
+	s.baseClosed = true
+	switch {
+	case !s.removeRequested:
+		s.closeMu.Unlock()
+		return true
+	case s.removeCleaned || s.removeCleanupInProgress:
+		completed := s.removeCleaned
+		s.closeMu.Unlock()
+		return completed
+	default:
+		s.removeCleanupInProgress = true
+		s.closeMu.Unlock()
+		return s.runRemoveCleanupAndFinish()
+	}
+}
+
+func (s *Sink) runRemoveCleanup() error {
+	if s.removeCleanupFn != nil {
+		return s.removeCleanupFn()
+	}
+	return nil
+}
+
+func (s *Sink) runRemoveCleanupAndFinish() bool {
+	err := s.runRemoveCleanup()
+
+	s.closeMu.Lock()
+	s.removeCleanupInProgress = false
+	if err == nil {
+		s.removeCleaned = true
+	}
+	s.closeMu.Unlock()
+
+	if err != nil {
+		log.Warn("close mysql sink, remove changefeed meet error",
+			zap.Any("changefeed", s.changefeedID.String()),
+			zap.Error(err))
+		return false
+	}
+	return true
+}
+
+func (s *Sink) closeBase() {
 	s.conflictDetector.CloseNotifiedNodes()
 	s.ddlWriter.Close()
 	for _, w := range s.dmlWriter {
@@ -417,10 +502,10 @@ func (s *Sink) Close(removeChangefeed bool) {
 	s.statistics.Close()
 }
 
-// CleanupRemovedChangefeed removes ddl_ts state for a deleted changefeed.
+// cleanupRemovedChangefeed removes ddl_ts state for a deleted changefeed.
 // It uses a short-lived DB connection so the cleanup can still run after the
 // normal sink close path has already closed the long-lived connection.
-func (s *Sink) CleanupRemovedChangefeed() error {
+func (s *Sink) cleanupRemovedChangefeed() error {
 	if !s.cfg.EnableDDLTs {
 		return nil
 	}
@@ -443,6 +528,7 @@ func (s *Sink) CleanupRemovedChangefeed() error {
 	}()
 
 	cleanupWriter := mysql.NewWriter(context.Background(), -1, db, s.cfg, s.changefeedID, nil, nil)
+	defer cleanupWriter.Close()
 	return cleanupWriter.RemoveDDLTsItem()
 }
 

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -394,7 +394,7 @@ func (s *Sink) GetTableRecoveryInfo(
 func (s *Sink) Close(removeChangefeed bool) {
 	// when remove the changefeed, we need to remove the ddl ts item in the ddl worker
 	if removeChangefeed {
-		if err := s.ddlWriter.RemoveDDLTsItem(); err != nil {
+		if err := s.CleanupRemovedChangefeed(); err != nil {
 			log.Warn("close mysql sink, remove changefeed meet error",
 				zap.Any("changefeed", s.changefeedID.String()), zap.Error(err))
 		}
@@ -415,6 +415,35 @@ func (s *Sink) Close(removeChangefeed bool) {
 		s.activeActiveSyncStatsCollector.Close()
 	}
 	s.statistics.Close()
+}
+
+// CleanupRemovedChangefeed removes ddl_ts state for a deleted changefeed.
+// It uses a short-lived DB connection so the cleanup can still run after the
+// normal sink close path has already closed the long-lived connection.
+func (s *Sink) CleanupRemovedChangefeed() error {
+	if !s.cfg.EnableDDLTs {
+		return nil
+	}
+
+	// Remove-changefeed cleanup must stay available even if the sink has already
+	// closed its long-lived DB connection in the normal close path.
+	dsnStr, err := mysql.GenerateDSN(context.Background(), s.cfg)
+	if err != nil {
+		return err
+	}
+	db, err := mysql.CreateMysqlDBConn(dsnStr)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			log.Warn("close mysql cleanup db meet error",
+				zap.Any("changefeed", s.changefeedID.String()), zap.Error(closeErr))
+		}
+	}()
+
+	cleanupWriter := mysql.NewWriter(context.Background(), -1, db, s.cfg, s.changefeedID, nil, nil)
+	return cleanupWriter.RemoveDDLTsItem()
 }
 
 func (s *Sink) BatchCount() int {

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -391,17 +391,7 @@ func (s *Sink) GetTableRecoveryInfo(
 	return newStartTsList, skipSyncpointAtStartTsList, skipDMLAsStartTsList, nil
 }
 
-func (s *Sink) Close(removeChangefeed bool) {
-	// Keep direct callers compatible: if they choose remove semantics at the sink
-	// layer, run the remove-only cleanup before releasing the long-lived resources.
-	if removeChangefeed {
-		if err := s.CleanupRemovedChangefeed(); err != nil {
-			log.Warn("close mysql sink, remove changefeed meet error",
-				zap.Any("changefeed", s.changefeedID.String()),
-				zap.Error(err))
-		}
-	}
-
+func (s *Sink) Close() {
 	s.conflictDetector.CloseNotifiedNodes()
 	s.ddlWriter.Close()
 	for _, w := range s.dmlWriter {

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -410,7 +410,7 @@ func TestGetTableRecoveryInfo_StartTsGreaterThanDDLTs(t *testing.T) {
 	require.False(t, skipDMLList[2], "Table 3: skipDML should be reset to false when startTs > ddlTs")
 
 	// Clean up
-	_ = sink.Close(false)
+	sink.Close(false)
 
 	// Check all mock expectations were met (after closing)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -448,15 +448,14 @@ func TestGetTableRecoveryInfo_RemoveDDLTs(t *testing.T) {
 	}
 
 	// Clean up
-	_ = sink.Close(false)
+	sink.Close(false)
 
 	// Check all mock expectations were met (after closing)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestMysqlSinkCloseUpgradeAfterBaseClose(t *testing.T) {
-	_, sink, mock := getMysqlSink()
-	mock.ExpectClose()
+func TestMysqlSinkCleanupRemovedChangefeedUsesExplicitHelper(t *testing.T) {
+	_, sink, _ := getMysqlSink()
 
 	cleanupCalls := 0
 	sink.removeCleanupFn = func() error {
@@ -464,29 +463,16 @@ func TestMysqlSinkCloseUpgradeAfterBaseClose(t *testing.T) {
 		return nil
 	}
 
-	require.True(t, sink.Close(false))
-	require.True(t, sink.Close(true))
-	require.True(t, sink.Close(true))
+	require.NoError(t, sink.CleanupRemovedChangefeed())
 	require.Equal(t, 1, cleanupCalls)
-	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestMysqlSinkCloseUpgradeRetriesCleanup(t *testing.T) {
-	_, sink, mock := getMysqlSink()
-	mock.ExpectClose()
+func TestMysqlSinkCleanupRemovedChangefeedReturnsError(t *testing.T) {
+	_, sink, _ := getMysqlSink()
 
-	cleanupCalls := 0
 	sink.removeCleanupFn = func() error {
-		cleanupCalls++
-		if cleanupCalls == 1 {
-			return errors.New("cleanup failed")
-		}
-		return nil
+		return errors.New("cleanup failed")
 	}
 
-	require.True(t, sink.Close(false))
-	require.False(t, sink.Close(true))
-	require.True(t, sink.Close(true))
-	require.Equal(t, 2, cleanupCalls)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.ErrorContains(t, sink.CleanupRemovedChangefeed(), "cleanup failed")
 }

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -410,7 +410,7 @@ func TestGetTableRecoveryInfo_StartTsGreaterThanDDLTs(t *testing.T) {
 	require.False(t, skipDMLList[2], "Table 3: skipDML should be reset to false when startTs > ddlTs")
 
 	// Clean up
-	sink.Close(false)
+	_ = sink.Close(false)
 
 	// Check all mock expectations were met (after closing)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -448,8 +448,45 @@ func TestGetTableRecoveryInfo_RemoveDDLTs(t *testing.T) {
 	}
 
 	// Clean up
-	sink.Close(false)
+	_ = sink.Close(false)
 
 	// Check all mock expectations were met (after closing)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMysqlSinkCloseUpgradeAfterBaseClose(t *testing.T) {
+	_, sink, mock := getMysqlSink()
+	mock.ExpectClose()
+
+	cleanupCalls := 0
+	sink.removeCleanupFn = func() error {
+		cleanupCalls++
+		return nil
+	}
+
+	require.True(t, sink.Close(false))
+	require.True(t, sink.Close(true))
+	require.True(t, sink.Close(true))
+	require.Equal(t, 1, cleanupCalls)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMysqlSinkCloseUpgradeRetriesCleanup(t *testing.T) {
+	_, sink, mock := getMysqlSink()
+	mock.ExpectClose()
+
+	cleanupCalls := 0
+	sink.removeCleanupFn = func() error {
+		cleanupCalls++
+		if cleanupCalls == 1 {
+			return errors.New("cleanup failed")
+		}
+		return nil
+	}
+
+	require.True(t, sink.Close(false))
+	require.False(t, sink.Close(true))
+	require.True(t, sink.Close(true))
+	require.Equal(t, 2, cleanupCalls)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -410,7 +410,7 @@ func TestGetTableRecoveryInfo_StartTsGreaterThanDDLTs(t *testing.T) {
 	require.False(t, skipDMLList[2], "Table 3: skipDML should be reset to false when startTs > ddlTs")
 
 	// Clean up
-	sink.Close(false)
+	sink.Close()
 
 	// Check all mock expectations were met (after closing)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -448,7 +448,7 @@ func TestGetTableRecoveryInfo_RemoveDDLTs(t *testing.T) {
 	}
 
 	// Clean up
-	sink.Close(false)
+	sink.Close()
 
 	// Check all mock expectations were met (after closing)
 	require.NoError(t, mock.ExpectationsWereMet())

--- a/downstreamadapter/sink/mysql/sink_test.go
+++ b/downstreamadapter/sink/mysql/sink_test.go
@@ -453,26 +453,3 @@ func TestGetTableRecoveryInfo_RemoveDDLTs(t *testing.T) {
 	// Check all mock expectations were met (after closing)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
-
-func TestMysqlSinkCleanupRemovedChangefeedUsesExplicitHelper(t *testing.T) {
-	_, sink, _ := getMysqlSink()
-
-	cleanupCalls := 0
-	sink.removeCleanupFn = func() error {
-		cleanupCalls++
-		return nil
-	}
-
-	require.NoError(t, sink.CleanupRemovedChangefeed())
-	require.Equal(t, 1, cleanupCalls)
-}
-
-func TestMysqlSinkCleanupRemovedChangefeedReturnsError(t *testing.T) {
-	_, sink, _ := getMysqlSink()
-
-	sink.removeCleanupFn = func() error {
-		return errors.New("cleanup failed")
-	}
-
-	require.ErrorContains(t, sink.CleanupRemovedChangefeed(), "cleanup failed")
-}

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -569,7 +569,7 @@ func (s *sink) getAllTableNames(ts uint64) []*commonEvent.SchemaTableName {
 	return s.tableSchemaStore.GetAllTableNames(ts, true)
 }
 
-func (s *sink) Close(_ bool) {
+func (s *sink) Close() {
 	s.ddlProducer.close()
 	s.dmlProducer.close()
 	s.comp.close()

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -569,11 +569,12 @@ func (s *sink) getAllTableNames(ts uint64) []*commonEvent.SchemaTableName {
 	return s.tableSchemaStore.GetAllTableNames(ts, true)
 }
 
-func (s *sink) Close(_ bool) {
+func (s *sink) Close(_ bool) bool {
 	s.ddlProducer.close()
 	s.dmlProducer.close()
 	s.comp.close()
 	s.statistics.Close()
+	return true
 }
 
 func (s *sink) BatchCount() int {

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -569,12 +569,11 @@ func (s *sink) getAllTableNames(ts uint64) []*commonEvent.SchemaTableName {
 	return s.tableSchemaStore.GetAllTableNames(ts, true)
 }
 
-func (s *sink) Close(_ bool) bool {
+func (s *sink) Close(_ bool) {
 	s.ddlProducer.close()
 	s.dmlProducer.close()
 	s.comp.close()
 	s.statistics.Close()
-	return true
 }
 
 func (s *sink) BatchCount() int {

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -190,9 +190,9 @@ func (s *Sink) SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStor
 	s.ddlWriter.SetTableSchemaStore(tableSchemaStore)
 }
 
-func (s *Sink) Close(_ bool) bool {
+func (s *Sink) Close(_ bool) {
 	if !s.isClosed.CompareAndSwap(false, true) {
-		return true
+		return
 	}
 	start := time.Now()
 	s.logBuffer.Close()
@@ -219,7 +219,6 @@ func (s *Sink) Close(_ bool) bool {
 		zap.String("keyspace", s.changefeedID.Keyspace()),
 		zap.String("changefeed", s.changefeedID.Name()),
 		zap.Duration("duration", time.Since(start)))
-	return true
 }
 
 func (s *Sink) sendMessages(ctx context.Context) error {

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -190,7 +190,7 @@ func (s *Sink) SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStor
 	s.ddlWriter.SetTableSchemaStore(tableSchemaStore)
 }
 
-func (s *Sink) Close(_ bool) {
+func (s *Sink) Close() {
 	if !s.isClosed.CompareAndSwap(false, true) {
 		return
 	}

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -190,9 +190,9 @@ func (s *Sink) SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStor
 	s.ddlWriter.SetTableSchemaStore(tableSchemaStore)
 }
 
-func (s *Sink) Close(_ bool) {
+func (s *Sink) Close(_ bool) bool {
 	if !s.isClosed.CompareAndSwap(false, true) {
-		return
+		return true
 	}
 	start := time.Now()
 	s.logBuffer.Close()
@@ -219,6 +219,7 @@ func (s *Sink) Close(_ bool) {
 		zap.String("keyspace", s.changefeedID.Keyspace()),
 		zap.String("changefeed", s.changefeedID.Name()),
 		zap.Duration("duration", time.Since(start)))
+	return true
 }
 
 func (s *Sink) sendMessages(ctx context.Context) error {

--- a/downstreamadapter/sink/redo/sink_test.go
+++ b/downstreamadapter/sink/redo/sink_test.go
@@ -113,7 +113,7 @@ func TestRedoSinkBatchConfig(t *testing.T) {
 		cfg,
 	)
 	require.NoError(t, err)
-	defer sink.Close(false)
+	defer sink.Close()
 
 	require.Equal(t, 4096, sink.BatchCount())
 	require.Equal(t, int(32*redo.Megabyte), sink.BatchBytes())
@@ -146,7 +146,7 @@ func TestRedoSinkInProcessor(t *testing.T) {
 		cfg.UseFileBackend = util.AddressOf(useFileBackend)
 		dmlMgr, err := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName), cfg)
 		require.NoError(t, err)
-		defer dmlMgr.Close(false)
+		defer dmlMgr.Close()
 
 		var eg errgroup.Group
 		eg.Go(func() error {
@@ -229,7 +229,7 @@ func TestRedoSinkError(t *testing.T) {
 	cfg := newTestConsistentConfig("blackhole-invalid://")
 	logMgr, err := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName), cfg)
 	require.NoError(t, err)
-	defer logMgr.Close(false)
+	defer logMgr.Close()
 
 	var eg errgroup.Group
 	eg.Go(func() error {
@@ -283,7 +283,7 @@ func runBenchTest(b *testing.B, storage string, useFileBackend bool) {
 	cfg.UseFileBackend = util.AddressOf(useFileBackend)
 	dmlMgr, err := New(ctx, common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName), cfg)
 	require.NoError(b, err)
-	defer dmlMgr.Close(false)
+	defer dmlMgr.Close()
 
 	var eg errgroup.Group
 	eg.Go(func() error {

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -43,7 +43,10 @@ type Sink interface {
 	AddCheckpointTs(ts uint64)
 
 	SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStore)
-	Close(removeChangefeed bool)
+	// Close is idempotent and may be called multiple times as remove semantics are
+	// upgraded from stop to delete. It returns whether all close work required by
+	// the latest remove intent has completed.
+	Close(removeChangefeed bool) bool
 	Run(ctx context.Context) error
 	BatchCount() int
 	BatchBytes() int

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -49,13 +49,6 @@ type Sink interface {
 	BatchBytes() int
 }
 
-// RemoveChangefeedCleaner is implemented by sinks that need an explicit
-// remove-only cleanup step after the base close path has released shared
-// resources.
-type RemoveChangefeedCleaner interface {
-	CleanupRemovedChangefeed() error
-}
-
 func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) (Sink, error) {
 	sinkURI, err := url.Parse(cfg.SinkURI)
 	if err != nil {

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -43,7 +43,7 @@ type Sink interface {
 	AddCheckpointTs(ts uint64)
 
 	SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStore)
-	Close(removeChangefeed bool)
+	Close()
 	Run(ctx context.Context) error
 	BatchCount() int
 	BatchBytes() int

--- a/downstreamadapter/sink/sink.go
+++ b/downstreamadapter/sink/sink.go
@@ -43,13 +43,17 @@ type Sink interface {
 	AddCheckpointTs(ts uint64)
 
 	SetTableSchemaStore(tableSchemaStore *commonEvent.TableSchemaStore)
-	// Close is idempotent and may be called multiple times as remove semantics are
-	// upgraded from stop to delete. It returns whether all close work required by
-	// the latest remove intent has completed.
-	Close(removeChangefeed bool) bool
+	Close(removeChangefeed bool)
 	Run(ctx context.Context) error
 	BatchCount() int
 	BatchBytes() int
+}
+
+// RemoveChangefeedCleaner is implemented by sinks that need an explicit
+// remove-only cleanup step after the base close path has released shared
+// resources.
+type RemoveChangefeedCleaner interface {
+	CleanupRemovedChangefeed() error
 }
 
 func New(ctx context.Context, cfg *config.ChangefeedConfig, changefeedID common.ChangeFeedID) (Sink, error) {

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -478,7 +478,7 @@ func (ra *RedoApplier) Apply(egCtx context.Context) (err error) {
 	ra.updateSplitter = newUpdateEventSplitter(ra.rd, ra.cfg.Dir)
 
 	eg.Go(func() error {
-		defer ra.mysqlSink.Close(false)
+		defer ra.mysqlSink.Close()
 		return ra.consumeLogs(egCtx)
 	})
 


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: close https://github.com/pingcap/ticdc/issues/4825

### What is changed and how it works?

## Background
The dispatcher orchestrator de-duplicates close requests by changefeed and message type. A later `removed=true` close request could overwrite the pending entry for the same key while the earlier `removed=false` request was already in flight.

## Motivation
That overwrite was not re-queued, and `Done(key)` later deleted the upgraded request together with the in-flight one. As a result, the stronger remove semantics could be dropped silently and the downstream cleanup path would only execute the normal close flow.

## Summary of changes
- split the pending close queue state into `queued` and `inFlight` slots so an upgrade never overwrites the request a worker is already processing
- re-queue upgraded `removed=true` close requests for the next round and keep the in-flight request stable until `Done`
- make `DispatcherManager` keep `removed=true` as a sticky close requirement and finish remove-only cleanup even after the base close path has completed
- add a retryable MySQL remove cleanup helper so ddl_ts cleanup still works after the normal sink close releases the long-lived DB handle
- add regression tests for both the queue upgrade timing and the post-close remove cleanup path

## Validation
- `make fmt`
- `go test ./downstreamadapter/dispatcherorchestrator`
- `go test ./downstreamadapter/dispatchermanager`
- `go test --tags=intest ./downstreamadapter/sink/mysql`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced changefeed removal and cleanup processes to properly handle late removal requests and ensure cleanup completes even after initial shutdown
- Improved message queue dequeue operation to return message content directly, enabling more reliable request processing and ordering
- Refined message queue behavior for more predictable duplicate prevention and request ordering during queue operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None