### PR TITLE
logpuller: speed up region error cache dispatch

### DIFF
--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -844,10 +844,12 @@ func (s *subscriptionClient) handleErrors(ctx context.Context) error {
 
 func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionErrorInfo) error {
 	err := errors.Cause(errInfo.err)
-	log.Debug("cdc region error",
-		zap.Uint64("subscriptionID", uint64(errInfo.subscribedSpan.subID)),
-		zap.Uint64("regionID", errInfo.verID.GetID()),
-		zap.Error(err))
+	if _, canceled := err.(*requestCancelledErr); !canceled {
+		log.Debug("cdc region error",
+			zap.Uint64("subscriptionID", uint64(errInfo.subscribedSpan.subID)),
+			zap.Uint64("regionID", errInfo.verID.GetID()),
+			zap.Error(err))
+	}
 
 	switch eerr := err.(type) {
 	case *eventError:
@@ -1157,6 +1159,8 @@ type errCache struct {
 	notify chan struct{}
 }
 
+const errCacheDispatchBatchSize = 1024
+
 func newErrCache() *errCache {
 	return &errCache{
 		cache:  make([]regionErrorInfo, 0, 1024),
@@ -1175,21 +1179,51 @@ func (e *errCache) add(errInfo regionErrorInfo) {
 	}
 }
 
-func (e *errCache) dispatch(ctx context.Context) error {
-	ticker := time.NewTicker(10 * time.Millisecond)
-	sendToErrCh := func() {
-		e.Lock()
-		if len(e.cache) == 0 {
-			e.Unlock()
-			return
-		}
-		errInfo := e.cache[0]
-		e.cache = e.cache[1:]
-		e.Unlock()
+func (e *errCache) popBatch(limit int) []regionErrorInfo {
+	e.Lock()
+	defer e.Unlock()
+	if len(e.cache) == 0 {
+		return nil
+	}
+	if limit <= 0 || limit > len(e.cache) {
+		limit = len(e.cache)
+	}
+	batch := make([]regionErrorInfo, limit)
+	copy(batch, e.cache[:limit])
+	clear(e.cache[:limit])
+	if limit == len(e.cache) {
+		e.cache = e.cache[:0]
+	} else {
+		e.cache = e.cache[limit:]
+	}
+	return batch
+}
+
+func (e *errCache) dispatchBatch(ctx context.Context, limit int) (int, error) {
+	batch := e.popBatch(limit)
+	for _, errInfo := range batch {
 		select {
 		case <-ctx.Done():
 			log.Info("subscription client dispatch err cache done")
+			return 0, ctx.Err()
 		case e.errCh <- errInfo:
+		}
+	}
+	return len(batch), nil
+}
+
+func (e *errCache) dispatch(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	sendToErrCh := func() error {
+		for {
+			n, err := e.dispatchBatch(ctx, errCacheDispatchBatchSize)
+			if err != nil {
+				return err
+			}
+			if n < errCacheDispatchBatchSize {
+				return nil
+			}
 		}
 	}
 	for {
@@ -1197,9 +1231,13 @@ func (e *errCache) dispatch(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			sendToErrCh()
+			if err := sendToErrCh(); err != nil {
+				return err
+			}
 		case <-e.notify:
-			sendToErrCh()
+			if err := sendToErrCh(); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -844,7 +844,7 @@ func (s *subscriptionClient) handleErrors(ctx context.Context) error {
 
 func (s *subscriptionClient) doHandleError(ctx context.Context, errInfo regionErrorInfo) error {
 	err := errors.Cause(errInfo.err)
-	if _, canceled := err.(*requestCancelledErr); !canceled {
+	if _, requestCancelled := err.(*requestCancelledErr); !requestCancelled {
 		log.Debug("cdc region error",
 			zap.Uint64("subscriptionID", uint64(errInfo.subscribedSpan.subID)),
 			zap.Uint64("regionID", errInfo.verID.GetID()),

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -1164,7 +1164,7 @@ const errCacheDispatchBatchSize = 1024
 func newErrCache() *errCache {
 	return &errCache{
 		cache:  make([]regionErrorInfo, 0, 1024),
-		errCh:  make(chan regionErrorInfo, 1024),
+		errCh:  make(chan regionErrorInfo, 4096),
 		notify: make(chan struct{}, 1024),
 	}
 }

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -483,11 +483,6 @@ func TestErrCacheDispatchWithFullChannelAndCanceledContext(t *testing.T) {
 }
 
 func TestErrCacheDispatchBatch(t *testing.T) {
-	errCache := &errCache{
-		cache:  make([]regionErrorInfo, 0, 10),
-		errCh:  make(chan regionErrorInfo, 10),
-		notify: make(chan struct{}, 1),
-	}
 	mockErrInfo := regionErrorInfo{
 		regionInfo: regionInfo{
 			verID: tikv.NewRegionVerID(1, 1, 1),
@@ -496,15 +491,82 @@ func TestErrCacheDispatchBatch(t *testing.T) {
 		err: errors.New("test error"),
 	}
 
-	for i := 0; i < 5; i++ {
-		errCache.add(mockErrInfo)
+	tests := []struct {
+		name          string
+		cacheLen      int
+		limit         int
+		expectedN     int
+		expectedCache int
+		expectedErrCh int
+	}{
+		{
+			name:          "dispatch all when limit equals cache length",
+			cacheLen:      5,
+			limit:         5,
+			expectedN:     5,
+			expectedCache: 0,
+			expectedErrCh: 5,
+		},
+		{
+			name:          "keep remaining cache when limit is smaller",
+			cacheLen:      5,
+			limit:         2,
+			expectedN:     2,
+			expectedCache: 3,
+			expectedErrCh: 2,
+		},
+		{
+			name:          "dispatch all when limit is larger",
+			cacheLen:      5,
+			limit:         10,
+			expectedN:     5,
+			expectedCache: 0,
+			expectedErrCh: 5,
+		},
+		{
+			name:          "dispatch all when limit is zero",
+			cacheLen:      5,
+			limit:         0,
+			expectedN:     5,
+			expectedCache: 0,
+			expectedErrCh: 5,
+		},
+		{
+			name:          "dispatch all when limit is negative",
+			cacheLen:      5,
+			limit:         -1,
+			expectedN:     5,
+			expectedCache: 0,
+			expectedErrCh: 5,
+		},
+		{
+			name:          "empty cache",
+			cacheLen:      0,
+			limit:         5,
+			expectedN:     0,
+			expectedCache: 0,
+			expectedErrCh: 0,
+		},
 	}
 
-	n, err := errCache.dispatchBatch(context.Background(), 5)
-	require.NoError(t, err)
-	require.Equal(t, 5, n)
-	require.Empty(t, errCache.cache)
-	require.Len(t, errCache.errCh, 5)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errCache := &errCache{
+				cache:  make([]regionErrorInfo, 0, 10),
+				errCh:  make(chan regionErrorInfo, 10),
+				notify: make(chan struct{}, 1),
+			}
+			for i := 0; i < tc.cacheLen; i++ {
+				errCache.add(mockErrInfo)
+			}
+
+			n, err := errCache.dispatchBatch(context.Background(), tc.limit)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedN, n)
+			require.Len(t, errCache.cache, tc.expectedCache)
+			require.Len(t, errCache.errCh, tc.expectedErrCh)
+		})
+	}
 }
 
 func TestGCResolveLastRunMap(t *testing.T) {

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -182,6 +182,50 @@ func TestStopTaskUsesSubscribedSpanFilterLoop(t *testing.T) {
 	require.True(t, region.filterLoop)
 }
 
+func TestOnRegionFailQueuesCanceledErrorCache(t *testing.T) {
+	client := &subscriptionClient{
+		errCache: newErrCache(),
+		ds:       &mockDynamicStream{},
+	}
+	rawSpan := heartbeatpb.TableSpan{
+		TableID:  1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+	}
+	span := &subscribedSpan{
+		subID:     SubscriptionID(1),
+		span:      rawSpan,
+		rangeLock: regionlock.NewRangeLock(1, rawSpan.StartKey, rawSpan.EndKey, 100),
+	}
+	client.totalSpans.spanMap = map[SubscriptionID]*subscribedSpan{span.subID: span}
+
+	res1 := span.rangeLock.LockRange(context.Background(), []byte("a"), []byte("m"), 1, 1)
+	require.Equal(t, regionlock.LockRangeStatusSuccess, res1.Status)
+	res2 := span.rangeLock.LockRange(context.Background(), []byte("m"), []byte("z"), 2, 1)
+	require.Equal(t, regionlock.LockRangeStatusSuccess, res2.Status)
+	require.False(t, span.rangeLock.Stop())
+
+	client.onRegionFail(newRegionErrorInfo(regionInfo{
+		verID:            tikv.NewRegionVerID(1, 1, 1),
+		span:             heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("m")},
+		subscribedSpan:   span,
+		lockedRangeState: res1.LockedRangeState,
+	}, &requestCancelledErr{}))
+
+	require.Len(t, client.errCache.cache, 1)
+	require.Len(t, span.rangeLock.IterAll(nil).UnLockedRanges, 1)
+
+	client.onRegionFail(newRegionErrorInfo(regionInfo{
+		verID:            tikv.NewRegionVerID(2, 1, 1),
+		span:             heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("m"), EndKey: []byte("z")},
+		subscribedSpan:   span,
+		lockedRangeState: res2.LockedRangeState,
+	}, &requestCancelledErr{}))
+
+	require.Len(t, client.errCache.cache, 1)
+	require.NotContains(t, client.totalSpans.spanMap, span.subID)
+}
+
 type mockDynamicStream struct{}
 
 func (s *mockDynamicStream) Start() {}
@@ -436,6 +480,31 @@ func TestErrCacheDispatchWithFullChannelAndCanceledContext(t *testing.T) {
 		// If we timeout here, it means dispatch is stuck
 		t.Fatal("dispatch method is stuck and didn't return after context cancellation")
 	}
+}
+
+func TestErrCacheDispatchBatch(t *testing.T) {
+	errCache := &errCache{
+		cache:  make([]regionErrorInfo, 0, 10),
+		errCh:  make(chan regionErrorInfo, 10),
+		notify: make(chan struct{}, 1),
+	}
+	mockErrInfo := regionErrorInfo{
+		regionInfo: regionInfo{
+			verID: tikv.NewRegionVerID(1, 1, 1),
+			span:  heartbeatpb.TableSpan{TableID: 1, StartKey: []byte("a"), EndKey: []byte("b")},
+		},
+		err: errors.New("test error"),
+	}
+
+	for i := 0; i < 5; i++ {
+		errCache.add(mockErrInfo)
+	}
+
+	n, err := errCache.dispatchBatch(context.Background(), 5)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Empty(t, errCache.cache)
+	require.Len(t, errCache.errCh, 5)
 }
 
 func TestGCResolveLastRunMap(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4653 

### What is changed and how it works?

This pull request optimizes the logpuller's error handling mechanism by introducing batch processing for the error cache and reducing unnecessary log noise. These changes improve system efficiency under high load by minimizing lock acquisition frequency and suppressing logs for expected cancellation events.

### Highlights

* **Logging Optimization**: Suppressed redundant 'cdc region error' debug logs when the error is identified as a request cancellation.
* **Performance Improvement**: Refactored the error cache dispatcher to process errors in batches of 1024, reducing lock contention and improving throughput.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary debug logging when requests are cancelled
* **Tests**
  * Added test coverage for error handling and cache management behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->