### PR TITLE
maintainer: disable no-operator terminal-status fallback logic

### DIFF
--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -188,42 +188,6 @@ func (c *Controller) HandleStatus(from node.ID, statusList []*heartbeatpb.TableS
 			continue
 		}
 		spanController.UpdateStatus(stm, status)
-
-		// Fallback: dispatcher becomes non-working without an operator.
-		//
-		// In normal scheduling flow, a dispatcher should transition to Stopped/Removed as part of a maintainer
-		// operator (Remove/Move/Split...). However, after maintainer failover we can lose operatorController state
-		// while dispatcher managers keep executing the already-issued requests.
-		//
-		// A real example is a "remove request in transit" during bootstrap:
-		// - Old maintainer sends a Remove (e.g. the remove-origin phase of Move), but the request hasn't reached
-		//   dispatcher manager yet.
-		// - New maintainer bootstraps from dispatcher manager snapshots and sees the dispatcher as Working, with
-		//   no in-flight operator reported in bootstrap response.
-		// - After bootstrap, the in-transit Remove arrives, the dispatcher is removed, and the new maintainer
-		//   observes a terminal status without a corresponding operator.
-		//
-		// In these cases we'd observe a non-working status but have no operator to drive the follow-up
-		// rescheduling, so we mark the span absent to let the scheduler recreate it.
-		//
-		// Safety against message reordering/resend:
-		// - We only reach here when stm != nil and stm.GetNodeID() == from (checked above). If the span was already
-		//   rebound to a different node, we skip it, so late statuses from the old node won't trigger rescheduling.
-		// - MarkSpanAbsent is idempotent and only affects the scheduler state, so even if we get duplicate terminal
-		//   statuses, the worst case is an extra no-op absent mark.
-		// TODO: temporarily comment out the fallback logic to avoid unexpected rescheduling, we will re-enable it
-		// after we have more confidence on the stability of the system in the failover scenario.
-		// if status.ComponentStatus == heartbeatpb.ComponentState_Stopped ||
-		// 	status.ComponentStatus == heartbeatpb.ComponentState_Removed {
-		// 	if op := operatorController.GetOperator(dispatcherID); op == nil {
-		// 		log.Warn("dispatcher becomes non-working without operator, mark span absent for rescheduling",
-		// 			zap.String("changefeed", c.changefeedID.Name()),
-		// 			zap.String("from", from.String()),
-		// 			zap.String("dispatcherID", dispatcherID.String()),
-		// 			zap.Any("status", status))
-		// 		spanController.MarkSpanAbsent(stm)
-		// 	}
-		// }
 	}
 }
 

