### PR TITLE
mysql: tolerate missing ddl ts metadata

### DIFF
--- a/pkg/sink/mysql/mysql_writer_ddl_ts_test.go
+++ b/pkg/sink/mysql/mysql_writer_ddl_ts_test.go
@@ -16,6 +16,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -78,6 +79,54 @@ func newTestMockDBForDDLTs(t *testing.T) (db *sql.DB, mock sqlmock.Sqlmock) {
 	return
 }
 
+func nonstandardDDLTsTableMissingErr() *mysql.MySQLError {
+	return &mysql.MySQLError{
+		Number:  9999,
+		Message: "ddl_ts_v1 is missing",
+	}
+}
+
+func standardDDLTsDatabaseMissingErr() *mysql.MySQLError {
+	return &mysql.MySQLError{
+		Number:  1049, // ER_BAD_DB_ERROR
+		Message: "Unknown database 'tidb_cdc'",
+	}
+}
+
+func expectDDLTsTableMetadataCount(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(ddlTsTableExistsQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(1)"}).AddRow(count))
+}
+
+func expectDDLTsTableMetadataError(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(ddlTsTableExistsQuery).
+		WillReturnError(errors.New("information schema is unavailable"))
+}
+
+func expectCreateDDLTsTable(mock sqlmock.Sqlmock) {
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("USE tidb_cdc").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS ddl_ts_v1
+	(
+		ticdc_cluster_id varchar (255),
+		changefeed varchar(255),
+		ddl_ts varchar(18),
+		table_id bigint(21),
+		finished bool,
+		is_syncpoint bool,
+		INDEX (ticdc_cluster_id, changefeed, table_id),
+		PRIMARY KEY (ticdc_cluster_id, changefeed, table_id)
+	);`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+}
+
+func expectCreateDDLTsTableError(mock sqlmock.Sqlmock) {
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS tidb_cdc").WillReturnError(errors.New("create database failed"))
+	mock.ExpectRollback()
+}
+
 // TestGetTableRecoveryInfo_Comprehensive - Comprehensive end-to-end test for GetTableRecoveryInfo
 func TestGetTableRecoveryInfo_Comprehensive(t *testing.T) {
 	// Test scenarios:
@@ -113,6 +162,97 @@ func TestGetTableRecoveryInfo_Comprehensive(t *testing.T) {
 			require.False(t, skipDMLAsStartTsList[i])
 		}
 
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("TableMissingByMetadata", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		tableIDs := []int64{1}
+		expectedQuery := "SELECT table_id, ddl_ts, finished, is_syncpoint FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed, table_id) IN (('default', 'test/test', 1), ('default', 'test/test', -1))"
+
+		mock.ExpectQuery(expectedQuery).WillReturnError(nonstandardDDLTsTableMissingErr())
+		expectDDLTsTableMetadataCount(mock, 0)
+
+		startTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, err := writer.GetTableRecoveryInfo(tableIDs)
+
+		require.NoError(t, err)
+		require.Equal(t, []int64{0}, startTsList)
+		require.Equal(t, []bool{false}, skipSyncpointAtStartTs)
+		require.Equal(t, []bool{false}, skipDMLAsStartTsList)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("TableExistsReportsOriginalError", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		tableIDs := []int64{1}
+		expectedQuery := "SELECT table_id, ddl_ts, finished, is_syncpoint FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed, table_id) IN (('default', 'test/test', 1), ('default', 'test/test', -1))"
+
+		mock.ExpectQuery(expectedQuery).WillReturnError(nonstandardDDLTsTableMissingErr())
+		expectDDLTsTableMetadataCount(mock, 1)
+
+		_, _, _, err := writer.GetTableRecoveryInfo(tableIDs)
+
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MetadataUnavailableCreateAndRetry", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		tableIDs := []int64{1}
+		expectedQuery := "SELECT table_id, ddl_ts, finished, is_syncpoint FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed, table_id) IN (('default', 'test/test', 1), ('default', 'test/test', -1))"
+
+		mock.ExpectQuery(expectedQuery).WillReturnError(nonstandardDDLTsTableMissingErr())
+		expectDDLTsTableMetadataError(mock)
+		expectCreateDDLTsTable(mock)
+		mock.ExpectQuery(expectedQuery).WillReturnRows(sqlmock.NewRows([]string{"table_id", "ddl_ts", "finished", "is_syncpoint"}))
+
+		startTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, err := writer.GetTableRecoveryInfo(tableIDs)
+
+		require.NoError(t, err)
+		require.Equal(t, []int64{0}, startTsList)
+		require.Equal(t, []bool{false}, skipSyncpointAtStartTs)
+		require.Equal(t, []bool{false}, skipDMLAsStartTsList)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MetadataUnavailableCreateFailed", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		tableIDs := []int64{1}
+		expectedQuery := "SELECT table_id, ddl_ts, finished, is_syncpoint FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed, table_id) IN (('default', 'test/test', 1), ('default', 'test/test', -1))"
+
+		mock.ExpectQuery(expectedQuery).WillReturnError(nonstandardDDLTsTableMissingErr())
+		expectDDLTsTableMetadataError(mock)
+		expectCreateDDLTsTableError(mock)
+
+		_, _, _, err := writer.GetTableRecoveryInfo(tableIDs)
+
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MetadataUnavailableRetryFailed", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		tableIDs := []int64{1}
+		expectedQuery := "SELECT table_id, ddl_ts, finished, is_syncpoint FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed, table_id) IN (('default', 'test/test', 1), ('default', 'test/test', -1))"
+
+		mock.ExpectQuery(expectedQuery).WillReturnError(nonstandardDDLTsTableMissingErr())
+		expectDDLTsTableMetadataError(mock)
+		expectCreateDDLTsTable(mock)
+		mock.ExpectQuery(expectedQuery).WillReturnError(errors.New("retry query failed"))
+
+		_, _, _, err := writer.GetTableRecoveryInfo(tableIDs)
+
+		require.Error(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -400,6 +540,118 @@ func TestGetTableRecoveryInfo_Comprehensive(t *testing.T) {
 		require.Equal(t, int64(200), startTsList[2])
 		require.False(t, skipSyncpointAtStartTs[2])
 
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestRemoveDDLTsItem_TableMissingFallback(t *testing.T) {
+	t.Run("StandardErrorCode", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		query := "DELETE FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed) IN (('default', 'test/test'))"
+
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(standardDDLTsDatabaseMissingErr())
+		mock.ExpectRollback()
+
+		err := writer.RemoveDDLTsItem()
+
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("TableMissingByMetadata", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		query := "DELETE FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed) IN (('default', 'test/test'))"
+
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(nonstandardDDLTsTableMissingErr())
+		mock.ExpectRollback()
+		expectDDLTsTableMetadataCount(mock, 0)
+
+		err := writer.RemoveDDLTsItem()
+
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("TableExistsReportsOriginalError", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		query := "DELETE FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed) IN (('default', 'test/test'))"
+
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(nonstandardDDLTsTableMissingErr())
+		mock.ExpectRollback()
+		expectDDLTsTableMetadataCount(mock, 1)
+
+		err := writer.RemoveDDLTsItem()
+
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MetadataUnavailableCreateFailed", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		query := "DELETE FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed) IN (('default', 'test/test'))"
+
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(nonstandardDDLTsTableMissingErr())
+		mock.ExpectRollback()
+		expectDDLTsTableMetadataError(mock)
+		expectCreateDDLTsTableError(mock)
+
+		err := writer.RemoveDDLTsItem()
+
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MetadataUnavailableRetryFailed", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		query := "DELETE FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed) IN (('default', 'test/test'))"
+
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(nonstandardDDLTsTableMissingErr())
+		mock.ExpectRollback()
+		expectDDLTsTableMetadataError(mock)
+		expectCreateDDLTsTable(mock)
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(errors.New("retry delete failed"))
+		mock.ExpectRollback()
+
+		err := writer.RemoveDDLTsItem()
+
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MetadataUnavailableCreateAndRetry", func(t *testing.T) {
+		writer, db, mock := newTestMysqlWriterForDDLTs(t)
+		defer db.Close()
+
+		query := "DELETE FROM tidb_cdc.ddl_ts_v1 WHERE (ticdc_cluster_id, changefeed) IN (('default', 'test/test'))"
+
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnError(nonstandardDDLTsTableMissingErr())
+		mock.ExpectRollback()
+		expectDDLTsTableMetadataError(mock)
+		expectCreateDDLTsTable(mock)
+		mock.ExpectBegin()
+		mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		err := writer.RemoveDDLTsItem()
+
+		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -31,6 +31,17 @@ const (
 	// syncPointMetaTableID is a reserved table_id in ddl_ts_v1 used to record syncpoint state.
 	// It is negative to avoid conflicting with any real table_id (including DDLSpanTableID=0).
 	syncPointMetaTableID int64 = -1
+
+	ddlTsTableExistsQuery = "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = '" +
+		filter.TiCDCSystemSchema + "' AND table_name = '" + filter.DDLTsTable + "'"
+)
+
+type ddlTsTableErrorAction int
+
+const (
+	ddlTsTableErrorReport ddlTsTableErrorAction = iota
+	ddlTsTableErrorIgnore
+	ddlTsTableErrorRetry
 )
 
 // FlushDDLTsPre is used to flush ddl ts before the ddl event is sent to downstream.
@@ -351,7 +362,11 @@ func (w *Writer) GetTableRecoveryInfo(tableIDs []int64) ([]int64, []bool, []bool
 	log.Info("query ddl ts table", zap.String("query", query))
 	rows, err := w.db.Query(query)
 	if err != nil {
-		if errors.IsTableNotExistsErr(err) {
+		action, handleErr := w.handleDDLTsTableQueryError(err)
+		if handleErr != nil {
+			return retStartTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, handleErr
+		}
+		if action == ddlTsTableErrorIgnore {
 			// If this table is not existed, this means the table is first being synced
 			log.Info("ddl ts table is not found",
 				zap.String("keyspace", w.ChangefeedID.Keyspace()),
@@ -359,7 +374,12 @@ func (w *Writer) GetTableRecoveryInfo(tableIDs []int64) ([]int64, []bool, []bool
 				zap.Error(err))
 			return retStartTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, nil
 		}
-		return retStartTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
+		if action == ddlTsTableErrorRetry {
+			rows, err = w.db.Query(query)
+		}
+		if err != nil {
+			return retStartTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
+		}
 	}
 
 	defer rows.Close()
@@ -502,10 +522,14 @@ func (w *Writer) RemoveDDLTsItem() error {
 
 	_, err = tx.Exec(query)
 	if err != nil {
-		if errors.IsTableNotExistsErr(err) {
-			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Error("failed to rollback", zap.Error(rbErr))
-			}
+		if rbErr := tx.Rollback(); rbErr != nil {
+			log.Error("failed to rollback", zap.Error(rbErr))
+		}
+		action, handleErr := w.handleDDLTsTableQueryError(err)
+		if handleErr != nil {
+			return handleErr
+		}
+		if action == ddlTsTableErrorIgnore {
 			// If this table is not existed, this means the changefeed has not table, so we just return nil.
 			log.Info("ddl ts table is not found when RemoveDDLTsItem",
 				zap.String("keyspace", w.ChangefeedID.Keyspace()),
@@ -513,6 +537,25 @@ func (w *Writer) RemoveDDLTsItem() error {
 				zap.Error(err))
 			return nil
 		}
+		if action == ddlTsTableErrorRetry {
+			return w.removeDDLTsItemWithQuery(query)
+		}
+		log.Error("failed to delete ddl ts item ", zap.Error(err))
+		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+	}
+
+	err = tx.Commit()
+	return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+}
+
+func (w *Writer) removeDDLTsItemWithQuery(query string) error {
+	tx, err := w.db.BeginTx(w.ctx, nil)
+	if err != nil {
+		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, "select ddl ts table: begin Tx fail;"))
+	}
+
+	_, err = tx.Exec(query)
+	if err != nil {
 		log.Error("failed to delete ddl ts item ", zap.Error(err))
 		err2 := tx.Rollback()
 		if err2 != nil {
@@ -523,6 +566,43 @@ func (w *Writer) RemoveDDLTsItem() error {
 
 	err = tx.Commit()
 	return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+}
+
+func (w *Writer) handleDDLTsTableQueryError(queryErr error) (ddlTsTableErrorAction, error) {
+	if errors.IsTableNotExistsErr(queryErr) {
+		return ddlTsTableErrorIgnore, nil
+	}
+
+	exists, err := w.ddlTsTableExists()
+	if err == nil {
+		if !exists {
+			return ddlTsTableErrorIgnore, nil
+		}
+		return ddlTsTableErrorReport, nil
+	}
+
+	log.Warn("failed to check ddl ts table metadata, create table and retry",
+		zap.String("keyspace", w.ChangefeedID.Keyspace()),
+		zap.String("changefeedID", w.ChangefeedID.Name()),
+		zap.Error(err),
+		zap.NamedError("queryError", queryErr))
+	if err := w.createDDLTsTable(); err != nil {
+		return ddlTsTableErrorReport, err
+	}
+
+	w.ddlTsTableInitMutex.Lock()
+	w.ddlTsTableInit = true
+	w.ddlTsTableInitMutex.Unlock()
+	return ddlTsTableErrorRetry, nil
+}
+
+func (w *Writer) ddlTsTableExists() (bool, error) {
+	row := w.db.QueryRowContext(w.ctx, ddlTsTableExistsQuery)
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return false, errors.Trace(err)
+	}
+	return count > 0, nil
 }
 
 func (w *Writer) isDDLExecuted(tableID int64, ddlTs uint64) (bool, error) {

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -32,15 +32,28 @@ const (
 	// It is negative to avoid conflicting with any real table_id (including DDLSpanTableID=0).
 	syncPointMetaTableID int64 = -1
 
+	// ddlTsTableExistsQuery checks only TiCDC's own ddl_ts metadata table.
+	// It is used after a failed ddl_ts operation when the downstream does not
+	// return standard MySQL/TiDB missing table error codes.
 	ddlTsTableExistsQuery = "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = '" +
 		filter.TiCDCSystemSchema + "' AND table_name = '" + filter.DDLTsTable + "'"
 )
 
+// ddlTsTableErrorAction tells the caller how to proceed after a failed
+// ddl_ts metadata query or cleanup operation.
 type ddlTsTableErrorAction int
 
 const (
+	// ddlTsTableErrorReport means the ddl_ts table exists or could not be
+	// prepared, so the caller should return an error to its own caller.
 	ddlTsTableErrorReport ddlTsTableErrorAction = iota
+	// ddlTsTableErrorIgnore means the ddl_ts table is absent. This is expected
+	// before the first DDL or syncpoint, so the caller can treat it as empty
+	// recovery metadata.
 	ddlTsTableErrorIgnore
+	// ddlTsTableErrorRetry means the metadata lookup was unavailable, but
+	// TiCDC has successfully created ddl_ts_v1 and the caller should retry the
+	// original operation once.
 	ddlTsTableErrorRetry
 )
 
@@ -570,6 +583,14 @@ func (w *Writer) removeDDLTsItemWithQuery(query string) error {
 	return nil
 }
 
+// handleDDLTsTableQueryError classifies a failed ddl_ts table operation.
+//
+// The ddl_ts table is created lazily, so missing tidb_cdc.ddl_ts_v1 is a valid
+// first-sync state. Standard MySQL/TiDB missing table errors are accepted
+// directly. For MySQL-compatible downstreams that use nonstandard error codes,
+// the function verifies table existence through information_schema.tables. If
+// that metadata check is unavailable, it creates the ddl_ts table and asks the
+// caller to retry the original operation exactly once.
 func (w *Writer) handleDDLTsTableQueryError(queryErr error) (ddlTsTableErrorAction, error) {
 	if errors.IsTableNotExistsErr(queryErr) {
 		return ddlTsTableErrorIgnore, nil
@@ -592,12 +613,16 @@ func (w *Writer) handleDDLTsTableQueryError(queryErr error) (ddlTsTableErrorActi
 		return ddlTsTableErrorReport, err
 	}
 
+	// createDDLTsTable bypasses the lazy-init cache on purpose. Mark the table
+	// initialized only after the forced create succeeds.
 	w.ddlTsTableInitMutex.Lock()
 	w.ddlTsTableInit = true
 	w.ddlTsTableInitMutex.Unlock()
 	return ddlTsTableErrorRetry, nil
 }
 
+// ddlTsTableExists returns whether tidb_cdc.ddl_ts_v1 is visible in the
+// downstream metadata tables.
 func (w *Writer) ddlTsTableExists() (bool, error) {
 	row := w.db.QueryRowContext(w.ctx, ddlTsTableExistsQuery)
 	var count int

--- a/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
+++ b/pkg/sink/mysql/mysql_writer_for_ddl_ts.go
@@ -360,7 +360,7 @@ func (w *Writer) GetTableRecoveryInfo(tableIDs []int64) ([]int64, []bool, []bool
 
 	query := selectDDLTsQuery(tableIDs, ticdcClusterID, changefeedID)
 	log.Info("query ddl ts table", zap.String("query", query))
-	rows, err := w.db.Query(query)
+	rows, err := w.db.QueryContext(w.ctx, query)
 	if err != nil {
 		action, handleErr := w.handleDDLTsTableQueryError(err)
 		if handleErr != nil {
@@ -375,7 +375,7 @@ func (w *Writer) GetTableRecoveryInfo(tableIDs []int64) ([]int64, []bool, []bool
 			return retStartTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, nil
 		}
 		if action == ddlTsTableErrorRetry {
-			rows, err = w.db.Query(query)
+			rows, err = w.db.QueryContext(w.ctx, query)
 		}
 		if err != nil {
 			return retStartTsList, skipSyncpointAtStartTs, skipDMLAsStartTsList, errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to check ddl ts table; Query is %s", query)))
@@ -523,7 +523,7 @@ func (w *Writer) RemoveDDLTsItem() error {
 	_, err = tx.Exec(query)
 	if err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
-			log.Error("failed to rollback", zap.Error(rbErr))
+			log.Warn("failed to rollback ddl ts cleanup transaction", zap.Error(rbErr))
 		}
 		action, handleErr := w.handleDDLTsTableQueryError(err)
 		if handleErr != nil {
@@ -540,12 +540,13 @@ func (w *Writer) RemoveDDLTsItem() error {
 		if action == ddlTsTableErrorRetry {
 			return w.removeDDLTsItemWithQuery(query)
 		}
-		log.Error("failed to delete ddl ts item ", zap.Error(err))
 		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
 	}
 
-	err = tx.Commit()
-	return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+	if err = tx.Commit(); err != nil {
+		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+	}
+	return nil
 }
 
 func (w *Writer) removeDDLTsItemWithQuery(query string) error {
@@ -556,16 +557,17 @@ func (w *Writer) removeDDLTsItemWithQuery(query string) error {
 
 	_, err = tx.Exec(query)
 	if err != nil {
-		log.Error("failed to delete ddl ts item ", zap.Error(err))
 		err2 := tx.Rollback()
 		if err2 != nil {
-			log.Error("failed to delete ddl ts item", zap.Error(err2))
+			log.Warn("failed to rollback ddl ts cleanup transaction", zap.Error(err2))
 		}
 		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
 	}
 
-	err = tx.Commit()
-	return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+	if err = tx.Commit(); err != nil {
+		return errors.WrapError(errors.ErrMySQLTxnError, errors.WithMessage(err, fmt.Sprintf("failed to delete ddl ts item; Query is %s", query)))
+	}
+	return nil
 }
 
 func (w *Writer) handleDDLTsTableQueryError(queryErr error) (ddlTsTableErrorAction, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5003

MySQL-compatible sinks query `tidb_cdc.ddl_ts_v1` during changefeed initialization and scheduling recovery. The table is created lazily after DDL-ts or syncpoint writes, so a missing `tidb_cdc` database or `ddl_ts_v1` table is expected before the first DDL or syncpoint.

Some MySQL-compatible downstreams return nonstandard error codes for missing databases or tables. TiCDC previously only tolerated standard MySQL/TiDB missing-table codes, so these downstreams could surface the recovery query as a MySQL transaction error and block changefeed progress.

### What is changed and how it works?

This PR adds ddl-ts-table-specific fallback handling for `GetTableRecoveryInfo` and `RemoveDDLTsItem`:

- Keep the existing fast path for standard missing database/table error codes.
- For nonstandard errors, check `information_schema.tables` to confirm whether `tidb_cdc.ddl_ts_v1` exists.
- If metadata confirms the table is missing, treat it as absent recovery metadata without creating the table.
- If metadata lookup itself fails, create `tidb_cdc.ddl_ts_v1` and retry the original operation once.
- Return an error if table creation or the retry still fails.

Unit tests cover the standard-code path, metadata-confirmed missing table path, table-exists error path, metadata-unavailable create-and-retry path, and create/retry failure paths for both recovery reads and cleanup deletes.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. The metadata query and create-and-retry fallback only run after the ddl-ts recovery or cleanup query fails. The normal successful path is unchanged.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix MySQL-compatible sinks getting stuck when missing `ddl_ts_v1` returns nonstandard error codes.
```
