### PR TITLE
grafana: render stacked nulls as zero

### DIFF
--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -24647,7 +24647,7 @@
           "linewidth": 1,
           "links": [],
           "maxPerRow": 3,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },

--- a/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
@@ -24647,7 +24647,7 @@
           "linewidth": 1,
           "links": [],
           "maxPerRow": 3,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },


### PR DESCRIPTION
## Summary

Issue Number: close #5009

- set stacked Grafana graph panels to render null points as zero
- avoid misleading stacked visualizations when a series has data gaps

## Test
- `make generate-next-gen-grafana`
- parsed dashboard JSON files
- verified every `stack: true` graph panel has `nullPointMode: "null as zero"`

```release-note
Fix TiCDC Grafana stacked memory usage panels to render null datapoints as zero.
```
