### PR TITLE
logpuller: fix potential stuck on EOF error

### DIFF
--- a/logservice/logpuller/errors.go
+++ b/logservice/logpuller/errors.go
@@ -45,9 +45,9 @@ type getStoreErr struct{}
 
 func (e *getStoreErr) Error() string { return "get store error" }
 
-type sendRequestToStoreErr struct{}
+type storeStreamErr struct{}
 
-func (e *sendRequestToStoreErr) Error() string { return "send request to store error" }
+func (e *storeStreamErr) Error() string { return "store stream error" }
 
 type requestCancelledErr struct{}
 

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -414,7 +414,7 @@ func (s *regionRequestWorker) processRegionSendTask(
 			// It can be skipped directly because there must be no pending states from
 			// the stopped subscribedTable, or the special singleRegionInfo for stopping
 			// the table will be handled later.
-				s.client.onRegionFail(newRegionErrorInfo(region, &storeStreamErr{}))
+			s.client.onRegionFail(newRegionErrorInfo(region, &storeStreamErr{}))
 			s.requestCache.markDone()
 		} else {
 			state := newRegionFeedState(region, uint64(subID), s)

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -206,6 +206,13 @@ func (s *regionRequestWorker) run(ctx context.Context, credential *security.Cred
 	return isCanceled()
 }
 
+func normalizeSendRequestError(err error) error {
+	if StatusIsEOF(grpcstatus.Convert(err)) {
+		return &sendRequestToStoreErr{}
+	}
+	return errors.Trace(err)
+}
+
 // receiveAndDispatchChangeEventsToProcessor receives events from the grpc stream and dispatches them to ds.
 func (s *regionRequestWorker) receiveAndDispatchChangeEvents(conn *ConnAndClient) error {
 	for {
@@ -353,7 +360,7 @@ func (s *regionRequestWorker) processRegionSendTask(
 				zap.Uint64("regionID", req.RegionId),
 				zap.String("addr", s.store.storeAddr),
 				zap.Error(err))
-			return errors.Trace(err)
+			return normalizeSendRequestError(err)
 		}
 		// TODO: add a metric?
 		return nil

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -206,7 +206,7 @@ func (s *regionRequestWorker) run(ctx context.Context, credential *security.Cred
 	return isCanceled()
 }
 
-func normalizeSendRequestError(err error) error {
+func normalizeStreamError(err error) error {
 	if StatusIsEOF(grpcstatus.Convert(err)) {
 		return &sendRequestToStoreErr{}
 	}
@@ -223,10 +223,7 @@ func (s *regionRequestWorker) receiveAndDispatchChangeEvents(conn *ConnAndClient
 				zap.String("addr", s.store.storeAddr),
 				zap.String("code", grpcstatus.Code(err).String()),
 				zap.Error(err))
-			if StatusIsEOF(grpcstatus.Convert(err)) {
-				return nil
-			}
-			return errors.Trace(err)
+			return normalizeStreamError(err)
 		}
 		if len(changeEvent.Events) > 0 {
 			s.dispatchRegionChangeEvents(changeEvent.Events)
@@ -360,7 +357,7 @@ func (s *regionRequestWorker) processRegionSendTask(
 				zap.Uint64("regionID", req.RegionId),
 				zap.String("addr", s.store.storeAddr),
 				zap.Error(err))
-			return normalizeSendRequestError(err)
+			return normalizeStreamError(err)
 		}
 		// TODO: add a metric?
 		return nil

--- a/logservice/logpuller/region_request_worker.go
+++ b/logservice/logpuller/region_request_worker.go
@@ -115,13 +115,13 @@ func newRegionRequestWorker(
 				if cerror.Is(err, cerror.ErrGetAllStoresFailed) {
 					regionErr = &getStoreErr{}
 				} else {
-					regionErr = &sendRequestToStoreErr{}
+					regionErr = &storeStreamErr{}
 				}
 			} else {
 				if canceled := worker.run(ctx, credential); canceled {
 					return nil
 				}
-				regionErr = &sendRequestToStoreErr{}
+				regionErr = &storeStreamErr{}
 			}
 			for subID, m := range worker.clearRegionStates() {
 				for _, state := range m {
@@ -208,7 +208,7 @@ func (s *regionRequestWorker) run(ctx context.Context, credential *security.Cred
 
 func normalizeStreamError(err error) error {
 	if StatusIsEOF(grpcstatus.Convert(err)) {
-		return &sendRequestToStoreErr{}
+		return &storeStreamErr{}
 	}
 	return errors.Trace(err)
 }
@@ -414,7 +414,7 @@ func (s *regionRequestWorker) processRegionSendTask(
 			// It can be skipped directly because there must be no pending states from
 			// the stopped subscribedTable, or the special singleRegionInfo for stopping
 			// the table will be handled later.
-			s.client.onRegionFail(newRegionErrorInfo(region, &sendRequestToStoreErr{}))
+				s.client.onRegionFail(newRegionErrorInfo(region, &storeStreamErr{}))
 			s.requestCache.markDone()
 		} else {
 			state := newRegionFeedState(region, uint64(subID), s)

--- a/logservice/logpuller/region_request_worker_test.go
+++ b/logservice/logpuller/region_request_worker_test.go
@@ -15,6 +15,7 @@ package logpuller
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -26,7 +27,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/tikv"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 type mockEventFeedV2Client struct {
@@ -331,4 +334,61 @@ func TestProcessRegionSendTaskSendFailureCleansSentRequest(t *testing.T) {
 	require.Empty(t, worker.requestCache.sentRequests.regionReqs)
 	state := worker.getRegionState(req.regionInfo.subscribedSpan.subID, req.regionInfo.verID.GetID())
 	require.True(t, state == nil || state.isStale(), "region state should be removed or marked stale after send failure")
+}
+
+func TestProcessRegionSendTaskSendEOFIsRetriable(t *testing.T) {
+	testCases := []struct {
+		name    string
+		sendErr error
+	}{
+		{
+			name:    "io EOF",
+			sendErr: io.EOF,
+		},
+		{
+			name:    "grpc canceled",
+			sendErr: grpcstatus.Error(codes.Canceled, context.Canceled.Error()),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			worker := &regionRequestWorker{
+				requestCache: newRequestCache(10),
+				store:        &requestedStore{storeAddr: "store-1"},
+				client:       &subscriptionClient{},
+			}
+			worker.requestedRegions.subscriptions = make(map[SubscriptionID]regionFeedStates)
+
+			ctx := context.Background()
+			region := prepareRegionForSendTest(createTestRegionInfo(1, 1))
+
+			ok, err := worker.requestCache.add(ctx, region, false)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			req, err := worker.requestCache.pop(ctx)
+			require.NoError(t, err)
+			worker.preFetchForConnecting = new(regionInfo)
+			*worker.preFetchForConnecting = req.regionInfo
+
+			conn := &ConnAndClient{
+				Client: &mockEventFeedV2Client{sendErr: tc.sendErr},
+				Conn:   &grpc.ClientConn{},
+			}
+
+			err = worker.processRegionSendTask(ctx, conn)
+			var sendRequestErr *sendRequestToStoreErr
+			require.ErrorAs(t, err, &sendRequestErr)
+			require.Equal(t, 0, worker.requestCache.getPendingCount())
+			require.Empty(t, worker.requestCache.sentRequests.regionReqs)
+
+			state := worker.getRegionState(req.regionInfo.subscribedSpan.subID, req.regionInfo.verID.GetID())
+			require.NotNil(t, state)
+			require.True(t, state.isStale())
+
+			var storedErr *sendRequestToStoreErr
+			require.ErrorAs(t, state.takeError(), &storedErr)
+		})
+	}
 }

--- a/logservice/logpuller/region_request_worker_test.go
+++ b/logservice/logpuller/region_request_worker_test.go
@@ -34,10 +34,11 @@ import (
 
 type mockEventFeedV2Client struct {
 	sendErr error
+	recvErr error
 }
 
 func (m *mockEventFeedV2Client) Send(*cdcpb.ChangeDataRequest) error   { return m.sendErr }
-func (m *mockEventFeedV2Client) Recv() (*cdcpb.ChangeDataEvent, error) { return nil, nil }
+func (m *mockEventFeedV2Client) Recv() (*cdcpb.ChangeDataEvent, error) { return nil, m.recvErr }
 func (m *mockEventFeedV2Client) Header() (metadata.MD, error)          { return metadata.MD{}, nil }
 func (m *mockEventFeedV2Client) Trailer() metadata.MD                  { return metadata.MD{} }
 func (m *mockEventFeedV2Client) CloseSend() error                      { return nil }
@@ -389,6 +390,38 @@ func TestProcessRegionSendTaskSendEOFIsRetriable(t *testing.T) {
 
 			var storedErr *sendRequestToStoreErr
 			require.ErrorAs(t, state.takeError(), &storedErr)
+		})
+	}
+}
+
+func TestReceiveAndDispatchChangeEventsEOFIsRetriable(t *testing.T) {
+	testCases := []struct {
+		name    string
+		recvErr error
+	}{
+		{
+			name:    "io EOF",
+			recvErr: io.EOF,
+		},
+		{
+			name:    "grpc canceled",
+			recvErr: grpcstatus.Error(codes.Canceled, context.Canceled.Error()),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			worker := &regionRequestWorker{
+				store: &requestedStore{storeAddr: "store-1"},
+			}
+			conn := &ConnAndClient{
+				Client: &mockEventFeedV2Client{recvErr: tc.recvErr},
+				Conn:   &grpc.ClientConn{},
+			}
+
+			err := worker.receiveAndDispatchChangeEvents(conn)
+			var streamErr *sendRequestToStoreErr
+			require.ErrorAs(t, err, &streamErr)
 		})
 	}
 }

--- a/logservice/logpuller/region_request_worker_test.go
+++ b/logservice/logpuller/region_request_worker_test.go
@@ -379,8 +379,8 @@ func TestProcessRegionSendTaskSendEOFIsRetriable(t *testing.T) {
 			}
 
 			err = worker.processRegionSendTask(ctx, conn)
-				var streamErr *storeStreamErr
-				require.ErrorAs(t, err, &streamErr)
+			var streamErr *storeStreamErr
+			require.ErrorAs(t, err, &streamErr)
 			require.Equal(t, 0, worker.requestCache.getPendingCount())
 			require.Empty(t, worker.requestCache.sentRequests.regionReqs)
 
@@ -388,8 +388,8 @@ func TestProcessRegionSendTaskSendEOFIsRetriable(t *testing.T) {
 			require.NotNil(t, state)
 			require.True(t, state.isStale())
 
-				var storedErr *storeStreamErr
-				require.ErrorAs(t, state.takeError(), &storedErr)
+			var storedErr *storeStreamErr
+			require.ErrorAs(t, state.takeError(), &storedErr)
 		})
 	}
 }

