### PR TITLE
sink: fix a panic when closing pulsar sink

### DIFF
--- a/downstreamadapter/sink/pulsar/ddl_producer.go
+++ b/downstreamadapter/sink/pulsar/ddl_producer.go
@@ -161,6 +161,9 @@ func (p *ddlProducers) getProducerByTopic(topicName string) (producer pulsarClie
 
 // Close all producers
 func (p *ddlProducers) close() {
+	if p == nil {
+		return
+	}
 	keys := p.producers.Keys()
 
 	p.producersMutex.Lock()

--- a/downstreamadapter/sink/pulsar/dml_producer.go
+++ b/downstreamadapter/sink/pulsar/dml_producer.go
@@ -195,6 +195,9 @@ func (p *dmlProducers) asyncSendMessage(
 }
 
 func (p *dmlProducers) close() { // We have to hold the lock to synchronize closing with writing.
+	if p == nil {
+		return
+	}
 	p.closedMu.Lock()
 	defer p.closedMu.Unlock()
 	// If the producer has already been closed, we should skip this close operation.

--- a/downstreamadapter/sink/pulsar/sink.go
+++ b/downstreamadapter/sink/pulsar/sink.go
@@ -89,13 +89,33 @@ func New(
 		sinkConfig,
 		comp,
 		protocol,
-		func(changefeedID commonType.ChangeFeedID, comp component, failpointCh chan error) (dmlProducer, error) {
-			return newDMLProducers(changefeedID, comp, failpointCh)
-		},
-		func(changefeedID commonType.ChangeFeedID, comp component, sinkConfig *config.SinkConfig) (ddlProducer, error) {
-			return newDDLProducers(changefeedID, comp, sinkConfig)
-		},
+		newPulsarDMLProducer,
+		newPulsarDDLProducer,
 	)
+}
+
+func newPulsarDMLProducer(
+	changefeedID commonType.ChangeFeedID,
+	comp component,
+	failpointCh chan error,
+) (dmlProducer, error) {
+	producer, err := newDMLProducers(changefeedID, comp, failpointCh)
+	if err != nil {
+		return nil, err
+	}
+	return producer, nil
+}
+
+func newPulsarDDLProducer(
+	changefeedID commonType.ChangeFeedID,
+	comp component,
+	sinkConfig *config.SinkConfig,
+) (ddlProducer, error) {
+	producer, err := newDDLProducers(changefeedID, comp, sinkConfig)
+	if err != nil {
+		return nil, err
+	}
+	return producer, nil
 }
 
 func newWithComponent(
@@ -110,6 +130,7 @@ func newWithComponent(
 	var (
 		dmlProducer dmlProducer
 		ddlProducer ddlProducer
+		statistics  *metrics.Statistics
 	)
 	defer func() {
 		if err != nil {
@@ -119,12 +140,15 @@ func newWithComponent(
 			if dmlProducer != nil {
 				dmlProducer.close()
 			}
+			if statistics != nil {
+				statistics.Close()
+			}
 			comp.close()
 		}
 	}()
 
 	failpointCh := make(chan error, 1)
-	statistics := metrics.NewStatistics(changefeedID, "pulsar")
+	statistics = metrics.NewStatistics(changefeedID, "pulsar")
 	dmlProducer, err = newDMLProducer(changefeedID, comp, failpointCh)
 	if err != nil {
 		return nil, err

--- a/downstreamadapter/sink/pulsar/sink_test.go
+++ b/downstreamadapter/sink/pulsar/sink_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
+	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/utils/chann"
 	"github.com/stretchr/testify/require"
@@ -137,4 +138,59 @@ func TestPulsarSinkBatchConfig(t *testing.T) {
 	sink := &sink{}
 	require.Equal(t, 4096, sink.BatchCount())
 	require.Zero(t, sink.BatchBytes())
+}
+
+func TestPulsarSinkNewWithComponentReturnsDMLProducerError(t *testing.T) {
+	changefeedID := common.NewChangefeedID4Test("test", "test")
+	expectedErr := cerror.ErrPulsarNewProducer.GenWithStackByArgs()
+	ddlProducerCreated := false
+	var err error
+
+	require.NotPanics(t, func() {
+		_, err = newWithComponent(
+			context.Background(),
+			changefeedID,
+			&config.SinkConfig{},
+			component{},
+			config.ProtocolCanalJSON,
+			func(common.ChangeFeedID, component, chan error) (dmlProducer, error) {
+				var producer *dmlProducers
+				return producer, expectedErr
+			},
+			func(common.ChangeFeedID, component, *config.SinkConfig) (ddlProducer, error) {
+				ddlProducerCreated = true
+				return newMockDDLProducer(), nil
+			},
+		)
+	})
+
+	require.Error(t, err)
+	require.EqualError(t, err, expectedErr.Error())
+	require.False(t, ddlProducerCreated)
+}
+
+func TestPulsarSinkNewWithComponentReturnsDDLProducerError(t *testing.T) {
+	changefeedID := common.NewChangefeedID4Test("test", "test")
+	expectedErr := cerror.ErrPulsarNewProducer.GenWithStackByArgs()
+	var err error
+
+	require.NotPanics(t, func() {
+		_, err = newWithComponent(
+			context.Background(),
+			changefeedID,
+			&config.SinkConfig{},
+			component{},
+			config.ProtocolCanalJSON,
+			func(common.ChangeFeedID, component, chan error) (dmlProducer, error) {
+				return newMockDMLProducer(), nil
+			},
+			func(common.ChangeFeedID, component, *config.SinkConfig) (ddlProducer, error) {
+				var producer *ddlProducers
+				return producer, expectedErr
+			},
+		)
+	})
+
+	require.Error(t, err)
+	require.EqualError(t, err, expectedErr.Error())
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4937

### What is changed and how it works?
The root cause of this panic is that when the Pulsar producer construction fails, *dmlProducers(nil) / *ddlProducers(nil) are directly returned as interface types, leading to the initialization cleanup phase mistakenly judging them as non-nil, and then calling close() which dereferences a nil receiver.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved nil safety in Pulsar producer management to prevent potential crashes.
  * Enhanced error handling and resource cleanup during sink initialization failures.

* **Tests**
  * Added unit tests to verify proper error propagation during producer initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->