### PR TITLE
schemastore: fix cross-schema create view with unqualified source table

### DIFF
--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -605,6 +605,14 @@ func buildPersistedDDLEventForDropView(args buildPersistedDDLEventFuncArgs) Pers
 	return event
 }
 
+// TiDB persists the normalized SELECT body of a view in
+// event.TableInfo.View.SelectStmt when executing CREATE VIEW, so this field can
+// carry fully resolved source-table references even if job.Query keeps the
+// original session-level text.
+// Field definition:
+// https://github.com/pingcap/tidb/blob/8f2630e53d5d/pkg/meta/model/table.go#L762-L770
+// Value assignment in CREATE VIEW:
+// https://github.com/pingcap/tidb/blob/8f2630e53d5d/pkg/ddl/create_table.go#L1668-L1678
 func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
 	if event == nil || event.Query == "" || event.TableInfo == nil || event.TableInfo.View == nil || event.TableInfo.View.SelectStmt == "" {
 		return
@@ -630,6 +638,9 @@ func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
 			zap.Error(err))
 		return
 	}
+	if createViewSelectUsesCurrentSchemaOnly(selectStmt, event.SchemaName) {
+		return
+	}
 
 	createViewStmt.Select = selectStmt
 	normalizedQuery, err := commonEvent.Restore(createViewStmt)
@@ -641,6 +652,35 @@ func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
 		return
 	}
 	event.Query = normalizedQuery
+}
+
+type tableSchemaExtractor struct {
+	schemas []string
+}
+
+func (e *tableSchemaExtractor) Enter(in ast.Node) (ast.Node, bool) {
+	if t, ok := in.(*ast.TableName); ok {
+		e.schemas = append(e.schemas, t.Schema.O)
+		return in, true
+	}
+	return in, false
+}
+
+func (e *tableSchemaExtractor) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
+func createViewSelectUsesCurrentSchemaOnly(selectStmt ast.StmtNode, currentSchema string) bool {
+	extractor := &tableSchemaExtractor{
+		schemas: make([]string, 0),
+	}
+	selectStmt.Accept(extractor)
+	for _, schema := range extractor.schemas {
+		if schema != "" && !strings.EqualFold(schema, currentSchema) {
+			return false
+		}
+	}
+	return true
 }
 
 func buildPersistedDDLEventForCreateTable(args buildPersistedDDLEventFuncArgs) PersistedDDLEvent {

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -655,28 +655,8 @@ func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
 	event.Query = normalizedQuery
 }
 
