### PR TITLE
eventstore: reduce allocations in write and iterator paths

### DIFF
--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1336,20 +1336,33 @@ func (e *eventStore) writeEvents(
 				compressionType = CompressionZSTD
 				metrics.EventStoreCompressedRowsCount.Inc()
 				op := batch.SetDeferred(keyLen, len(value))
-				EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
-				copy(op.Value, value)
+				op.Key = EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
+				if len(op.Key) != keyLen {
+					return fmt.Errorf("encoded event store key size mismatch, expected %d, got %d",
+						keyLen, len(op.Key))
+				}
+				copiedValueLen := copy(op.Value, value)
+				op.Value = op.Value[:copiedValueLen]
+				if copiedValueLen != len(value) {
+					return fmt.Errorf("compressed raw kv entry size mismatch, expected %d, got %d",
+						len(value), copiedValueLen)
+				}
 				if err := op.Finish(); err != nil {
 					return err
 				}
 				rawBuf = rawValue[:0]
-				dstBuf = dstBuf[:0]
+				dstBuf = value[:0]
 			} else {
 				op := batch.SetDeferred(keyLen, int(valueBytesBefore))
-				EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
-				encodedValue := kv.EncodeTo(op.Value[:0])
-				if len(encodedValue) != int(valueBytesBefore) {
+				op.Key = EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
+				if len(op.Key) != keyLen {
+					return fmt.Errorf("encoded event store key size mismatch, expected %d, got %d",
+						keyLen, len(op.Key))
+				}
+				op.Value = kv.EncodeTo(op.Value[:0])
+				if len(op.Value) != int(valueBytesBefore) {
 					return fmt.Errorf("encoded raw kv entry size mismatch, expected %d, got %d",
-						valueBytesBefore, len(encodedValue))
+						valueBytesBefore, len(op.Value))
 				}
 				if err := op.Finish(); err != nil {
 					return err

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -16,7 +16,6 @@ package eventstore
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math"
 	"os"
@@ -1381,51 +1380,6 @@ type eventStoreIter struct {
 	decodeBuf   []byte
 }
 
-func decodeRawKVEntry(data []byte, v *common.RawKVEntry) error {
-	if len(data) < 36 {
-		return fmt.Errorf("insufficient data length")
-	}
-
-	offset := 0
-	v.OpType = common.OpType(binary.LittleEndian.Uint32(data[offset : offset+4]))
-	offset += 4
-	v.CRTs = binary.LittleEndian.Uint64(data[offset : offset+8])
-	offset += 8
-	v.StartTs = binary.LittleEndian.Uint64(data[offset : offset+8])
-	offset += 8
-	v.RegionID = binary.LittleEndian.Uint64(data[offset : offset+8])
-	offset += 8
-
-	v.KeyLen = binary.LittleEndian.Uint32(data[offset : offset+4])
-	offset += 4
-	v.ValueLen = binary.LittleEndian.Uint32(data[offset : offset+4])
-	offset += 4
-	v.OldValueLen = binary.LittleEndian.Uint32(data[offset : offset+4])
-	offset += 4
-
-	keyLen := int(v.KeyLen)
-	valueLen := int(v.ValueLen)
-	oldValueLen := int(v.OldValueLen)
-	totalLen := keyLen + valueLen + oldValueLen
-	if len(data[offset:]) < totalLen {
-		return fmt.Errorf("insufficient data for variable length fields")
-	}
-
-	valueBuf := make([]byte, totalLen)
-	copy(valueBuf, data[offset:offset+totalLen])
-	keyEnd := keyLen
-	valueEnd := keyEnd + valueLen
-	oldValueEnd := valueEnd + oldValueLen
-	v.Key = valueBuf[:keyEnd:keyEnd]
-	v.Value = valueBuf[keyEnd:valueEnd:valueEnd]
-	if oldValueLen > 0 {
-		v.OldValue = valueBuf[valueEnd:oldValueEnd:oldValueEnd]
-	} else {
-		v.OldValue = nil
-	}
-	return nil
-}
-
 func (iter *eventStoreIter) Next() (*common.RawKVEntry, bool) {
 	rawKV := &common.RawKVEntry{}
 	for {
@@ -1452,7 +1406,7 @@ func (iter *eventStoreIter) Next() (*common.RawKVEntry, bool) {
 			decodedValue = value
 		}
 
-		err := decodeRawKVEntry(decodedValue, rawKV)
+		err := rawKV.Decode(decodedValue)
 		if err != nil {
 			log.Panic("fail to decode raw kv entry", zap.Error(err))
 		}

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1318,6 +1318,7 @@ func (e *eventStore) writeEvents(
 			valueBytesBefore := kv.GetSize()
 			valueBytesAfter := valueBytesBefore
 			keyLen := encodedKeyLen(kv)
+
 			if e.enableZstdCompression && valueBytesBefore > int64(e.compressionThreshold) {
 				if cap(rawBuf) < int(valueBytesBefore) {
 					rawBuf = make([]byte, 0, int(valueBytesBefore))
@@ -1335,6 +1336,10 @@ func (e *eventStore) writeEvents(
 				valueBytesAfter = int64(len(value))
 				compressionType = CompressionZSTD
 				metrics.EventStoreCompressedRowsCount.Inc()
+				// SetDeferred is a write path optimization. Now that the compressed
+				// value length is known, reserve the exact key/value space in the
+				// Pebble batch, encode the key directly into op.Key, and copy the
+				// compressed value into op.Value without building a temporary key.
 				op := batch.SetDeferred(keyLen, len(value))
 				op.Key = EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
 				if len(op.Key) != keyLen {
@@ -1353,6 +1358,9 @@ func (e *eventStore) writeEvents(
 				rawBuf = rawValue[:0]
 				dstBuf = value[:0]
 			} else {
+				// SetDeferred reserves the final Pebble batch space up front, so
+				// the uncompressed raw KV can be encoded directly into op.Value
+				// without allocating a separate value slice and copying it later.
 				op := batch.SetDeferred(keyLen, int(valueBytesBefore))
 				op.Key = EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
 				if len(op.Key) != keyLen {

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -319,6 +319,7 @@ func (p *writeTaskPool) run(ctx context.Context) {
 		go func(workerID int) {
 			defer p.store.wg.Done()
 			var compressionBuf []byte
+			var rawValueBuf []byte
 			encodeOpt := zstd.WithEncoderLevel(zstd.SpeedFastest)
 			encoder, err := zstd.NewWriter(nil, encodeOpt)
 			if err != nil {
@@ -344,7 +345,7 @@ func (p *writeTaskPool) run(ctx context.Context) {
 						queueDuration.Observe(float64(time.Now().UnixNano()-events[0].enqueueTimeNano) / float64(time.Second))
 					}
 					start := time.Now()
-					if err = p.store.writeEvents(p.db, events, encoder, &compressionBuf); err != nil {
+					if err = p.store.writeEvents(p.db, events, encoder, &compressionBuf, &rawValueBuf); err != nil {
 						log.Panic("write events failed", zap.Error(err))
 					}
 					ioWriteDuration.Observe(time.Since(start).Seconds())
@@ -1283,6 +1284,7 @@ func (e *eventStore) writeEvents(
 	events []eventWithCallback,
 	encoder *zstd.Encoder,
 	compressionBuf *[]byte,
+	rawValueBuf *[]byte,
 ) error {
 	metrics.EventStoreWriteRequestsCount.Inc()
 	prepareStart := time.Now()
@@ -1294,6 +1296,10 @@ func (e *eventStore) writeEvents(
 	var dstBuf []byte
 	if compressionBuf != nil {
 		dstBuf = *compressionBuf
+	}
+	var rawBuf []byte
+	if rawValueBuf != nil {
+		rawBuf = *rawValueBuf
 	}
 	for _, event := range events {
 		kvCount += len(event.kvs)
@@ -1313,7 +1319,12 @@ func (e *eventStore) writeEvents(
 			valueBytesAfter := valueBytesBefore
 			keyLen := encodedKeyLen(kv)
 			if e.enableZstdCompression && valueBytesBefore > int64(e.compressionThreshold) {
-				rawValue := kv.Encode()
+				if cap(rawBuf) < int(valueBytesBefore) {
+					rawBuf = make([]byte, 0, int(valueBytesBefore))
+				} else {
+					rawBuf = rawBuf[:0]
+				}
+				rawValue := kv.EncodeTo(rawBuf)
 				maxEncodedSize := encoder.MaxEncodedSize(len(rawValue))
 				if cap(dstBuf) < maxEncodedSize {
 					dstBuf = make([]byte, 0, maxEncodedSize)
@@ -1330,6 +1341,7 @@ func (e *eventStore) writeEvents(
 				if err := op.Finish(); err != nil {
 					return err
 				}
+				rawBuf = rawValue[:0]
 				dstBuf = dstBuf[:0]
 			} else {
 				op := batch.SetDeferred(keyLen, int(valueBytesBefore))
@@ -1346,6 +1358,9 @@ func (e *eventStore) writeEvents(
 	}
 	if compressionBuf != nil {
 		*compressionBuf = dstBuf
+	}
+	if rawValueBuf != nil {
+		*rawValueBuf = rawBuf
 	}
 	kvEventCount.Add(float64(kvCount))
 	metrics.EventStoreWriteBatchEventsCountHist.Observe(float64(kvCount))

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1346,7 +1346,11 @@ func (e *eventStore) writeEvents(
 			} else {
 				op := batch.SetDeferred(keyLen, int(valueBytesBefore))
 				EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
-				kv.EncodeTo(op.Value[:0])
+				encodedValue := kv.EncodeTo(op.Value[:0])
+				if len(encodedValue) != int(valueBytesBefore) {
+					return fmt.Errorf("encoded raw kv entry size mismatch, expected %d, got %d",
+						valueBytesBefore, len(encodedValue))
+				}
 				if err := op.Finish(); err != nil {
 					return err
 				}

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -16,6 +16,7 @@ package eventstore
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"os"
@@ -194,7 +195,7 @@ type eventWithCallback struct {
 func eventWithCallbackSizer(e eventWithCallback) int {
 	size := 0
 	for _, kv := range e.kvs {
-		size += int(kv.KeyLen + kv.ValueLen + kv.OldValueLen)
+		size += len(kv.Key) + len(kv.Value) + len(kv.OldValue)
 	}
 	return size
 }
@@ -1297,7 +1298,8 @@ func (e *eventStore) writeEvents(
 	}
 	for _, event := range events {
 		kvCount += len(event.kvs)
-		for _, kv := range event.kvs {
+		for i := range event.kvs {
+			kv := &event.kvs[i]
 			if kv.CRTs <= event.currentResolvedTs {
 				log.Warn("event store received kv with commitTs less than resolvedTs",
 					zap.Uint64("commitTs", kv.CRTs),
@@ -1308,32 +1310,39 @@ func (e *eventStore) writeEvents(
 			}
 
 			compressionType := CompressionNone
-			rawValue := kv.Encode()
-			valueBytesBefore := int64(len(rawValue))
+			valueBytesBefore := int64(kv.EncodedSize())
 			valueBytesAfter := valueBytesBefore
-			value := rawValue
-			if e.enableZstdCompression && len(rawValue) > e.compressionThreshold {
+			keyLen := encodedKeyLen(kv)
+			if e.enableZstdCompression && int(valueBytesBefore) > e.compressionThreshold {
+				rawValue := kv.Encode()
 				maxEncodedSize := encoder.MaxEncodedSize(len(rawValue))
 				if cap(dstBuf) < maxEncodedSize {
 					dstBuf = make([]byte, 0, maxEncodedSize)
 				} else {
 					dstBuf = dstBuf[:0]
 				}
-				value = encoder.EncodeAll(rawValue, dstBuf)
+				value := encoder.EncodeAll(rawValue, dstBuf)
 				valueBytesAfter = int64(len(value))
 				compressionType = CompressionZSTD
 				metrics.EventStoreCompressedRowsCount.Inc()
+				op := batch.SetDeferred(keyLen, len(value))
+				EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
+				copy(op.Value, value)
+				if err := op.Finish(); err != nil {
+					return err
+				}
+				dstBuf = dstBuf[:0]
+			} else {
+				op := batch.SetDeferred(keyLen, int(valueBytesBefore))
+				EncodeKeyTo(op.Key[:0], uint64(event.subID), event.tableID, kv, compressionType)
+				kv.EncodeTo(op.Value[:0])
+				if err := op.Finish(); err != nil {
+					return err
+				}
 			}
 
-			key := EncodeKey(uint64(event.subID), event.tableID, &kv, compressionType)
-			if err := batch.Set(key, value, pebble.NoSync); err != nil {
-				log.Panic("failed to update pebble batch", zap.Error(err))
-			}
 			totalValueBytesBefore += valueBytesBefore
 			totalValueBytesAfter += valueBytesAfter
-			if compressionType == CompressionZSTD {
-				dstBuf = dstBuf[:0]
-			}
 		}
 	}
 	if compressionBuf != nil {
@@ -1372,6 +1381,51 @@ type eventStoreIter struct {
 	decodeBuf   []byte
 }
 
+func decodeRawKVEntry(data []byte, v *common.RawKVEntry) error {
+	if len(data) < 36 {
+		return fmt.Errorf("insufficient data length")
+	}
+
+	offset := 0
+	v.OpType = common.OpType(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	v.CRTs = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	v.StartTs = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	v.RegionID = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+
+	v.KeyLen = binary.LittleEndian.Uint32(data[offset : offset+4])
+	offset += 4
+	v.ValueLen = binary.LittleEndian.Uint32(data[offset : offset+4])
+	offset += 4
+	v.OldValueLen = binary.LittleEndian.Uint32(data[offset : offset+4])
+	offset += 4
+
+	keyLen := int(v.KeyLen)
+	valueLen := int(v.ValueLen)
+	oldValueLen := int(v.OldValueLen)
+	totalLen := keyLen + valueLen + oldValueLen
+	if len(data[offset:]) < totalLen {
+		return fmt.Errorf("insufficient data for variable length fields")
+	}
+
+	valueBuf := make([]byte, totalLen)
+	copy(valueBuf, data[offset:offset+totalLen])
+	keyEnd := keyLen
+	valueEnd := keyEnd + valueLen
+	oldValueEnd := valueEnd + oldValueLen
+	v.Key = valueBuf[:keyEnd:keyEnd]
+	v.Value = valueBuf[keyEnd:valueEnd:valueEnd]
+	if oldValueLen > 0 {
+		v.OldValue = valueBuf[valueEnd:oldValueEnd:oldValueEnd]
+	} else {
+		v.OldValue = nil
+	}
+	return nil
+}
+
 func (iter *eventStoreIter) Next() (*common.RawKVEntry, bool) {
 	rawKV := &common.RawKVEntry{}
 	for {
@@ -1398,7 +1452,7 @@ func (iter *eventStoreIter) Next() (*common.RawKVEntry, bool) {
 			decodedValue = value
 		}
 
-		err := rawKV.Decode(decodedValue)
+		err := decodeRawKVEntry(decodedValue, rawKV)
 		if err != nil {
 			log.Panic("fail to decode raw kv entry", zap.Error(err))
 		}

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -1309,10 +1309,10 @@ func (e *eventStore) writeEvents(
 			}
 
 			compressionType := CompressionNone
-			valueBytesBefore := int64(kv.EncodedSize())
+			valueBytesBefore := kv.GetSize()
 			valueBytesAfter := valueBytesBefore
 			keyLen := encodedKeyLen(kv)
-			if e.enableZstdCompression && int(valueBytesBefore) > e.compressionThreshold {
+			if e.enableZstdCompression && valueBytesBefore > int64(e.compressionThreshold) {
 				rawValue := kv.Encode()
 				maxEncodedSize := encoder.MaxEncodedSize(len(rawValue))
 				if cap(dstBuf) < maxEncodedSize {

--- a/logservice/eventstore/event_store_bench_test.go
+++ b/logservice/eventstore/event_store_bench_test.go
@@ -25,20 +25,111 @@ import (
 	"github.com/pingcap/ticdc/pkg/common"
 )
 
+const benchmarkKiB = 1024
+
+var benchmarkWriteEventSizes = []struct {
+	name string
+	size int
+}{
+	{name: "4K", size: 4 * benchmarkKiB},
+	{name: "8K", size: 8 * benchmarkKiB},
+	{name: "16K", size: 16 * benchmarkKiB},
+	{name: "32K", size: 32 * benchmarkKiB},
+}
+
+var benchmarkCompressionModes = []struct {
+	name    string
+	enabled bool
+}{
+	{name: "CompressionOff", enabled: false},
+	{name: "CompressionOn", enabled: true},
+}
+
+func makeBenchmarkRawKVEntry(index int, valueSize int) common.RawKVEntry {
+	key := []byte(fmt.Sprintf("key-%06d", index))
+	value := bytes.Repeat([]byte{'v'}, valueSize)
+	return common.RawKVEntry{
+		OpType:  common.OpTypePut,
+		StartTs: uint64(100 + index),
+		CRTs:    uint64(1000 + index),
+		Key:     key,
+		Value:   value,
+	}
+}
+
 func makeBenchmarkRawKVEntries(count int, valueSize int) []common.RawKVEntry {
 	kvs := make([]common.RawKVEntry, 0, count)
 	for i := 0; i < count; i++ {
-		key := []byte(fmt.Sprintf("key-%06d", i))
-		value := bytes.Repeat([]byte{'v'}, valueSize)
-		kvs = append(kvs, common.RawKVEntry{
-			OpType:  common.OpTypePut,
-			StartTs: uint64(100 + i),
-			CRTs:    uint64(1000 + i),
-			Key:     key,
-			Value:   value,
-		})
+		kvs = append(kvs, makeBenchmarkRawKVEntry(i, valueSize))
 	}
 	return kvs
+}
+
+func makeBenchmarkWriteRawKVEntries(targetSize int) []common.RawKVEntry {
+	entry := makeBenchmarkRawKVEntry(0, 1)
+	fixedSize := int(entry.GetSize()) - len(entry.Value)
+	valueSize := targetSize - fixedSize
+	if valueSize < 1 {
+		valueSize = 1
+	}
+	return []common.RawKVEntry{makeBenchmarkRawKVEntry(0, valueSize)}
+}
+
+func BenchmarkEventStoreWriteEvents(b *testing.B) {
+	for _, compressionMode := range benchmarkCompressionModes {
+		b.Run(compressionMode.name, func(b *testing.B) {
+			for _, size := range benchmarkWriteEventSizes {
+				b.Run(size.name, func(b *testing.B) {
+					_, storeInt := newEventStoreForTest(b.TempDir())
+					store := storeInt.(*eventStore)
+					store.enableZstdCompression = compressionMode.enabled
+					defer store.Close(context.Background())
+
+					events := []eventWithCallback{{
+						subID:    1,
+						tableID:  1,
+						kvs:      makeBenchmarkWriteRawKVEntries(size.size),
+						callback: func() {},
+					}}
+					if compressionMode.enabled &&
+						size.name == "32K" &&
+						!hasCompressibleBenchmarkKV(store, events) {
+						b.Fatalf("32K case should trigger compression, threshold=%d", store.compressionThreshold)
+					}
+
+					encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+					if err != nil {
+						b.Fatal(err)
+					}
+					defer encoder.Close()
+					var compressionBuf []byte
+					var rawValueBuf []byte
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if err := store.writeEvents(store.dbs[0], events, encoder, &compressionBuf, &rawValueBuf); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func hasCompressibleBenchmarkKV(store *eventStore, events []eventWithCallback) bool {
+	if !store.enableZstdCompression {
+		return false
+	}
+	for _, event := range events {
+		for i := range event.kvs {
+			if event.kvs[i].GetSize() > int64(store.compressionThreshold) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func BenchmarkEventWithCallbackSizer(b *testing.B) {
@@ -52,33 +143,6 @@ func BenchmarkEventWithCallbackSizer(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = eventWithCallbackSizer(event)
-	}
-}
-
-func BenchmarkEventStoreWriteEvents(b *testing.B) {
-	_, storeInt := newEventStoreForTest(b.TempDir())
-	store := storeInt.(*eventStore)
-	defer store.Close(context.Background())
-
-	events := []eventWithCallback{{
-		subID:    1,
-		tableID:  1,
-		kvs:      makeBenchmarkRawKVEntries(128, 256),
-		callback: func() {},
-	}}
-	encoder, err := zstd.NewWriter(nil)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer encoder.Close()
-	var compressionBuf []byte
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := store.writeEvents(store.dbs[0], events, encoder, &compressionBuf); err != nil {
-			b.Fatal(err)
-		}
 	}
 }
 
@@ -107,7 +171,8 @@ func BenchmarkEventStoreIteratorNext(b *testing.B) {
 	}
 	defer encoder.Close()
 	var compressionBuf []byte
-	if err := store.writeEvents(db, events, encoder, &compressionBuf); err != nil {
+	var rawValueBuf []byte
+	if err := store.writeEvents(db, events, encoder, &compressionBuf, &rawValueBuf); err != nil {
 		b.Fatal(err)
 	}
 

--- a/logservice/eventstore/event_store_bench_test.go
+++ b/logservice/eventstore/event_store_bench_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/klauspost/compress/zstd"
+	"github.com/pingcap/ticdc/heartbeatpb"
+	"github.com/pingcap/ticdc/pkg/common"
+)
+
+func makeBenchmarkRawKVEntries(count int, valueSize int) []common.RawKVEntry {
+	kvs := make([]common.RawKVEntry, 0, count)
+	for i := 0; i < count; i++ {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		value := bytes.Repeat([]byte{'v'}, valueSize)
+		kvs = append(kvs, common.RawKVEntry{
+			OpType:  common.OpTypePut,
+			StartTs: uint64(100 + i),
+			CRTs:    uint64(1000 + i),
+			Key:     key,
+			Value:   value,
+		})
+	}
+	return kvs
+}
+
+func BenchmarkEventWithCallbackSizer(b *testing.B) {
+	event := eventWithCallback{
+		subID:   1,
+		tableID: 1,
+		kvs:     makeBenchmarkRawKVEntries(1024, 128),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = eventWithCallbackSizer(event)
+	}
+}
+
+func BenchmarkEventStoreWriteEvents(b *testing.B) {
+	_, storeInt := newEventStoreForTest(b.TempDir())
+	store := storeInt.(*eventStore)
+	defer store.Close(context.Background())
+
+	events := []eventWithCallback{{
+		subID:    1,
+		tableID:  1,
+		kvs:      makeBenchmarkRawKVEntries(128, 256),
+		callback: func() {},
+	}}
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer encoder.Close()
+	var compressionBuf []byte
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.writeEvents(store.dbs[0], events, encoder, &compressionBuf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEventStoreIteratorNext(b *testing.B) {
+	dir := b.TempDir()
+	db, err := pebble.Open(dir, &pebble.Options{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	_, storeInt := newEventStoreForTest(b.TempDir())
+	store := storeInt.(*eventStore)
+	defer store.Close(context.Background())
+
+	kvs := makeBenchmarkRawKVEntries(1024, 256)
+	events := []eventWithCallback{{
+		subID:    1,
+		tableID:  1,
+		kvs:      kvs,
+		callback: func() {},
+	}}
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer encoder.Close()
+	var compressionBuf []byte
+	if err := store.writeEvents(db, events, encoder, &compressionBuf); err != nil {
+		b.Fatal(err)
+	}
+
+	tableSpan := &heartbeatpb.TableSpan{
+		TableID:  1,
+		StartKey: []byte{},
+		EndKey:   []byte{0xff},
+	}
+	lower := EncodeKeyPrefix(1, 1, 1)
+	upper := EncodeKeyPrefix(1, 1, 1<<63)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		innerIter, err := db.NewIter(&pebble.IterOptions{
+			LowerBound: lower,
+			UpperBound: upper,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = innerIter.First()
+		iter := &eventStoreIter{
+			tableSpan:     tableSpan,
+			needCheckSpan: false,
+			innerIter:     innerIter,
+			decoder:       store.decoderPool.Get().(*zstd.Decoder),
+			decoderPool:   store.decoderPool,
+		}
+		count := 0
+		for {
+			if _, ok := iter.Next(); !ok {
+				break
+			}
+			count++
+		}
+		if count != len(kvs) {
+			b.Fatalf("unexpected row count: %d", count)
+		}
+		if _, err := iter.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -875,7 +875,8 @@ func TestWriteToEventStore(t *testing.T) {
 	defer encoder.Close()
 
 	var compressionBuf []byte
-	err = store.writeEvents(store.dbs[0], events, encoder, &compressionBuf)
+	var rawValueBuf []byte
+	err = store.writeEvents(store.dbs[0], events, encoder, &compressionBuf, &rawValueBuf)
 	require.NoError(t, err)
 
 	// Read events back and verify.
@@ -956,7 +957,8 @@ func TestWriteToEventStoreZstdCompressionDisabled(t *testing.T) {
 	defer encoder.Close()
 
 	var compressionBuf []byte
-	err = store.writeEvents(store.dbs[0], events, encoder, &compressionBuf)
+	var rawValueBuf []byte
+	err = store.writeEvents(store.dbs[0], events, encoder, &compressionBuf, &rawValueBuf)
 	require.NoError(t, err)
 
 	iter, err := store.dbs[0].NewIter(&pebble.IterOptions{})
@@ -1015,7 +1017,8 @@ func TestEventStoreCompressionAndIterDecodeBufferReuse(t *testing.T) {
 	require.NoError(t, err)
 	defer encoder.Close()
 	var compressionBuf []byte
-	err = store.writeEvents(store.dbs[0], events, encoder, &compressionBuf)
+	var rawValueBuf []byte
+	err = store.writeEvents(store.dbs[0], events, encoder, &compressionBuf, &rawValueBuf)
 	require.NoError(t, err)
 	afterMetric := testutil.ToFloat64(metrics.EventStoreCompressedRowsCount)
 	require.InDelta(t, float64(len(expectedValues)), afterMetric-beforeMetric, 1e-9)
@@ -1108,7 +1111,8 @@ func TestEventStoreGetIteratorConcurrently(t *testing.T) {
 	require.NoError(t, err)
 	defer encoder.Close()
 	var compressionBuf []byte
-	err = store.(*eventStore).writeEvents(store.(*eventStore).dbs[0], events, encoder, &compressionBuf)
+	var rawValueBuf []byte
+	err = store.(*eventStore).writeEvents(store.(*eventStore).dbs[0], events, encoder, &compressionBuf, &rawValueBuf)
 	require.NoError(t, err)
 
 	// 3. Advance resolved ts for the subscription.

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -827,11 +827,9 @@ func TestEventStoreSwitchSubStat(t *testing.T) {
 }
 
 func TestWriteToEventStore(t *testing.T) {
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
-
 	dir := t.TempDir()
-	store := New(dir, nil).(*eventStore)
+	_, storeInt := newEventStoreForTest(dir)
+	store := storeInt.(*eventStore)
 	defer store.Close(context.Background())
 
 	smallEntryKey := []byte("small-key")

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -1153,6 +1153,21 @@ func TestEventStoreGetIteratorConcurrently(t *testing.T) {
 	wg.Wait()
 }
 
+func TestEventWithCallbackSizerUsesCurrentKVBytes(t *testing.T) {
+	event := eventWithCallback{
+		kvs: []common.RawKVEntry{{
+			Key:         []byte("key"),
+			Value:       []byte("value"),
+			OldValue:    []byte("old"),
+			KeyLen:      1,
+			ValueLen:    1,
+			OldValueLen: 1,
+		}},
+	}
+
+	require.Equal(t, len("key")+len("value")+len("old"), eventWithCallbackSizer(event))
+}
+
 func TestEventStoreIter_NextWithFiltering(t *testing.T) {
 	t.Parallel()
 

--- a/logservice/eventstore/format.go
+++ b/logservice/eventstore/format.go
@@ -76,35 +76,41 @@ func EncodeKeyPrefix(uniqueID uint64, tableID int64, CRTs uint64, startTs ...uin
 	return buf
 }
 
-// EncodeKey encodes a key according to event.
+func encodedKeyLen(event *common.RawKVEntry) int {
+	return 8 + 8 + 8 + 8 + 1 + 1 + len(event.Key)
+}
+
+// EncodeKeyTo appends an encoded event-store key to buf.
 // Format: uniqueID, tableID, CRTs, startTs, delete/update/insert, Key.
-func EncodeKey(uniqueID uint64, tableID int64, event *common.RawKVEntry, compressionType CompressionType) []byte {
+func EncodeKeyTo(
+	buf []byte,
+	uniqueID uint64,
+	tableID int64,
+	event *common.RawKVEntry,
+	compressionType CompressionType,
+) []byte {
 	if event == nil {
 		log.Panic("rawkv must not be nil", zap.Any("event", event))
 	}
-	// uniqueID, tableID, CRTs, startTs, Put/Delete, CompressionType, Key
-	length := 8 + 8 + 8 + 8 + 1 + 1 + len(event.Key)
-	buf := make([]byte, 0, length)
-	uint64Buf := [8]byte{}
 	// unique ID
-	binary.BigEndian.PutUint64(uint64Buf[:], uniqueID)
-	buf = append(buf, uint64Buf[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, uniqueID)
 	// table ID
-	binary.BigEndian.PutUint64(uint64Buf[:], uint64(tableID))
-	buf = append(buf, uint64Buf[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(tableID))
 	// CRTs
-	binary.BigEndian.PutUint64(uint64Buf[:], event.CRTs)
-	buf = append(buf, uint64Buf[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, event.CRTs)
 	// startTs
-	binary.BigEndian.PutUint64(uint64Buf[:], event.StartTs)
-	buf = append(buf, uint64Buf[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, event.StartTs)
 	// Let Delete < Update < Insert
 	dmlOrder := getDMLOrder(event)
 	combinedOrder := uint16(compressionType) | (uint16(dmlOrder) << dmlOrderShift)
-	binary.BigEndian.PutUint16(uint64Buf[:], combinedOrder)
-	buf = append(buf, uint64Buf[:2]...)
+	buf = binary.BigEndian.AppendUint16(buf, combinedOrder)
 	// key
 	return append(buf, event.Key...)
+}
+
+// EncodeKey encodes a key according to event.
+func EncodeKey(uniqueID uint64, tableID int64, event *common.RawKVEntry, compressionType CompressionType) []byte {
+	return EncodeKeyTo(make([]byte, 0, encodedKeyLen(event)), uniqueID, tableID, event, compressionType)
 }
 
 // DecodeKeyMetas decodes compression type and dml order from the key.

--- a/logservice/eventstore/format.go
+++ b/logservice/eventstore/format.go
@@ -77,6 +77,7 @@ func EncodeKeyPrefix(uniqueID uint64, tableID int64, CRTs uint64, startTs ...uin
 }
 
 func encodedKeyLen(event *common.RawKVEntry) int {
+	// uniqueID, tableID, CRTs, startTs, Put/Delete, CompressionType, Key
 	return 8 + 8 + 8 + 8 + 1 + 1 + len(event.Key)
 }
 

--- a/pkg/common/kv_entry.go
+++ b/pkg/common/kv_entry.go
@@ -36,6 +36,14 @@ const (
 	CompressTypeZstd
 )
 
+const (
+	rawKVEntryOpTypeSize = 4
+	rawKVEntryUint32Size = 4
+	rawKVEntryUint64Size = 8
+
+	rawKVEntryHeaderSize = rawKVEntryOpTypeSize + 3*rawKVEntryUint64Size + 3*rawKVEntryUint32Size
+)
+
 // RawKVEntry represents a kv change or a resolved ts event
 // TODO: use a different struct
 type RawKVEntry struct {
@@ -127,12 +135,12 @@ func (v *RawKVEntry) String() string {
 
 // GetSize return the size of the RawKVEntry in bytes
 func (v *RawKVEntry) GetSize() int64 {
-	return int64(len(v.Key)+len(v.Value)+len(v.OldValue)) + 40 // 4*uint32 + 3*uint64
+	return int64(rawKVEntryHeaderSize + len(v.Key) + len(v.Value) + len(v.OldValue))
 }
 
 // EncodedSize returns the byte length produced by Encode.
 func (v *RawKVEntry) EncodedSize() int {
-	return 4*5 + 8*3 + len(v.Key) + len(v.Value) + len(v.OldValue)
+	return rawKVEntryHeaderSize + len(v.Key) + len(v.Value) + len(v.OldValue)
 }
 
 // Encode serializes the RawKVEntry into a byte slice.
@@ -166,7 +174,7 @@ func (v *RawKVEntry) EncodeTo(buf []byte) []byte {
 // Decode deserializes a byte slice into a RawKVEntry
 // Note: the `data` slice may be changed after calling this function, so do not keep reference to it.
 func (v *RawKVEntry) Decode(data []byte) error {
-	if len(data) < 36 { // Minimum size for fixed-length fields
+	if len(data) < rawKVEntryHeaderSize {
 		return fmt.Errorf("insufficient data length")
 	}
 
@@ -187,23 +195,25 @@ func (v *RawKVEntry) Decode(data []byte) error {
 	v.OldValueLen = binary.LittleEndian.Uint32(data[offset : offset+4])
 	offset += 4
 
-	totalLen := int(v.KeyLen + v.ValueLen + v.OldValueLen)
+	keyLen := int(v.KeyLen)
+	valueLen := int(v.ValueLen)
+	oldValueLen := int(v.OldValueLen)
+	totalLen := keyLen + valueLen + oldValueLen
 	if len(data[offset:]) < totalLen {
 		return fmt.Errorf("insufficient data for variable-length fields")
 	}
 
-	// the `data` slice may be changed, so we copy it here
-	v.Key = make([]byte, v.KeyLen)
-	copy(v.Key, data[offset:offset+int(v.KeyLen)])
-	offset += int(v.KeyLen)
+	// The `data` slice may be changed, so keep all variable-length fields in an owned buffer.
+	valueBuf := make([]byte, totalLen)
+	copy(valueBuf, data[offset:offset+totalLen])
+	keyEnd := keyLen
+	valueEnd := keyEnd + valueLen
+	oldValueEnd := valueEnd + oldValueLen
 
-	v.Value = make([]byte, v.ValueLen)
-	copy(v.Value, data[offset:offset+int(v.ValueLen)])
-	offset += int(v.ValueLen)
-
-	if v.OldValueLen > 0 {
-		v.OldValue = make([]byte, v.OldValueLen)
-		copy(v.OldValue, data[offset:offset+int(v.OldValueLen)])
+	v.Key = valueBuf[:keyEnd:keyEnd]
+	v.Value = valueBuf[keyEnd:valueEnd:valueEnd]
+	if oldValueLen > 0 {
+		v.OldValue = valueBuf[valueEnd:oldValueEnd:oldValueEnd]
 	} else {
 		v.OldValue = nil
 	}

--- a/pkg/common/kv_entry.go
+++ b/pkg/common/kv_entry.go
@@ -130,11 +130,18 @@ func (v *RawKVEntry) GetSize() int64 {
 	return int64(len(v.Key)+len(v.Value)+len(v.OldValue)) + 40 // 4*uint32 + 3*uint64
 }
 
-// Encode serializes the RawKVEntry into a byte slice
+// EncodedSize returns the byte length produced by Encode.
+func (v *RawKVEntry) EncodedSize() int {
+	return 4*5 + 8*3 + len(v.Key) + len(v.Value) + len(v.OldValue)
+}
+
+// Encode serializes the RawKVEntry into a byte slice.
 func (v *RawKVEntry) Encode() []byte {
-	// Calculate total size
-	totalSize := 4*5 + 8*3 + len(v.Key) + len(v.Value) + len(v.OldValue)
-	buf := make([]byte, 0, totalSize)
+	return v.EncodeTo(make([]byte, 0, v.EncodedSize()))
+}
+
+// EncodeTo serializes the RawKVEntry by appending to buf.
+func (v *RawKVEntry) EncodeTo(buf []byte) []byte {
 	// Use binary.LittleEndian.PutUint32/64 to write directly to the buffer
 	buf = binary.LittleEndian.AppendUint32(buf, uint32(v.OpType))
 	buf = binary.LittleEndian.AppendUint64(buf, v.CRTs)

--- a/pkg/common/kv_entry.go
+++ b/pkg/common/kv_entry.go
@@ -41,6 +41,10 @@ const (
 	rawKVEntryUint32Size = 4
 	rawKVEntryUint64Size = 8
 
+	// rawKVEntryHeaderSize contains OpType (rawKVEntryOpTypeSize),
+	// CRTs (rawKVEntryUint64Size), StartTs (rawKVEntryUint64Size),
+	// RegionID (rawKVEntryUint64Size), KeyLen (rawKVEntryUint32Size),
+	// ValueLen (rawKVEntryUint32Size), and OldValueLen (rawKVEntryUint32Size).
 	rawKVEntryHeaderSize = rawKVEntryOpTypeSize + 3*rawKVEntryUint64Size + 3*rawKVEntryUint32Size
 )
 
@@ -138,14 +142,9 @@ func (v *RawKVEntry) GetSize() int64 {
 	return int64(rawKVEntryHeaderSize + len(v.Key) + len(v.Value) + len(v.OldValue))
 }
 
-// EncodedSize returns the byte length produced by Encode.
-func (v *RawKVEntry) EncodedSize() int {
-	return rawKVEntryHeaderSize + len(v.Key) + len(v.Value) + len(v.OldValue)
-}
-
 // Encode serializes the RawKVEntry into a byte slice.
 func (v *RawKVEntry) Encode() []byte {
-	return v.EncodeTo(make([]byte, 0, v.EncodedSize()))
+	return v.EncodeTo(make([]byte, 0, int(v.GetSize())))
 }
 
 // EncodeTo serializes the RawKVEntry by appending to buf.

--- a/pkg/common/kv_entry_test.go
+++ b/pkg/common/kv_entry_test.go
@@ -88,7 +88,38 @@ func TestCompareEncodedSize(t *testing.T) {
 	jsonEncoded, err := json.Marshal(entry)
 	require.NoError(t, err)
 
+	require.Equal(t, len(encoded), entry.EncodedSize())
 	require.Less(t, len(encoded), len(jsonEncoded))
+}
+
+func TestRawKVEntryDecodeRejectsTruncatedHeader(t *testing.T) {
+	var entry RawKVEntry
+	err := entry.Decode(make([]byte, rawKVEntryHeaderSize-1))
+	require.ErrorContains(t, err, "insufficient data length")
+}
+
+func TestRawKVEntryDecodeFieldsDoNotShareAppendCapacity(t *testing.T) {
+	original := RawKVEntry{
+		OpType:   OpTypePut,
+		CRTs:     1234567890,
+		StartTs:  9876543210,
+		RegionID: 42,
+		Key:      []byte("key"),
+		Value:    []byte("value"),
+		OldValue: []byte("old"),
+	}
+
+	var decoded RawKVEntry
+	err := decoded.Decode(original.Encode())
+	require.NoError(t, err)
+
+	key := append(decoded.Key, 'x')
+	value := append(decoded.Value, 'x')
+
+	require.Equal(t, []byte("keyx"), key)
+	require.Equal(t, []byte("valuex"), value)
+	require.Equal(t, []byte("value"), decoded.Value)
+	require.Equal(t, []byte("old"), decoded.OldValue)
 }
 
 func TestRawKVEntry_SplitUpdate_UpdateOperation(t *testing.T) {

--- a/pkg/common/kv_entry_test.go
+++ b/pkg/common/kv_entry_test.go
@@ -98,6 +98,9 @@ func TestRawKVEntryDecodeRejectsTruncatedHeader(t *testing.T) {
 	require.ErrorContains(t, err, "insufficient data length")
 }
 
+// TestRawKVEntryDecodeFieldsDoNotShareAppendCapacity verifies that decoded
+// fields can share one backing buffer without letting append on one field
+// overwrite the next field.
 func TestRawKVEntryDecodeFieldsDoNotShareAppendCapacity(t *testing.T) {
 	original := RawKVEntry{
 		OpType:   OpTypePut,

--- a/pkg/common/kv_entry_test.go
+++ b/pkg/common/kv_entry_test.go
@@ -88,7 +88,7 @@ func TestCompareEncodedSize(t *testing.T) {
 	jsonEncoded, err := json.Marshal(entry)
 	require.NoError(t, err)
 
-	require.Equal(t, len(encoded), entry.EncodedSize())
+	require.Equal(t, len(encoded), int(entry.GetSize()))
 	require.Less(t, len(encoded), len(jsonEncoded))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4928 

### What is changed and how it works?

This pull request optimizes the event store's write and iterator paths by minimizing memory allocations. By introducing buffer-reuse patterns and switching to deferred batch operations, the changes reduce the overhead of encoding and writing events. These improvements are supported by updated size calculations and new benchmarks that confirm significant reductions in memory usage and allocation counts.

### Highlights

* **Allocation Reduction**: Implemented buffer-append encoding APIs and reused buffers in the write path to significantly reduce temporary allocations per row.
* **Write Path Optimization**: Switched to deferred Pebble batch operations for writes, allowing for more efficient memory usage and optional Zstd compression.
* **Accurate Sizing**: Updated size calculations to use actual byte lengths, ensuring memory accounting is precise and avoiding trailing uninitialized bytes.
* **Performance Benchmarking**: Added comprehensive benchmarks for write, sizing, and iteration paths to validate performance improvements and monitor allocation counts.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Benchmark Result: The benefits on the write path are clear, primarily due to the elimination of temporary key/value allocations per row. For the iterator, the main improvement is a reduction in allocation count, while the time overhead remains largely unchanged.

`BenchmarkEventStoreWriteEvents`
| Compression | Row size | ns/op | B/op | allocs/op |
|---|---:|---:|---:|---:|
| off | 4K | 1242 -> 622.8 (-49.9%) | 5049 -> 2 | 3 -> 0 |
| off | 8K | 2120 -> 1050 (-50.5%) | 9668 -> 5 | 3 -> 0 |
| off | 16K | 3609 -> 1577 (-56.3%) | 18654 -> 8 | 3 -> 0 |
| off | 32K | 7342 -> 2544 (-65.4%) | 41258 -> 15 | 3 -> 0 |
| on | 4K | 1248 -> 1003 (-19.6%) | 5049 -> 2 | 3 -> 0 |
| on | 8K | 2198 -> 1033 (-53.0%) | 9668 -> 5 | 3 -> 0 |
| on | 16K | 3600 -> 1555 (-56.8%) | 18653 -> 8 | 3 -> 0 |
| on | 32K | 11661 -> 9215 (-21.0%) | 41185 -> 37 | 3 -> 0 |

`BenchmarkEventStoreIteratorNext`
| ns/op | B/op | allocs/op |
|---:|---:|---:|
| 159370 -> 154035 (-3.3%) | 409855 -> 426253 (+4.0%) | 3074 -> 2050 (-33.3%) |

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced allocations and improved write/read performance via buffer reuse and precise key/value sizing.
  * Size calculations now use actual byte lengths for more accurate memory accounting.

* **Tests**
  * Added benchmarks for write throughput, sizing, and iteration with varied payloads and compression.
  * Added unit tests for encode/decode correctness and memory-safety of encoded entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->