--- a/maintainer/maintainer_controller.go
+++ b/maintainer/maintainer_controller.go
@@ -211,17 +211,19 @@ func (c *Controller) HandleStatus(from node.ID, statusList []*heartbeatpb.TableS
 		//   rebound to a different node, we skip it, so late statuses from the old node won't trigger rescheduling.
 		// - MarkSpanAbsent is idempotent and only affects the scheduler state, so even if we get duplicate terminal
 		//   statuses, the worst case is an extra no-op absent mark.
-		if status.ComponentStatus == heartbeatpb.ComponentState_Stopped ||
-			status.ComponentStatus == heartbeatpb.ComponentState_Removed {
-			if op := operatorController.GetOperator(dispatcherID); op == nil {
-				log.Warn("dispatcher becomes non-working without operator, mark span absent for rescheduling",
-					zap.String("changefeed", c.changefeedID.Name()),
-					zap.String("from", from.String()),
-					zap.String("dispatcherID", dispatcherID.String()),
-					zap.Any("status", status))
-				spanController.MarkSpanAbsent(stm)
-			}
-		}
+		// TODO: temporarily comment out the fallback logic to avoid unexpected rescheduling, we will re-enable it
+		// after we have more confidence on the stability of the system in the failover scenario.
+		// if status.ComponentStatus == heartbeatpb.ComponentState_Stopped ||
+		// 	status.ComponentStatus == heartbeatpb.ComponentState_Removed {
+		// 	if op := operatorController.GetOperator(dispatcherID); op == nil {
+		// 		log.Warn("dispatcher becomes non-working without operator, mark span absent for rescheduling",
+		// 			zap.String("changefeed", c.changefeedID.Name()),
+		// 			zap.String("from", from.String()),
+		// 			zap.String("dispatcherID", dispatcherID.String()),
+		// 			zap.Any("status", status))
+		// 		spanController.MarkSpanAbsent(stm)
+		// 	}
+		// }
 	}
 }
 

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -61,7 +61,9 @@ mysql_groups=(
 	# G12
 	'row_format tiflash multi_rocks fail_over_ddl_M correctness_for_shared_column_schema'
 	# G13
-	'cli_tls_with_auth cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
+	# maintainer_failover_when_operator is temporarily excluded from release-8.5 CI because this branch
+	# disables the no-operator terminal-status fallback; the case depends on that rescheduling path.
+	'cli_tls_with_auth cli_with_auth fail_over_ddl_N'
 	# G14
 	'batch_add_table batch_update_to_no_batch fail_over_ddl_O update_changefeed_check_config pause_changefeed_with_long_time_ddl'
 	# G15
@@ -99,7 +101,9 @@ kafka_groups=(
 	# G12
 	'row_format tiflash multi_rocks fail_over_ddl_M correctness_for_shared_column_schema'
 	# G13
-	'cli_tls_with_auth cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
+	# maintainer_failover_when_operator is temporarily excluded from release-8.5 CI because this branch
+	# disables the no-operator terminal-status fallback; the case depends on that rescheduling path.
+	'cli_tls_with_auth cli_with_auth fail_over_ddl_N'
 	# G14
 	'kafka_simple_basic avro_basic debezium_basic fail_over_ddl_O update_changefeed_check_config'
 	# G15
@@ -137,7 +141,9 @@ pulsar_groups=(
 	# G12
 	'row_format tiflash multi_rocks fail_over_ddl_M correctness_for_shared_column_schema'
 	# G13
-	'cli_tls_with_auth cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
+	# maintainer_failover_when_operator is temporarily excluded from release-8.5 CI because this branch
+	# disables the no-operator terminal-status fallback; the case depends on that rescheduling path.
+	'cli_tls_with_auth cli_with_auth fail_over_ddl_N'
 	# G14
 	'avro_basic debezium_basic fail_over_ddl_O update_changefeed_check_config'
 	# G15
@@ -175,7 +181,9 @@ storage_groups=(
 	# G12
 	'row_format tiflash multi_rocks fail_over_ddl_M correctness_for_shared_column_schema'
 	# G13
-	'cli_tls_with_auth cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
+	# maintainer_failover_when_operator is temporarily excluded from release-8.5 CI because this branch
+	# disables the no-operator terminal-status fallback; the case depends on that rescheduling path.
+	'cli_tls_with_auth cli_with_auth fail_over_ddl_N'
 	# G14
 	'csv_storage_partition_table csv_storage_multi_tables_ddl fail_over_ddl_O'
 	# G15


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4874

The maintainer fallback logic currently marks a span absent when a dispatcher reports `Stopped` or `Removed` without an active operator. This can recover some maintainer failover cases, but it can also misclassify valid terminal statuses and unexpectedly add a dispatcher back after it was legitimately removed.

### What is changed and how it works?

This PR temporarily disables the no-operator terminal-status fallback in `Controller.HandleStatus` on the release-8.5 branch.

The existing orphan-working-dispatcher cleanup is kept unchanged. Only the `Stopped`/`Removed` fallback rescheduling path is disabled.

The `maintainer_failover_when_operator` integration test is also removed from release-8.5 light CI groups for mysql, kafka, pulsar, and storage. That test depends on the disabled fallback rescheduling path, so it is expected to fail while this stopgap is active. Comments were added beside the removed CI entries to explain the temporary exclusion.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test

Manual test:

```bash
bash -n tests/integration_tests/run_light_it_in_ci.sh
bash -c 'source tests/integration_tests/_utils/check_coverage.sh; check_test_coverage tests/integration_tests'
```

The coverage check exits successfully. It prints the existing uncovered-test warning list, now including `maintainer_failover_when_operator` because the test directory is intentionally kept but no longer scheduled by CI.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No performance regression is expected. This is a temporary behavior change in maintainer failover recovery: it avoids unexpected dispatcher re-creation at the cost of disabling one fallback self-healing path.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix an issue that TiCDC maintainer may unexpectedly reschedule a dispatcher after it has been removed.
```