-type tableSchemaExtractor struct {
-	schemas []string
-}
-
-func (e *tableSchemaExtractor) Enter(in ast.Node) (ast.Node, bool) {
-	if t, ok := in.(*ast.TableName); ok {
-		e.schemas = append(e.schemas, t.Schema.O)
-		return in, true
-	}
-	return in, false
-}
-
-func (e *tableSchemaExtractor) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
-}
-
 func createViewSelectUsesCurrentSchemaOnly(selectStmt ast.StmtNode, currentSchema string) bool {
-	extractor := &tableSchemaExtractor{
-		schemas: make([]string, 0),
-	}
-	selectStmt.Accept(extractor)
-	for _, schema := range extractor.schemas {
+	for _, schema := range extractTableSchemas(selectStmt) {
 		if schema != "" && !strings.EqualFold(schema, currentSchema) {
 			return false
 		}

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -591,6 +591,7 @@ func buildPersistedDDLEventForCreateView(args buildPersistedDDLEventFuncArgs) Pe
 	event := buildPersistedDDLEventCommon(args)
 	event.SchemaName = getSchemaName(args.databaseMap, event.SchemaID)
 	event.TableName = args.job.TableName
+	normalizeCreateViewQueryWithStoredSelect(&event)
 	return event
 }
 
@@ -602,6 +603,44 @@ func buildPersistedDDLEventForDropView(args buildPersistedDDLEventFuncArgs) Pers
 	// The query in job maybe "DROP VIEW test1.view1, test2.view2", we need rebuild it here.
 	event.Query = fmt.Sprintf("DROP VIEW %s", common.QuoteSchema(event.SchemaName, event.TableName))
 	return event
+}
+
+func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
+	if event == nil || event.Query == "" || event.TableInfo == nil || event.TableInfo.View == nil || event.TableInfo.View.SelectStmt == "" {
+		return
+	}
+
+	stmt, err := parser.New().ParseOneStmt(event.Query, "", "")
+	if err != nil {
+		log.Warn("parse create view query failed when normalizing select statement",
+			zap.String("query", event.Query),
+			zap.Error(err))
+		return
+	}
+	createViewStmt, ok := stmt.(*ast.CreateViewStmt)
+	if !ok {
+		return
+	}
+
+	selectStmt, err := parser.New().ParseOneStmt(event.TableInfo.View.SelectStmt, "", "")
+	if err != nil {
+		log.Warn("parse stored create view select statement failed",
+			zap.String("selectStmt", event.TableInfo.View.SelectStmt),
+			zap.String("query", event.Query),
+			zap.Error(err))
+		return
+	}
+
+	createViewStmt.Select = selectStmt
+	normalizedQuery, err := commonEvent.Restore(createViewStmt)
+	if err != nil {
+		log.Warn("restore normalized create view query failed",
+			zap.String("query", event.Query),
+			zap.String("selectStmt", event.TableInfo.View.SelectStmt),
+			zap.Error(err))
+		return
+	}
+	event.Query = normalizedQuery
 }
 
 func buildPersistedDDLEventForCreateTable(args buildPersistedDDLEventFuncArgs) PersistedDDLEvent {

--- a/logservice/schemastore/persist_storage_ddl_handlers.go
+++ b/logservice/schemastore/persist_storage_ddl_handlers.go
@@ -614,7 +614,7 @@ func buildPersistedDDLEventForDropView(args buildPersistedDDLEventFuncArgs) Pers
 // Value assignment in CREATE VIEW:
 // https://github.com/pingcap/tidb/blob/8f2630e53d5d/pkg/ddl/create_table.go#L1668-L1678
 func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
-	if event == nil || event.Query == "" || event.TableInfo == nil || event.TableInfo.View == nil || event.TableInfo.View.SelectStmt == "" {
+	if event.Query == "" || event.TableInfo == nil || event.TableInfo.View == nil || event.TableInfo.View.SelectStmt == "" {
 		return
 	}
 
@@ -638,6 +638,7 @@ func normalizeCreateViewQueryWithStoredSelect(event *PersistedDDLEvent) {
 			zap.Error(err))
 		return
 	}
+	// Keep the original CREATE VIEW text when the stored SELECT only qualifies tables in the view's own schema.
 	if createViewSelectUsesCurrentSchemaOnly(selectStmt, event.SchemaName) {
 		return
 	}

--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -3648,6 +3648,31 @@ func TestParseRenameTablesQueryInfos(t *testing.T) {
 	}
 }
 
