### PR TITLE
sink: optimize causality slot mapping

### DIFF
--- a/downstreamadapter/sink/mysql/causality/helper.go
+++ b/downstreamadapter/sink/mysql/causality/helper.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ConflictKeys implements causality.txnEvent interface.
-func ConflictKeys(event *commonEvent.DMLEvent) []uint64 {
+func ConflictKeys(event *commonEvent.DMLEvent) map[uint64]struct{} {
 	if event.Len() == 0 {
 		return nil
 	}
@@ -51,11 +51,7 @@ func ConflictKeys(event *commonEvent.DMLEvent) []uint64 {
 		}
 	}
 
-	keys := make([]uint64, 0, len(hashRes))
-	for key := range hashRes {
-		keys = append(keys, key)
-	}
-	return keys
+	return hashRes
 }
 
 func genRowKeys(row commonEvent.RowChange, tableInfo *common.TableInfo, dispatcherID common.DispatcherID) [][]byte {

--- a/downstreamadapter/sink/mysql/causality/node.go
+++ b/downstreamadapter/sink/mysql/causality/node.go
@@ -46,8 +46,8 @@ var (
 // in conflict detection.
 type Node struct {
 	// Immutable fields.
-	id                  int64
-	sortedDedupKeysHash []uint64
+	id             int64
+	sortedKeysHash []uint64
 
 	// Called when all dependencies are resolved.
 	TrySendToTxnCache func(id cacheID) bool

--- a/downstreamadapter/sink/mysql/causality/slot.go
+++ b/downstreamadapter/sink/mysql/causality/slot.go
@@ -17,6 +17,8 @@ import (
 	"math"
 	"sort"
 	"sync"
+
+	"github.com/pingcap/log"
 )
 
 type slot struct {
@@ -24,16 +26,23 @@ type slot struct {
 	mu    sync.Mutex
 }
 
+type getSlotFunc func(hash uint64) uint64
+
 // Slots implements slot-based conflict detection.
 // It holds references to Node, which can be used to build
 // a DAG of dependency.
 type Slots struct {
 	slots    []slot
 	numSlots uint64
+	getSlot  getSlotFunc
 }
 
 // NewSlots creates a new Slots.
 func NewSlots(numSlots uint64) *Slots {
+	if numSlots == 0 {
+		log.Panic("causality slot count must be positive")
+	}
+
 	slots := make([]slot, numSlots)
 	for i := uint64(0); i < numSlots; i++ {
 		slots[i].nodes = make(map[uint64]*Node, 8)
@@ -41,6 +50,7 @@ func NewSlots(numSlots uint64) *Slots {
 	return &Slots{
 		slots:    slots,
 		numSlots: numSlots,
+		getSlot:  newGetSlotFunc(numSlots),
 	}
 }
 
@@ -52,7 +62,7 @@ func NewSlots(numSlots uint64) *Slots {
 func (s *Slots) AllocNode(hashes []uint64) *Node {
 	return &Node{
 		id:                  genNextNodeID(),
-		sortedDedupKeysHash: sortAndDedupHashes(hashes, s.numSlots),
+		sortedDedupKeysHash: sortHashes(hashes, s.getSlot),
 		assignedTo:          unassigned,
 	}
 }
@@ -64,8 +74,10 @@ func (s *Slots) Add(elem *Node) {
 
 	var lastSlot uint64 = math.MaxUint64
 	for _, hash := range hashes {
-		// lock the slot that the node belongs to.
-		slotIdx := getSlot(hash, s.numSlots)
+		// Lock slots in a stable order to avoid deadlock across concurrent txns.
+		// The actual slot mapper is selected once in NewSlots:
+		// power-of-two slot counts use bitmasking, other values fall back to modulo.
+		slotIdx := s.getSlot(hash)
 		if lastSlot != slotIdx {
 			s.slots[slotIdx].mu.Lock()
 			lastSlot = slotIdx
@@ -92,7 +104,7 @@ func (s *Slots) Add(elem *Node) {
 	// we can avoid 2 transactions get executed interleaved.
 	lastSlot = math.MaxUint64
 	for _, hash := range hashes {
-		slotIdx := getSlot(hash, s.numSlots)
+		slotIdx := s.getSlot(hash)
 		if lastSlot != slotIdx {
 			s.slots[slotIdx].mu.Unlock()
 			lastSlot = slotIdx
@@ -105,7 +117,7 @@ func (s *Slots) Remove(elem *Node) {
 	elem.remove()
 	hashes := elem.sortedDedupKeysHash
 	for _, hash := range hashes {
-		slotIdx := getSlot(hash, s.numSlots)
+		slotIdx := s.getSlot(hash)
 		s.slots[slotIdx].mu.Lock()
 		// Remove the node from the slot.
 		// If the node is not in the slot, it means the node has been replaced by new node with the same hash,
@@ -117,41 +129,52 @@ func (s *Slots) Remove(elem *Node) {
 	}
 }
 
-func getSlot(hash, numSlots uint64) uint64 {
+func newGetSlotFunc(numSlots uint64) getSlotFunc {
+	if isPowerOfTwo(numSlots) {
+		mask := numSlots - 1
+		return func(hash uint64) uint64 {
+			return getSlotByMask(hash, mask)
+		}
+	}
+
+	return func(hash uint64) uint64 {
+		return getSlotByModulo(hash, numSlots)
+	}
+}
+
+func isPowerOfTwo(n uint64) bool {
+	return n != 0 && n&(n-1) == 0
+}
+
+// getSlotByMask maps a hashed conflict key to one slot with a bitmask.
+//
+// This is only correct when the original slot count is a power of two, because
+// only then does `hash & (numSlots-1)` equal `hash % numSlots`. We choose this
+// version on the hot path for the fixed MySQL sink default because it is
+// branchless and slightly cheaper than modulo.
+func getSlotByMask(hash, numSlotsMask uint64) uint64 {
+	return hash & numSlotsMask
+}
+
+// getSlotByModulo maps a hashed conflict key to one slot for arbitrary slot
+// counts. It is the correctness fallback when the slot count is not a power of
+// two.
+func getSlotByModulo(hash, numSlots uint64) uint64 {
 	return hash % numSlots
 }
 
-// Sort and dedup hashes.
-// Sort hashes by `hash % numSlots` to avoid deadlock, and then dedup
-// hashes, so the same node will not check conflict with the same hash
-// twice to prevent potential cyclic self dependency in the causality
-// dependency graph.
-func sortAndDedupHashes(hashes []uint64, numSlots uint64) []uint64 {
+// Sort hashes by slot index to ensure all transactions lock slots in the same
+// order and therefore cannot deadlock each other. The slot mapper is selected
+// once when the Slots object is created, so sorting and later lock acquisition
+// always use the same mapping rule.
+func sortHashes(hashes []uint64, getSlot getSlotFunc) []uint64 {
 	if len(hashes) == 0 {
 		return nil
 	}
 
-	// Sort hashes by `hash % numSlots` to avoid deadlock.
 	sort.Slice(hashes, func(i, j int) bool {
-		return hashes[i]%numSlots < hashes[j]%numSlots
+		return getSlot(hashes[i]) < getSlot(hashes[j])
 	})
-
-	// Dedup hashes
-	last := hashes[0]
-	j := 1
-	for i, hash := range hashes {
-		if i == 0 {
-			// skip first one, start checking duplication from 2nd one
-			continue
-		}
-		if hash == last {
-			continue
-		}
-		last = hash
-		hashes[j] = hash
-		j++
-	}
-	hashes = hashes[:j]
 
 	return hashes
 }

--- a/downstreamadapter/sink/mysql/causality/slot.go
+++ b/downstreamadapter/sink/mysql/causality/slot.go
@@ -59,17 +59,17 @@ func NewSlots(numSlots uint64) *Slots {
 // The reason is a node can step functions `assignTo`, `Remove`, `free`, then `assignTo`.
 // again. In the last `assignTo`, it can never know whether the node has been reused
 // or not.
-func (s *Slots) AllocNode(hashes []uint64) *Node {
+func (s *Slots) AllocNode(hashes map[uint64]struct{}) *Node {
 	return &Node{
-		id:                  genNextNodeID(),
-		sortedDedupKeysHash: sortHashes(hashes, s.getSlot),
-		assignedTo:          unassigned,
+		id:             genNextNodeID(),
+		sortedKeysHash: sortHashes(hashes, s.getSlot),
+		assignedTo:     unassigned,
 	}
 }
 
 // Add adds an elem to the slots and calls DependOn for elem.
 func (s *Slots) Add(elem *Node) {
-	hashes := elem.sortedDedupKeysHash
+	hashes := elem.sortedKeysHash
 	dependencyNodes := make(map[int64]*Node, len(hashes))
 
 	var lastSlot uint64 = math.MaxUint64
@@ -115,7 +115,7 @@ func (s *Slots) Add(elem *Node) {
 // Remove removes an element from the Slots.
 func (s *Slots) Remove(elem *Node) {
 	elem.remove()
-	hashes := elem.sortedDedupKeysHash
+	hashes := elem.sortedKeysHash
 	for _, hash := range hashes {
 		slotIdx := s.getSlot(hash)
 		s.slots[slotIdx].mu.Lock()
@@ -167,14 +167,19 @@ func getSlotByModulo(hash, numSlots uint64) uint64 {
 // order and therefore cannot deadlock each other. The slot mapper is selected
 // once when the Slots object is created, so sorting and later lock acquisition
 // always use the same mapping rule.
-func sortHashes(hashes []uint64, getSlot getSlotFunc) []uint64 {
+func sortHashes(hashes map[uint64]struct{}, getSlot getSlotFunc) []uint64 {
 	if len(hashes) == 0 {
 		return nil
 	}
 
-	sort.Slice(hashes, func(i, j int) bool {
-		return getSlot(hashes[i]) < getSlot(hashes[j])
+	hashList := make([]uint64, 0, len(hashes))
+	for hash := range hashes {
+		hashList = append(hashList, hash)
+	}
+
+	sort.Slice(hashList, func(i, j int) bool {
+		return getSlot(hashList[i]) < getSlot(hashList[j])
 	})
 
-	return hashes
+	return hashList
 }

--- a/downstreamadapter/sink/mysql/causality/slot.go
+++ b/downstreamadapter/sink/mysql/causality/slot.go
@@ -133,34 +133,17 @@ func newGetSlotFunc(numSlots uint64) getSlotFunc {
 	if isPowerOfTwo(numSlots) {
 		mask := numSlots - 1
 		return func(hash uint64) uint64 {
-			return getSlotByMask(hash, mask)
+			return hash & mask
 		}
 	}
 
 	return func(hash uint64) uint64 {
-		return getSlotByModulo(hash, numSlots)
+		return hash % numSlots
 	}
 }
 
 func isPowerOfTwo(n uint64) bool {
 	return n != 0 && n&(n-1) == 0
-}
-
-// getSlotByMask maps a hashed conflict key to one slot with a bitmask.
-//
-// This is only correct when the original slot count is a power of two, because
-// only then does `hash & (numSlots-1)` equal `hash % numSlots`. We choose this
-// version on the hot path for the fixed MySQL sink default because it is
-// branchless and slightly cheaper than modulo.
-func getSlotByMask(hash, numSlotsMask uint64) uint64 {
-	return hash & numSlotsMask
-}
-
-// getSlotByModulo maps a hashed conflict key to one slot for arbitrary slot
-// counts. It is the correctness fallback when the slot count is not a power of
-// two.
-func getSlotByModulo(hash, numSlots uint64) uint64 {
-	return hash % numSlots
 }
 
 // Sort hashes by slot index to ensure all transactions lock slots in the same

--- a/downstreamadapter/sink/mysql/causality/slot.go
+++ b/downstreamadapter/sink/mysql/causality/slot.go
@@ -17,8 +17,6 @@ import (
 	"math"
 	"sort"
 	"sync"
-
-	"github.com/pingcap/log"
 )
 
 type slot struct {
@@ -39,8 +37,8 @@ type Slots struct {
 
 // NewSlots creates a new Slots.
 func NewSlots(numSlots uint64) *Slots {
-	if numSlots == 0 {
-		log.Panic("causality slot count must be positive")
+	if numSlots <= 0 {
+		numSlots = 1
 	}
 
 	slots := make([]slot, numSlots)

--- a/downstreamadapter/sink/mysql/causality/slot_benchmark_test.go
+++ b/downstreamadapter/sink/mysql/causality/slot_benchmark_test.go
@@ -98,8 +98,12 @@ func BenchmarkSortHashesBySlot(b *testing.B) {
 						benchmarkSortHashesByFuncAndDedup(b, tc.source, newGetSlotFunc(benchmarkDefaultSlotCount))
 					})
 
+					sourceMap := make(map[uint64]struct{})
+					for _, hash := range tc.source {
+						sourceMap[hash] = struct{}{}
+					}
 					b.Run("selected_mapper_no_dedup", func(b *testing.B) {
-						benchmarkSortHashesByFunc(b, tc.source, newGetSlotFunc(benchmarkDefaultSlotCount))
+						benchmarkSortHashesByFunc(b, sourceMap, newGetSlotFunc(benchmarkDefaultSlotCount))
 					})
 				})
 			}
@@ -121,17 +125,16 @@ func benchmarkSortHashesByOldModuloAndDedup(b *testing.B, source []uint64, numSl
 	}
 }
 
-func benchmarkSortHashesByFunc(b *testing.B, source []uint64, getSlot getSlotFunc) {
+func benchmarkSortHashesByFunc(b *testing.B, source map[uint64]struct{}, getSlot getSlotFunc) {
 	b.Helper()
-	sample := sortHashes(append([]uint64(nil), source...), getSlot)
+	sample := sortHashes(source, getSlot)
 	b.ResetTimer()
 	b.ReportAllocs()
 	b.ReportMetric(float64(len(source)), "hashes/op")
 	b.ReportMetric(float64(len(sample)), "out_hashes/op")
 
 	for i := 0; i < b.N; i++ {
-		hashes := append([]uint64(nil), source...)
-		benchmarkSlotHashesResult = sortHashes(hashes, getSlot)
+		benchmarkSlotHashesResult = sortHashes(source, getSlot)
 	}
 }
 

--- a/downstreamadapter/sink/mysql/causality/slot_benchmark_test.go
+++ b/downstreamadapter/sink/mysql/causality/slot_benchmark_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package causality
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+var (
+	benchmarkDefaultSlotCount uint64 = 16 * 1024
+	benchmarkSlotIndexResult  uint64
+	benchmarkSlotHashesResult []uint64
+)
+
+func BenchmarkSlotIndex(b *testing.B) {
+	hashes := makeBenchmarkSlotHashes(4096)
+
+	b.Run("modulo_power_of_two", func(b *testing.B) {
+		numSlots := benchmarkDefaultSlotCount
+		var result uint64
+
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			result += getSlotByModulo(hashes[i&(len(hashes)-1)], numSlots)
+		}
+		benchmarkSlotIndexResult = result
+	})
+
+	b.Run("mask_power_of_two", func(b *testing.B) {
+		mask := benchmarkDefaultSlotCount - 1
+		var result uint64
+
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			result += getSlotByMask(hashes[i&(len(hashes)-1)], mask)
+		}
+		benchmarkSlotIndexResult = result
+	})
+
+	b.Run("selected_mapper_power_of_two", func(b *testing.B) {
+		getSlot := newGetSlotFunc(benchmarkDefaultSlotCount)
+		var result uint64
+
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			result += getSlot(hashes[i&(len(hashes)-1)])
+		}
+		benchmarkSlotIndexResult = result
+	})
+
+	b.Run("selected_mapper_non_power_of_two", func(b *testing.B) {
+		getSlot := newGetSlotFunc(benchmarkDefaultSlotCount - 1)
+		var result uint64
+
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			result += getSlot(hashes[i&(len(hashes)-1)])
+		}
+		benchmarkSlotIndexResult = result
+	})
+}
+
+func BenchmarkSortHashesBySlot(b *testing.B) {
+	for _, hashCount := range []int{8, 64, 1024} {
+		b.Run(fmt.Sprintf("hashes_%d", hashCount), func(b *testing.B) {
+			for _, tc := range []struct {
+				name   string
+				source []uint64
+			}{
+				{
+					name:   "unique",
+					source: makeBenchmarkSlotHashes(hashCount),
+				},
+				{
+					name:   "with_duplicates",
+					source: makeBenchmarkSlotHashesWithDuplicates(hashCount),
+				},
+			} {
+				b.Run(tc.name, func(b *testing.B) {
+					b.Run("old_modulo_dedup", func(b *testing.B) {
+						benchmarkSortHashesByOldModuloAndDedup(b, tc.source, benchmarkDefaultSlotCount)
+					})
+
+					b.Run("selected_mapper_dedup", func(b *testing.B) {
+						benchmarkSortHashesByFuncAndDedup(b, tc.source, newGetSlotFunc(benchmarkDefaultSlotCount))
+					})
+
+					b.Run("selected_mapper_no_dedup", func(b *testing.B) {
+						benchmarkSortHashesByFunc(b, tc.source, newGetSlotFunc(benchmarkDefaultSlotCount))
+					})
+				})
+			}
+		})
+	}
+}
+
+func benchmarkSortHashesByOldModuloAndDedup(b *testing.B, source []uint64, numSlots uint64) {
+	b.Helper()
+	sample := sortHashesByOldModuloAndDedup(append([]uint64(nil), source...), numSlots)
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(source)), "hashes/op")
+	b.ReportMetric(float64(len(sample)), "out_hashes/op")
+
+	for i := 0; i < b.N; i++ {
+		hashes := append([]uint64(nil), source...)
+		benchmarkSlotHashesResult = sortHashesByOldModuloAndDedup(hashes, numSlots)
+	}
+}
+
+func benchmarkSortHashesByFunc(b *testing.B, source []uint64, getSlot getSlotFunc) {
+	b.Helper()
+	sample := sortHashes(append([]uint64(nil), source...), getSlot)
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(source)), "hashes/op")
+	b.ReportMetric(float64(len(sample)), "out_hashes/op")
+
+	for i := 0; i < b.N; i++ {
+		hashes := append([]uint64(nil), source...)
+		benchmarkSlotHashesResult = sortHashes(hashes, getSlot)
+	}
+}
+
+func benchmarkSortHashesByFuncAndDedup(b *testing.B, source []uint64, getSlot getSlotFunc) {
+	b.Helper()
+	sample := sortHashesByFuncAndDedup(append([]uint64(nil), source...), getSlot)
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(source)), "hashes/op")
+	b.ReportMetric(float64(len(sample)), "out_hashes/op")
+
+	for i := 0; i < b.N; i++ {
+		hashes := append([]uint64(nil), source...)
+		benchmarkSlotHashesResult = sortHashesByFuncAndDedup(hashes, getSlot)
+	}
+}
+
+func sortHashesByOldModuloAndDedup(hashes []uint64, numSlots uint64) []uint64 {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	sort.Slice(hashes, func(i, j int) bool {
+		return hashes[i]%numSlots < hashes[j]%numSlots
+	})
+
+	return dedupSortedHashes(hashes)
+}
+
+func sortHashesByFuncAndDedup(hashes []uint64, getSlot getSlotFunc) []uint64 {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	sort.Slice(hashes, func(i, j int) bool {
+		return getSlot(hashes[i]) < getSlot(hashes[j])
+	})
+
+	return dedupSortedHashes(hashes)
+}
+
+func dedupSortedHashes(hashes []uint64) []uint64 {
+	last := hashes[0]
+	j := 1
+	for i, hash := range hashes {
+		if i == 0 {
+			continue
+		}
+		if hash == last {
+			continue
+		}
+		last = hash
+		hashes[j] = hash
+		j++
+	}
+	return hashes[:j]
+}
+
+func makeBenchmarkSlotHashes(count int) []uint64 {
+	hashes := make([]uint64, count)
+	x := uint64(0x9e3779b97f4a7c15)
+	for i := range hashes {
+		x += 0x9e3779b97f4a7c15
+		z := x
+		z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9
+		z = (z ^ (z >> 27)) * 0x94d049bb133111eb
+		hashes[i] = z ^ (z >> 31)
+	}
+	return hashes
+}
+
+func makeBenchmarkSlotHashesWithDuplicates(count int) []uint64 {
+	if count == 0 {
+		return nil
+	}
+	distinctCount := count / 4
+	if distinctCount == 0 {
+		distinctCount = 1
+	}
+	distinctHashes := makeBenchmarkSlotHashes(distinctCount)
+	hashes := make([]uint64, count)
+	for i := range hashes {
+		hashes[i] = distinctHashes[i%distinctCount]
+	}
+	return hashes
+}

--- a/downstreamadapter/sink/mysql/causality/slot_benchmark_test.go
+++ b/downstreamadapter/sink/mysql/causality/slot_benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkSlotIndex(b *testing.B) {
 
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			result += getSlotByModulo(hashes[i&(len(hashes)-1)], numSlots)
+			result += hashes[i&(len(hashes)-1)] % numSlots
 		}
 		benchmarkSlotIndexResult = result
 	})
@@ -45,7 +45,7 @@ func BenchmarkSlotIndex(b *testing.B) {
 
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			result += getSlotByMask(hashes[i&(len(hashes)-1)], mask)
+			result += hashes[i&(len(hashes)-1)] & mask
 		}
 		benchmarkSlotIndexResult = result
 	})
@@ -76,37 +76,20 @@ func BenchmarkSlotIndex(b *testing.B) {
 func BenchmarkSortHashesBySlot(b *testing.B) {
 	for _, hashCount := range []int{8, 64, 1024} {
 		b.Run(fmt.Sprintf("hashes_%d", hashCount), func(b *testing.B) {
-			for _, tc := range []struct {
-				name   string
-				source []uint64
-			}{
-				{
-					name:   "unique",
-					source: makeBenchmarkSlotHashes(hashCount),
-				},
-				{
-					name:   "with_duplicates",
-					source: makeBenchmarkSlotHashesWithDuplicates(hashCount),
-				},
-			} {
-				b.Run(tc.name, func(b *testing.B) {
-					b.Run("old_modulo_dedup", func(b *testing.B) {
-						benchmarkSortHashesByOldModuloAndDedup(b, tc.source, benchmarkDefaultSlotCount)
-					})
+			source := makeBenchmarkSlotHashes(hashCount)
 
-					b.Run("selected_mapper_dedup", func(b *testing.B) {
-						benchmarkSortHashesByFuncAndDedup(b, tc.source, newGetSlotFunc(benchmarkDefaultSlotCount))
-					})
+			b.Run("old_modulo_dedup", func(b *testing.B) {
+				benchmarkSortHashesByOldModuloAndDedup(b, source, benchmarkDefaultSlotCount)
+			})
 
-					sourceMap := make(map[uint64]struct{})
-					for _, hash := range tc.source {
-						sourceMap[hash] = struct{}{}
-					}
-					b.Run("selected_mapper_no_dedup", func(b *testing.B) {
-						benchmarkSortHashesByFunc(b, sourceMap, newGetSlotFunc(benchmarkDefaultSlotCount))
-					})
-				})
-			}
+			b.Run("selected_mapper_dedup", func(b *testing.B) {
+				benchmarkSortHashesByFuncAndDedup(b, source, newGetSlotFunc(benchmarkDefaultSlotCount))
+			})
+
+			sourceMap := makeBenchmarkSlotHashMap(source)
+			b.Run("selected_mapper_map_input", func(b *testing.B) {
+				benchmarkSortHashesByMap(b, len(source), sourceMap, newGetSlotFunc(benchmarkDefaultSlotCount))
+			})
 		})
 	}
 }
@@ -116,7 +99,7 @@ func benchmarkSortHashesByOldModuloAndDedup(b *testing.B, source []uint64, numSl
 	sample := sortHashesByOldModuloAndDedup(append([]uint64(nil), source...), numSlots)
 	b.ResetTimer()
 	b.ReportAllocs()
-	b.ReportMetric(float64(len(source)), "hashes/op")
+	b.ReportMetric(float64(len(source)), "input_hashes/op")
 	b.ReportMetric(float64(len(sample)), "out_hashes/op")
 
 	for i := 0; i < b.N; i++ {
@@ -125,12 +108,13 @@ func benchmarkSortHashesByOldModuloAndDedup(b *testing.B, source []uint64, numSl
 	}
 }
 
-func benchmarkSortHashesByFunc(b *testing.B, source map[uint64]struct{}, getSlot getSlotFunc) {
+func benchmarkSortHashesByMap(b *testing.B, inputCount int, source map[uint64]struct{}, getSlot getSlotFunc) {
 	b.Helper()
 	sample := sortHashes(source, getSlot)
 	b.ResetTimer()
 	b.ReportAllocs()
-	b.ReportMetric(float64(len(source)), "hashes/op")
+	b.ReportMetric(float64(inputCount), "input_hashes/op")
+	b.ReportMetric(float64(len(source)), "unique_hashes/op")
 	b.ReportMetric(float64(len(sample)), "out_hashes/op")
 
 	for i := 0; i < b.N; i++ {
@@ -143,7 +127,7 @@ func benchmarkSortHashesByFuncAndDedup(b *testing.B, source []uint64, getSlot ge
 	sample := sortHashesByFuncAndDedup(append([]uint64(nil), source...), getSlot)
 	b.ResetTimer()
 	b.ReportAllocs()
-	b.ReportMetric(float64(len(source)), "hashes/op")
+	b.ReportMetric(float64(len(source)), "input_hashes/op")
 	b.ReportMetric(float64(len(sample)), "out_hashes/op")
 
 	for i := 0; i < b.N; i++ {
@@ -206,18 +190,10 @@ func makeBenchmarkSlotHashes(count int) []uint64 {
 	return hashes
 }
 
-func makeBenchmarkSlotHashesWithDuplicates(count int) []uint64 {
-	if count == 0 {
-		return nil
-	}
-	distinctCount := count / 4
-	if distinctCount == 0 {
-		distinctCount = 1
-	}
-	distinctHashes := makeBenchmarkSlotHashes(distinctCount)
-	hashes := make([]uint64, count)
-	for i := range hashes {
-		hashes[i] = distinctHashes[i%distinctCount]
+func makeBenchmarkSlotHashMap(source []uint64) map[uint64]struct{} {
+	hashes := make(map[uint64]struct{}, len(source))
+	for _, hash := range source {
+		hashes[hash] = struct{}{}
 	}
 	return hashes
 }

--- a/downstreamadapter/sink/mysql/causality/slot_test.go
+++ b/downstreamadapter/sink/mysql/causality/slot_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package causality
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSlotByMask(t *testing.T) {
+	t.Parallel()
+
+	// numSlots=16 => mask=15
+	require.Equal(t, uint64(11), getSlotByMask(11, 15))
+	require.Equal(t, uint64(14), getSlotByMask(14, 15))
+	require.Equal(t, uint64(3), getSlotByMask(19, 15))
+}
+
+func TestGetSlotByModulo(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, uint64(5), getSlotByModulo(11, 6))
+	require.Equal(t, uint64(2), getSlotByModulo(14, 6))
+	require.Equal(t, uint64(1), getSlotByModulo(19, 6))
+}
+
+func TestNewSlotIndexFunc(t *testing.T) {
+	t.Parallel()
+
+	powerOfTwoSlots := NewSlots(16)
+	require.Equal(t, uint64(3), powerOfTwoSlots.getSlot(19))
+	require.Equal(t, uint64(15), powerOfTwoSlots.getSlot(31))
+
+	nonPowerOfTwoSlots := NewSlots(6)
+	require.Equal(t, uint64(1), nonPowerOfTwoSlots.getSlot(19))
+	require.Equal(t, uint64(5), nonPowerOfTwoSlots.getSlot(11))
+}

--- a/downstreamadapter/sink/mysql/causality/slot_test.go
+++ b/downstreamadapter/sink/mysql/causality/slot_test.go
@@ -19,21 +19,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetSlotByMask(t *testing.T) {
+func TestNewGetSlotFunc(t *testing.T) {
 	t.Parallel()
 
-	// numSlots=16 => mask=15
-	require.Equal(t, uint64(11), getSlotByMask(11, 15))
-	require.Equal(t, uint64(14), getSlotByMask(14, 15))
-	require.Equal(t, uint64(3), getSlotByMask(19, 15))
-}
+	powerOfTwoGetSlot := newGetSlotFunc(16)
+	require.Equal(t, uint64(11), powerOfTwoGetSlot(11))
+	require.Equal(t, uint64(14), powerOfTwoGetSlot(14))
+	require.Equal(t, uint64(3), powerOfTwoGetSlot(19))
 
-func TestGetSlotByModulo(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, uint64(5), getSlotByModulo(11, 6))
-	require.Equal(t, uint64(2), getSlotByModulo(14, 6))
-	require.Equal(t, uint64(1), getSlotByModulo(19, 6))
+	nonPowerOfTwoGetSlot := newGetSlotFunc(6)
+	require.Equal(t, uint64(5), nonPowerOfTwoGetSlot(11))
+	require.Equal(t, uint64(2), nonPowerOfTwoGetSlot(14))
+	require.Equal(t, uint64(1), nonPowerOfTwoGetSlot(19))
 }
 
 func TestNewSlotIndexFunc(t *testing.T) {

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -35,12 +35,6 @@ import (
 )
 
 const (
-	// defaultConflictDetectorSlots is intentionally fixed to a power of two.
-	//
-	// The causality slot mapper uses `hash & (numSlots-1)` instead of `% numSlots`
-	// on the hot path, so changing this constant to a non power-of-two value would
-	// break slot distribution. Keep it as a power of two unless the slot mapping
-	// logic is changed accordingly.
 	defaultConflictDetectorSlots uint64 = 16 * 1024
 )
 

--- a/downstreamadapter/sink/mysql/sink.go
+++ b/downstreamadapter/sink/mysql/sink.go
@@ -35,7 +35,12 @@ import (
 )
 
 const (
-	// defaultConflictDetectorSlots indicates the default slot count of conflict detector. TODO:check this
+	// defaultConflictDetectorSlots is intentionally fixed to a power of two.
+	//
+	// The causality slot mapper uses `hash & (numSlots-1)` instead of `% numSlots`
+	// on the hot path, so changing this constant to a non power-of-two value would
+	// break slot distribution. Keep it as a power of two unless the slot mapping
+	// logic is changed accordingly.
 	defaultConflictDetectorSlots uint64 = 16 * 1024
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4582

### What is changed and how it works?
This pull request optimizes the causality slot mapping by introducing a specialized mapping function that uses bitmasking for power-of-two slot counts, improving performance on the hot path.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
  BenchmarkSortHashesBySlot/hashes_8/old_modulo_dedup-72             529.7 ns/op
  BenchmarkSortHashesBySlot/hashes_8/selected_mapper_dedup-72        313.2 ns/op
  BenchmarkSortHashesBySlot/hashes_8/selected_mapper_map_input-72    428.5 ns/op
  BenchmarkSortHashesBySlot/hashes_64/old_modulo_dedup-72            7871 ns/op
  BenchmarkSortHashesBySlot/hashes_64/selected_mapper_dedup-72       3463 ns/op
  BenchmarkSortHashesBySlot/hashes_64/selected_mapper_map_input-72   5549 ns/op
  BenchmarkSortHashesBySlot/hashes_1024/old_modulo_dedup-72          247007 ns/op
  BenchmarkSortHashesBySlot/hashes_1024/selected_mapper_dedup-72     119883 ns/op
  BenchmarkSortHashesBySlot/hashes_1024/selected_mapper_map_input-72 142416 ns/op

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests and new benchmarks covering slot selection and hash ordering performance.

* **Refactor**
  * More consistent slot-to-lock mapping and enforced minimum slot count for safer allocation.
  * Hash handling now uses unique-hash sets and updated ordering to improve concurrent locking reliability.

* **Chores**
  * Removed a stale inline TODO comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->