--- a/logservice/logpuller/region_request_worker_test.go
+++ b/logservice/logpuller/region_request_worker_test.go
@@ -379,8 +379,8 @@ func TestProcessRegionSendTaskSendEOFIsRetriable(t *testing.T) {
 			}
 
 			err = worker.processRegionSendTask(ctx, conn)
-			var sendRequestErr *sendRequestToStoreErr
-			require.ErrorAs(t, err, &sendRequestErr)
+				var streamErr *storeStreamErr
+				require.ErrorAs(t, err, &streamErr)
 			require.Equal(t, 0, worker.requestCache.getPendingCount())
 			require.Empty(t, worker.requestCache.sentRequests.regionReqs)
 
@@ -388,8 +388,8 @@ func TestProcessRegionSendTaskSendEOFIsRetriable(t *testing.T) {
 			require.NotNil(t, state)
 			require.True(t, state.isStale())
 
-			var storedErr *sendRequestToStoreErr
-			require.ErrorAs(t, state.takeError(), &storedErr)
+				var storedErr *storeStreamErr
+				require.ErrorAs(t, state.takeError(), &storedErr)
 		})
 	}
 }
@@ -420,7 +420,7 @@ func TestReceiveAndDispatchChangeEventsEOFIsRetriable(t *testing.T) {
 			}
 
 			err := worker.receiveAndDispatchChangeEvents(conn)