+func TestBuildPersistedDDLEventForCreateViewUsesStoredSelectStmt(t *testing.T) {
+	job := buildCreateViewJobForTest(101, 100)
+	job.TableName = "v"
+	job.Query = "CREATE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `target_db`.`v` AS SELECT `id` FROM `users`"
+	job.BinlogInfo.TableInfo = &model.TableInfo{
+		Name: ast.NewCIStr("v"),
+		View: &model.ViewInfo{
+			SelectStmt: "SELECT `id` FROM `source_db`.`users`",
+		},
+	}
+
+	ddl := buildPersistedDDLEventForCreateView(buildPersistedDDLEventFuncArgs{
+		job: job,
+		databaseMap: map[int64]*BasicDatabaseInfo{
+			101: {Name: "target_db", Tables: map[int64]bool{}},
+		},
+	})
+
+	require.Equal(t,
+		"CREATE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `target_db`.`v` AS SELECT `id` FROM `source_db`.`users`",
+		ddl.Query)
+	require.Equal(t, "target_db", ddl.SchemaName)
+	require.Equal(t, "v", ddl.TableName)
+}
+
 func TestBuildDDLEventForNewTableDDL_CreateTableLikeBlockedTableNames(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/logservice/schemastore/persist_storage_test.go
+++ b/logservice/schemastore/persist_storage_test.go
@@ -3673,6 +3673,31 @@ func TestBuildPersistedDDLEventForCreateViewUsesStoredSelectStmt(t *testing.T) {
 	require.Equal(t, "v", ddl.TableName)
 }
 
+func TestBuildPersistedDDLEventForCreateViewKeepsOriginalQueryForSameSchemaSelect(t *testing.T) {
+	job := buildCreateViewJobForTest(101, 100)
+	job.TableName = "v"
+	job.Query = "CREATE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `target_db`.`v` AS SELECT `id` FROM `users`"
+	job.BinlogInfo.TableInfo = &model.TableInfo{
+		Name: ast.NewCIStr("v"),
+		View: &model.ViewInfo{
+			SelectStmt: "SELECT `id` FROM `target_db`.`users`",
+		},
+	}
+
+	ddl := buildPersistedDDLEventForCreateView(buildPersistedDDLEventFuncArgs{
+		job: job,
+		databaseMap: map[int64]*BasicDatabaseInfo{
+			101: {Name: "target_db", Tables: map[int64]bool{}},
+		},
+	})
+
+	require.Equal(t,
+		"CREATE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `target_db`.`v` AS SELECT `id` FROM `users`",
+		ddl.Query)
+	require.Equal(t, "target_db", ddl.SchemaName)
+	require.Equal(t, "v", ddl.TableName)
+}
+
 func TestBuildDDLEventForNewTableDDL_CreateTableLikeBlockedTableNames(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/logservice/schemastore/utils.go
+++ b/logservice/schemastore/utils.go
@@ -21,6 +21,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"go.uber.org/zap"
 )
 
@@ -119,4 +120,34 @@ func extractAddIndexIDs(job *model.Job) []int64 {
 		res = append(res, indexArg.IndexID)
 	}
 	return res
+}
+
+type tableSchemaExtractor struct {
+	schemas []string
+}
+
+func (e *tableSchemaExtractor) Enter(in ast.Node) (ast.Node, bool) {
+	if t, ok := in.(*ast.TableName); ok {
+		e.schemas = append(e.schemas, t.Schema.O)
+		return in, true
+	}
+	return in, false
+}
+
+func (e *tableSchemaExtractor) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
+// extractTableSchemas returns schema qualifiers from all *ast.TableName nodes in
+// AST visit order. Unqualified tables contribute an empty schema name.
+func extractTableSchemas(node ast.Node) []string {
+	if node == nil {
+		return nil
+	}
+
+	extractor := &tableSchemaExtractor{
+		schemas: make([]string, 0),
+	}
+	node.Accept(extractor)
+	return extractor.schemas
 }

--- a/logservice/schemastore/utils_test.go
+++ b/logservice/schemastore/utils_test.go
@@ -21,6 +21,7 @@ import (
 	ticonfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/disttask/framework/handle"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/stretchr/testify/require"
 )
 
@@ -222,4 +223,39 @@ func TestGetIndexIDsIgnoresAddPrimaryKeySubJobsForMultiSchemaChange(t *testing.T
 	}
 	require.NotZero(t, anonymousIndexID)
 	require.Equal(t, []int64{anonymousIndexID}, getIndexIDs(job))
+}
+
+func TestExtractTableSchemas(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		expected []string
+	}{
+		{
+			name:     "unqualified table",
+			query:    "SELECT * FROM `t`",
+			expected: []string{""},
+		},
+		{
+			name:     "mixed qualified tables",
+			query:    "SELECT * FROM `db1`.`t1` JOIN `t2` ON `db1`.`t1`.`id` = `t2`.`id`",
+			expected: []string{"db1", ""},
+		},
+		{
+			name:     "subquery preserves visit order",
+			query:    "SELECT * FROM `db1`.`t1` WHERE EXISTS (SELECT 1 FROM `db2`.`t2`)",
+			expected: []string{"db1", "db2"},
+		},
+	}
+
+	p := parser.New()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := p.ParseOneStmt(tc.query, "", "")
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, extractTableSchemas(stmt))
+		})
+	}
+
+	require.Nil(t, extractTableSchemas(nil))
 }

--- a/tests/integration_tests/common_1/conf/diff_config.toml
+++ b/tests/integration_tests/common_1/conf/diff_config.toml
@@ -13,7 +13,7 @@ check-struct-only = false
 
     target-instance = "tidb0"
 
-    target-check-tables = ["common_1.?*","common.?*","source_db.?*","source_extra_db.?*"]
+    target-check-tables = ["common_1.?*","common.?*"]
 
 [data-sources]
 [data-sources.mysql1]

--- a/tests/integration_tests/common_1/conf/diff_config.toml
+++ b/tests/integration_tests/common_1/conf/diff_config.toml
@@ -13,7 +13,7 @@ check-struct-only = false
 
     target-instance = "tidb0"
 
