### PR TITLE
eventcollector, eventbroker: fix deadlock when available memory quota is zero

### DIFF
--- a/downstreamadapter/eventcollector/event_collector.go
+++ b/downstreamadapter/eventcollector/event_collector.go
@@ -738,10 +738,6 @@ func (c *EventCollector) newCongestionControlMessages() map[node.ID]*event.Conge
 		congestionControl := event.NewCongestionControlWithVersion(event.CongestionControlVersion2)
 
 		for changefeedID, dispatcherMemory := range changefeedDispatchers {
-			if len(dispatcherMemory) == 0 {
-				continue
-			}
-
 			// get total available memory directly from AreaMemoryMetric
 			totalAvailable, ok := changefeedTotalMemory[changefeedID]
 			if !ok {

--- a/downstreamadapter/eventcollector/event_collector_test.go
+++ b/downstreamadapter/eventcollector/event_collector_test.go
@@ -30,10 +30,44 @@ import (
 	"github.com/pingcap/ticdc/pkg/messaging"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/ticdc/utils/dynstream"
 	"github.com/stretchr/testify/require"
 )
 
 var _ dispatcher.DispatcherService = (*mockEventDispatcher)(nil)
+var _ dynstream.DynamicStream[common.GID, common.DispatcherID, dispatcher.DispatcherEvent, *dispatcherStat, *EventsHandler] = (*mockDynamicStream)(nil)
+
+type mockDynamicStream struct {
+	metrics dynstream.Metrics[common.GID, common.DispatcherID]
+}
+
+func (m *mockDynamicStream) Start() {}
+
+func (m *mockDynamicStream) Close() {}
+
+func (m *mockDynamicStream) Push(common.DispatcherID, dispatcher.DispatcherEvent) {}
+
+func (m *mockDynamicStream) Wake(common.DispatcherID) {}
+
+func (m *mockDynamicStream) Feedback() <-chan dynstream.Feedback[common.GID, common.DispatcherID, *dispatcherStat] {
+	return nil
+}
+
+func (m *mockDynamicStream) AddPath(common.DispatcherID, *dispatcherStat, ...dynstream.AreaSettings) error {
+	return nil
+}
+
+func (m *mockDynamicStream) RemovePath(common.DispatcherID) error {
+	return nil
+}
+
+func (m *mockDynamicStream) Release(common.DispatcherID) {}
+
+func (m *mockDynamicStream) SetAreaSettings(common.GID, dynstream.AreaSettings) {}
+
+func (m *mockDynamicStream) GetMetrics() dynstream.Metrics[common.GID, common.DispatcherID] {
+	return m.metrics
+}
 
 type mockEventDispatcher struct {
 	id                       common.DispatcherID
@@ -584,4 +618,45 @@ func TestEventCollectorBatchByBytes(t *testing.T) {
 
 	require.Equal(t, totalDML, sumDML)
 	require.Equal(t, 1, maxBatch)
+}
+
+func TestNewCongestionControlMessagesSendZeroAvailableWithoutDispatcherMetrics(t *testing.T) {
+	changefeedID := common.NewChangefeedID4Test("default", t.Name())
+	dispatcherID := common.NewDispatcherID()
+	remoteID := node.ID("remote-event-service")
+	c := &EventCollector{
+		serverId: node.NewID(),
+		ds: &mockDynamicStream{
+			metrics: dynstream.Metrics[common.GID, common.DispatcherID]{
+				MemoryControl: dynstream.MemoryMetric[common.GID, common.DispatcherID]{
+					AreaMemoryMetrics: []dynstream.AreaMemoryMetric[common.GID, common.DispatcherID]{
+						{
+							AreaValue:           changefeedID.ID(),
+							PathAvailableMemory: map[common.DispatcherID]int64{},
+							UsedMemoryValue:     1024,
+							MaxMemoryValue:      1024,
+						},
+					},
+				},
+			},
+		},
+		redoDs: &mockDynamicStream{},
+	}
+
+	c.changefeedMap.Store(changefeedID.ID(), newChangefeedStat(changefeedID))
+	stat := newDispatcherStat(&mockEventDispatcher{
+		id:           dispatcherID,
+		tableSpan:    &heartbeatpb.TableSpan{TableID: 1},
+		changefeedID: changefeedID,
+	}, c, nil)
+	stat.connState.setEventServiceID(remoteID)
+	c.dispatcherMap.Store(dispatcherID, stat)
+
+	messages := c.newCongestionControlMessages()
+	message, ok := messages[remoteID]
+	require.True(t, ok)
+	require.Len(t, message.GetAvailables(), 1)
+	require.Equal(t, uint64(0), message.GetAvailables()[0].Available)
+	require.Equal(t, uint32(0), message.GetAvailables()[0].DispatcherCount)
+	require.Empty(t, message.GetAvailables()[0].DispatcherAvailable)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where congestion control messages were being skipped for nodes without dispatcher-level memory metrics, affecting system resource visibility. The system now properly includes all nodes in congestion control messaging, ensuring accurate memory availability data is transmitted to support consistent resource allocation and improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->