-			var streamErr *sendRequestToStoreErr
+			var streamErr *storeStreamErr
 			require.ErrorAs(t, err, &streamErr)
 		})
 	}

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -907,7 +907,7 @@ func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionEr
 		s.regionCache.OnSendFail(bo, errInfo.rpcCtx, true, err)
 		s.scheduleRangeRequest(ctx, errInfo.span, errInfo.subscribedSpan, errInfo.filterLoop, TaskHighPrior)
 		return nil
-	case *sendRequestToStoreErr:
+	case *storeStreamErr:
 		metricStoreSendRequestErr.Inc()
 		bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
 		s.regionCache.OnSendFail(bo, errInfo.rpcCtx, regionScheduleReload, err)

--- a/tests/integration_tests/kv_client_stream_reconnect/run.sh
+++ b/tests/integration_tests/kv_client_stream_reconnect/run.sh
@@ -63,7 +63,6 @@ EOF
 		echo "" >$WORK_DIR/pulsar_test.toml
 	fi
 	changefeed_id=$(cdc_cli_changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" --config $WORK_DIR/pulsar_test.toml | grep '^ID:' | head -n1 | awk '{print $2}')
-	ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
 	case $SINK_TYPE in
 	kafka) run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=open-protocol&partition-num=4&version=${KAFKA_VERSION}&max-message-bytes=10485760" $WORK_DIR/pulsar_test.toml ;;
 	storage) run_storage_consumer $WORK_DIR $SINK_URI $WORK_DIR/pulsar_test.toml "" ;;
