### PR TITLE
eventcollector, eventbroker: fix deadlock when available memory quota is zero

### DIFF
--- a/downstreamadapter/eventcollector/event_collector.go
+++ b/downstreamadapter/eventcollector/event_collector.go
@@ -688,13 +688,11 @@ func (c *EventCollector) newCongestionControlMessages() map[node.ID]*event.Conge
 
 			// get total available memory directly from AreaMemoryMetric
 			totalAvailable := uint64(changefeedTotalMemory[changefeedID])
-			if totalAvailable > 0 {
-				congestionControl.AddAvailableMemoryWithDispatchers(
-					changefeedID.ID(),
-					totalAvailable,
-					dispatcherMemory,
-				)
-			}
+			congestionControl.AddAvailableMemoryWithDispatchers(
+				changefeedID.ID(),
+				totalAvailable,
+				dispatcherMemory,
+			)
 		}
 
 		if len(congestionControl.GetAvailables()) > 0 {

--- a/downstreamadapter/eventcollector/event_collector_test.go
+++ b/downstreamadapter/eventcollector/event_collector_test.go
@@ -233,3 +233,81 @@ func TestRemoveLastDispatcher(t *testing.T) {
 	_, ok = c.changefeedMap.Load(cfID2.ID())
 	require.True(t, ok, "changefeedStat for cfID2 should not be affected")
 }
+
+func TestNewCongestionControlMessagesSendZeroAvailable(t *testing.T) {
+	localServerID := node.NewID()
+	remoteID := node.ID("remote-event-service")
+	c := newTestEventCollector(localServerID)
+	defer c.ds.Close()
+	defer c.redoDs.Close()
+
+	dispatcherID := common.NewDispatcherID()
+	mockDisp := newMockDispatcher(dispatcherID, 100)
+	mockDisp.changefeedID = common.NewChangefeedID4Test("default", t.Name())
+	blocked := make(chan struct{}, 1)
+	mockDisp.handleEvents = func(events []dispatcher.DispatcherEvent, wakeCallback func()) (block bool) {
+		select {
+		case blocked <- struct{}{}:
+		default:
+		}
+		return true
+	}
+	c.AddDispatcher(mockDisp, 1024)
+
+	stat := c.getDispatcherStatByID(dispatcherID)
+	require.NotNil(t, stat)
+	stat.connState.setEventServiceID(remoteID)
+
+	handshake := commonEvent.NewHandshakeEvent(dispatcherID, 99, 0, nil)
+	from := remoteID
+	c.ds.Push(dispatcherID, dispatcher.NewDispatcherEvent(&from, &handshake))
+
+	firstDML := &mockEvent{
+		eventType:    commonEvent.TypeDMLEvent,
+		seq:          2,
+		epoch:        0,
+		dispatcherID: dispatcherID,
+		commitTs:     101,
+		size:         64,
+		len:          1,
+	}
+	c.ds.Push(dispatcherID, dispatcher.NewDispatcherEvent(&from, firstDML))
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-blocked:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond)
+
+	secondDML := &mockEvent{
+		eventType:    commonEvent.TypeDMLEvent,
+		seq:          3,
+		epoch:        0,
+		dispatcherID: dispatcherID,
+		commitTs:     102,
+		size:         2048,
+		len:          1,
+	}
+	c.ds.Push(dispatcherID, dispatcher.NewDispatcherEvent(&from, secondDML))
+
+	require.Eventually(t, func() bool {
+		metrics := c.ds.GetMetrics().MemoryControl.AreaMemoryMetrics
+		if len(metrics) != 1 {
+			return false
+		}
+		return metrics[0].Area() == mockDisp.changefeedID.ID() && metrics[0].AvailableMemory() == 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	messages := c.newCongestionControlMessages()
+	message, ok := messages[remoteID]
+	require.True(t, ok)
+	require.Len(t, message.GetAvailables(), 1)
+	require.Equal(t, uint64(0), message.GetAvailables()[0].Available)
+	require.Equal(t, uint32(1), message.GetAvailables()[0].DispatcherCount)
+	dispatcherAvailable, ok := message.GetAvailables()[0].DispatcherAvailable[dispatcherID]
+	require.True(t, ok)
+	require.Greater(t, dispatcherAvailable, uint64(0))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4899 

### What is changed and how it works?

This pull request addresses a critical deadlock scenario that could occur in the event collector when the available memory quota for event processing reached zero. By removing a conditional check, the system now consistently dispatches congestion control messages, even under zero-memory conditions, thereby preventing the system from stalling and improving overall stability.

### Highlights

* **Deadlock Fix**: Removed a conditional check that prevented congestion control messages from being sent when the available memory quota was zero, resolving a potential deadlock in event processing.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