-    target-check-tables = ["common_1.?*","common.?*"]
+    target-check-tables = ["common_1.?*","common.?*","source_db.?*","source_extra_db.?*"]
 
 [data-sources]
 [data-sources.mysql1]

--- a/tests/integration_tests/common_1/data/test.sql
+++ b/tests/integration_tests/common_1/data/test.sql
@@ -88,6 +88,25 @@ SELECT *
 FROM t1
 WHERE c1 > 2;
 
+-- cross-schema view test
+
+DROP DATABASE IF EXISTS source_extra_db;
+DROP DATABASE IF EXISTS source_db;
+CREATE DATABASE source_db;
+CREATE DATABASE source_extra_db;
+CREATE TABLE source_db.users
+(
+    id INT PRIMARY KEY
+);
+
+USE source_db;
+
+CREATE VIEW source_extra_db.v AS
+SELECT id
+FROM users;
+
+USE common_1;
+
 -- uk without pk
 -- https://internal.pingcap.net/jira/browse/TOOL-714
 -- CDC don't support UK is null

--- a/tests/integration_tests/common_1/data/test.sql
+++ b/tests/integration_tests/common_1/data/test.sql
@@ -88,24 +88,10 @@ SELECT *
 FROM t1
 WHERE c1 > 2;
 
--- cross-schema view test
-
-DROP DATABASE IF EXISTS source_extra_db;
-DROP DATABASE IF EXISTS source_db;
-CREATE DATABASE source_db;
-CREATE DATABASE source_extra_db;
-CREATE TABLE source_db.users
+CREATE TABLE users
 (
     id INT PRIMARY KEY
 );
-
-USE source_db;
-
-CREATE VIEW source_extra_db.v AS
-SELECT id
-FROM users;
-
-USE common_1;
 
 -- uk without pk
 -- https://internal.pingcap.net/jira/browse/TOOL-714

--- a/tests/integration_tests/common_1/data/test_finish.sql
+++ b/tests/integration_tests/common_1/data/test_finish.sql
@@ -2,6 +2,10 @@
 USE common_1;
 
 create database common;
+CREATE VIEW common.v AS
+SELECT id
+FROM users;
+
 create table a (a bigint primary key, b int);
 create table b like a;
 rename table a to common.c, b to a, common.c to b;

--- a/tests/integration_tests/common_1/run.sh
+++ b/tests/integration_tests/common_1/run.sh
@@ -65,6 +65,8 @@ EOF
 
 	# sync_diff can't check non-exist table, so we check expected tables are created in downstream first
 	check_table_exists common_1.v1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_table_exists source_db.users ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_table_exists source_extra_db.v ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists common_1.recover_and_insert ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists common_1.finish_mark ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml

--- a/tests/integration_tests/common_1/run.sh
+++ b/tests/integration_tests/common_1/run.sh
@@ -65,8 +65,8 @@ EOF
 
 	# sync_diff can't check non-exist table, so we check expected tables are created in downstream first
 	check_table_exists common_1.v1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-	check_table_exists source_db.users ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-	check_table_exists source_extra_db.v ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_table_exists common_1.users ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	check_table_exists common.v ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists common_1.recover_and_insert ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists common_1.finish_mark ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5026 

### What is changed and how it works?

This pull request addresses an issue where cross-schema CREATE VIEW statements could fail or be incorrectly processed due to unqualified source table references. By leveraging the normalized SELECT statement stored in the table metadata, the system can now correctly reconstruct the view definition with fully qualified table names. This ensures consistency and accuracy in downstream replication for views that span multiple schemas.

### Highlights

* **Cross-Schema View Normalization**: Introduced logic to normalize CREATE VIEW queries by utilizing the stored SELECT statement from the table metadata, ensuring that cross-schema table references are correctly resolved.
* **AST Table Schema Extraction**: Added a helper utility to extract schema qualifiers from AST nodes, allowing the system to identify when a view's SELECT statement references tables outside the current schema.
* **Integration Testing**: Expanded integration tests to verify that cross-schema views are correctly handled and that original queries are preserved when only the current schema is involved.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced persistence and replication of database views
  * Improved handling for views that reference tables across different schemas with proper DDL query normalization

* **Tests**
  * Added validation tests for view creation DDL events
  * Added test coverage for schema extraction and query normalization logic

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5027)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->