@@ -79,9 +78,6 @@ EOF
 	for i in $(seq 60); do
 		tbl="t$((1 + $RANDOM % $TABLE_COUNT))"
 		run_sql "insert into kv_client_stream_reconnect.$tbl values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-		if ((i % 10 == 0)); then
-			ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
-		fi
 		sleep 1
 	done
 

--- a/tests/integration_tests/kv_client_stream_reconnect/run.sh
+++ b/tests/integration_tests/kv_client_stream_reconnect/run.sh
@@ -11,6 +11,13 @@ TABLE_COUNT=10
 FAILPOINT_API_TEST_NAME="github.com/pingcap/ticdc/utils/dynstream/FailpointAPITestValue"
 FAILPOINT_API_TEST_VALUE="kv_client_stream_reconnect"
 
+function check_changefeed_normal() {
+	local pd_addr=$1
+	local changefeed_id=$2
+
+	ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
+}
+
 function check_failpoint_log_value() {
 	local value=$1
 	local log_file="$WORK_DIR/cdc.log"
@@ -63,6 +70,7 @@ EOF
 		echo "" >$WORK_DIR/pulsar_test.toml
 	fi
 	changefeed_id=$(cdc_cli_changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" --config $WORK_DIR/pulsar_test.toml | grep '^ID:' | head -n1 | awk '{print $2}')
+	check_changefeed_normal "$pd_addr" "$changefeed_id"
 	case $SINK_TYPE in
 	kafka) run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=open-protocol&partition-num=4&version=${KAFKA_VERSION}&max-message-bytes=10485760" $WORK_DIR/pulsar_test.toml ;;
 	storage) run_storage_consumer $WORK_DIR $SINK_URI $WORK_DIR/pulsar_test.toml "" ;;
@@ -78,11 +86,15 @@ EOF
 	for i in $(seq 60); do
 		tbl="t$((1 + $RANDOM % $TABLE_COUNT))"
 		run_sql "insert into kv_client_stream_reconnect.$tbl values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+		if ((i % 10 == 0)); then
+			check_changefeed_normal "$pd_addr" "$changefeed_id"
+		fi
 		sleep 1
 	done
 
 	check_failpoint_log_value "$FAILPOINT_API_TEST_VALUE"
 	disable_failpoint --name "$FAILPOINT_API_TEST_NAME"
+	check_changefeed_normal "$pd_addr" "$changefeed_id"
 
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 	export GO_FAILPOINTS=''

--- a/tests/integration_tests/kv_client_stream_reconnect/run.sh
+++ b/tests/integration_tests/kv_client_stream_reconnect/run.sh
@@ -11,13 +11,6 @@ TABLE_COUNT=10
 FAILPOINT_API_TEST_NAME="github.com/pingcap/ticdc/utils/dynstream/FailpointAPITestValue"
 FAILPOINT_API_TEST_VALUE="kv_client_stream_reconnect"
 
-function check_changefeed_normal() {
-	local pd_addr=$1
-	local changefeed_id=$2
-
-	ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
-}
-
 function check_failpoint_log_value() {
 	local value=$1
 	local log_file="$WORK_DIR/cdc.log"
@@ -70,7 +63,7 @@ EOF
 		echo "" >$WORK_DIR/pulsar_test.toml
 	fi
 	changefeed_id=$(cdc_cli_changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" --config $WORK_DIR/pulsar_test.toml | grep '^ID:' | head -n1 | awk '{print $2}')
-	check_changefeed_normal "$pd_addr" "$changefeed_id"
+	ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
 	case $SINK_TYPE in
 	kafka) run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=open-protocol&partition-num=4&version=${KAFKA_VERSION}&max-message-bytes=10485760" $WORK_DIR/pulsar_test.toml ;;
 	storage) run_storage_consumer $WORK_DIR $SINK_URI $WORK_DIR/pulsar_test.toml "" ;;
@@ -87,14 +80,14 @@ EOF
 		tbl="t$((1 + $RANDOM % $TABLE_COUNT))"
 		run_sql "insert into kv_client_stream_reconnect.$tbl values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 		if ((i % 10 == 0)); then
-			check_changefeed_normal "$pd_addr" "$changefeed_id"
+			ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
 		fi
 		sleep 1
 	done
 
 	check_failpoint_log_value "$FAILPOINT_API_TEST_VALUE"
 	disable_failpoint --name "$FAILPOINT_API_TEST_NAME"
-	check_changefeed_normal "$pd_addr" "$changefeed_id"
+	ensure 20 check_changefeed_state "$pd_addr" "$changefeed_id" "normal" "null" ""
 
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 	export GO_FAILPOINTS=''


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4880 

### What is changed and how it works?

This pull request addresses a potential issue where gRPC stream errors, specifically EOF, were not being handled as retriable, leading to silent failures in the logpuller. By centralizing error normalization, the system now correctly identifies these transient failures and triggers a reconnection, ensuring the stability and reliability of the changefeed process.

### Highlights

* **Stream Error Normalization**: Introduced a centralized `normalizeStreamError` function to consistently map EOF and canceled gRPC stream errors to a retriable `storeStreamErr` type.
* **Error Handling Consistency**: Renamed `sendRequestToStoreErr` to `storeStreamErr` and updated both send and receive paths to use the new normalization logic, preventing silent loop termination.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made stream error handling consistent: EOF-like and canceled stream errors are now normalized and treated as retriable, preventing silent termination of send/receive loops.

* **Tests**
  * Added unit tests for send/receive EOF and canceled-stream scenarios, verifying pending requests are cleared and region state is marked stale.
  * Added integration check to confirm changefeed returns to and remains in normal state after reconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->