### PR TITLE
tableInfo: init the private sql lazily

### DIFF
--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -384,10 +384,6 @@ func (d *dispatcherStat) handleBatchDataEvents(events []dispatcher.DispatcherEve
 			batchDML := event.Event.(*commonEvent.BatchDMLEvent)
 			batchDML.AssembleRows(tableInfo)
 			for _, dml := range batchDML.DMLEvents {
-				// DMLs in the same batch share the same updateTs in their table info,
-				// but they may reference different table info objects,
-				// so each needs to be initialized separately.
-				dml.TableInfo.InitPrivateFields()
 				dml.TableInfoVersion = tableInfoVersion
 				dmlEvent := dispatcher.NewDispatcherEvent(event.From, dml)
 				if d.shouldForwardEventByCommitTs(dmlEvent) {

--- a/pkg/common/event/active_active_test.go
+++ b/pkg/common/event/active_active_test.go
@@ -369,7 +369,6 @@ func newTestTableInfo(t *testing.T, activeActive, softDelete bool) *commonpkg.Ta
 	ti := commonpkg.WrapTableInfo("test", table)
 	ti.ActiveActiveTable = activeActive
 	ti.SoftDeleteTable = softDelete
-	ti.InitPrivateFields()
 	return ti
 }
 

--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -522,13 +522,6 @@ func (t *DDLEvent) decodeV1(data []byte) error {
 		return err
 	}
 
-	for _, info := range t.MultipleTableInfos {
-		info.InitPrivateFields()
-	}
-	if t.TableInfo != nil {
-		t.TableInfo.InitPrivateFields()
-	}
-
 	return nil
 }
 

--- a/pkg/common/event/ddl_event_test.go
+++ b/pkg/common/event/ddl_event_test.go
@@ -242,8 +242,6 @@ func TestDDLEvent(t *testing.T) {
 		},
 		Err: errors.ErrDDLEventError.GenWithStackByArgs("test").Error(),
 	}
-	ddlEvent.TableInfo.InitPrivateFields()
-
 	// Test normal marshal/unmarshal
 	data, err := ddlEvent.Marshal()
 	require.Nil(t, err)
@@ -536,12 +534,9 @@ func TestNewRoutedDDLEvent(t *testing.T) {
 
 	// Create original DDL event with all fields populated
 	originalTableInfo := common.WrapTableInfo(ddlJob.SchemaName, ddlJob.BinlogInfo.TableInfo)
-	originalTableInfo.InitPrivateFields()
 
 	multipleTableInfo1 := common.WrapTableInfo("schema1", ddlJob.BinlogInfo.TableInfo)
-	multipleTableInfo1.InitPrivateFields()
 	multipleTableInfo2 := common.WrapTableInfo("schema2", ddlJob.BinlogInfo.TableInfo)
-	multipleTableInfo2.InitPrivateFields()
 
 	postFlushFunc1 := func() {}
 	postFlushFunc2 := func() {}

--- a/pkg/common/event/dml_event.go
+++ b/pkg/common/event/dml_event.go
@@ -283,10 +283,6 @@ func (b *BatchDMLEvent) AssembleRows(tableInfo *common.TableInfo) {
 		log.Panic("DMLEvent: TableInfo is nil")
 	}
 
-	defer func() {
-		b.TableInfo.InitPrivateFields()
-	}()
-
 	// For local events (same node), rows are already set.
 	if b.Rows != nil {
 		if !tableInfo.TableName.IsRouted() {

--- a/pkg/common/event/handshake_event.go
+++ b/pkg/common/event/handshake_event.go
@@ -205,8 +205,5 @@ func (e *HandshakeEvent) decodeV1(data []byte) error {
 		return err
 	}
 
-	// Initialize private fields after unmarshaling
-	e.TableInfo.InitPrivateFields()
-
 	return nil
 }

--- a/pkg/common/event/util.go
+++ b/pkg/common/event/util.go
@@ -141,7 +141,6 @@ func (s *EventTestHelper) storeTableInfo(schemaName string, tableInfo *timodel.T
 	if info == nil {
 		return
 	}
-	info.InitPrivateFields()
 	key := toTableInfosKey(info.GetSchemaName(), info.GetTableName())
 	if tableInfo.Partition != nil {
 		if _, ok := s.partitionIDs[key]; !ok {

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -116,8 +116,8 @@ type TableInfo struct {
 	} `json:"-"`
 }
 
-func (ti *TableInfo) InitPrivateFields() {
-	if ti == nil {
+func (ti *TableInfo) initPreSQLs() {
+	if ti == nil || ti.columnSchema == nil {
 		return
 	}
 
@@ -142,10 +142,10 @@ func (ti *TableInfo) InitPrivateFields() {
 
 // CloneWithRouting creates a shallow copy of TableInfo with routing applied.
 // The new TableInfo shares the same columnSchema, View, Sequence pointers
-// but has its own TableName (with TargetSchema/TargetTable set) and uninitialized preSQLs.
+// but has its own TableName (with TargetSchema/TargetTable set) and preSQLs.
 // This is safe because:
 // - columnSchema, View, Sequence are read-only after creation
-// - preSQLs will be initialized later via InitPrivateFields() using the new TableName
+// - preSQLs will be initialized lazily using the new TableName
 // - TableName is a value type that gets copied
 func (ti *TableInfo) CloneWithRouting(targetSchema, targetTable string) *TableInfo {
 	if ti == nil {
@@ -289,6 +289,7 @@ func (ti *TableInfo) GetUpdateTS() uint64 {
 }
 
 func (ti *TableInfo) GetPreInsertSQL() string {
+	ti.initPreSQLs()
 	if ti.preSQLs.m[preSQLInsert] == "" {
 		log.Panic("preSQLs[preSQLInsert] is not initialized")
 	}
@@ -296,6 +297,7 @@ func (ti *TableInfo) GetPreInsertSQL() string {
 }
 
 func (ti *TableInfo) GetPreReplaceSQL() string {
+	ti.initPreSQLs()
 	if ti.preSQLs.m[preSQLReplace] == "" {
 		log.Panic("preSQLs[preSQLReplace] is not initialized")
 	}
@@ -303,6 +305,7 @@ func (ti *TableInfo) GetPreReplaceSQL() string {
 }
 
 func (ti *TableInfo) GetPreUpdateSQL() string {
+	ti.initPreSQLs()
 	if ti.preSQLs.m[preSQLUpdate] == "" {
 		log.Panic("preSQLs[preSQLUpdate] is not initialized")
 	}
@@ -698,7 +701,5 @@ func WrapTableInfo(schemaName string, info *model.TableInfo) *TableInfo {
 // do not call this method on the production code.
 func NewTableInfo4Decoder(schema string, tableInfo *model.TableInfo) *TableInfo {
 	cs := NewColumnSchema4Decoder(tableInfo)
-	result := newTableInfo(schema, tableInfo.Name.O, tableInfo.ID, tableInfo.GetPartitionInfo() != nil, cs, tableInfo)
-	result.InitPrivateFields()
-	return result
+	return NewTableInfo(schema, tableInfo.Name.O, tableInfo.ID, tableInfo.GetPartitionInfo() != nil, cs, tableInfo)
 }

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -701,5 +701,5 @@ func WrapTableInfo(schemaName string, info *model.TableInfo) *TableInfo {
 // do not call this method on the production code.
 func NewTableInfo4Decoder(schema string, tableInfo *model.TableInfo) *TableInfo {
 	cs := NewColumnSchema4Decoder(tableInfo)
-	return NewTableInfo(schema, tableInfo.Name.O, tableInfo.ID, tableInfo.GetPartitionInfo() != nil, cs, tableInfo)
+	return newTableInfo(schema, tableInfo.Name.O, tableInfo.ID, tableInfo.GetPartitionInfo() != nil, cs, tableInfo)
 }

--- a/pkg/common/table_info_test.go
+++ b/pkg/common/table_info_test.go
@@ -136,6 +136,57 @@ func TestUnmarshalJSONToTableInfoInvalidData(t *testing.T) {
 func TestUnmarshalJSONToTableInfoRoundTrip(t *testing.T) {
 	t.Parallel()
 
+	source := WrapTableInfo("test", newPreSQLTestModelTableInfo("t_roundtrip"))
+	require.NotNil(t, source)
+	require.Contains(t, source.GetPreInsertSQL(), QuoteSchema("test", "t_roundtrip"))
+
+	routed := source.CloneWithRouting("target_db", "target_table")
+	require.Contains(t, routed.GetPreInsertSQL(), QuoteSchema("target_db", "target_table"))
+
+	data, err := source.Marshal()
+	require.NoError(t, err)
+
+	decoded, err := UnmarshalJSONToTableInfo(data)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+
+	require.Equal(t, source.TableName.Schema, decoded.TableName.Schema)
+	require.Equal(t, source.TableName.Table, decoded.TableName.Table)
+	require.Equal(t, source.TableName.TableID, decoded.TableName.TableID)
+	require.Equal(t, len(source.GetColumns()), len(decoded.GetColumns()))
+	require.Equal(t, source.GetColumns()[0].Name.O, decoded.GetColumns()[0].Name.O)
+	require.Equal(t, source.GetColumns()[1].Name.O, decoded.GetColumns()[1].Name.O)
+	require.Contains(t, decoded.GetPreInsertSQL(), QuoteSchema("test", "t_roundtrip"))
+}
+
+func TestPreSQLsAreInitializedLazily(t *testing.T) {
+	t.Parallel()
+
+	source := WrapTableInfo("source_db", newPreSQLTestModelTableInfo("source_table"))
+	require.NotNil(t, source)
+	require.False(t, source.preSQLs.isInitialized.Load())
+
+	routed := source.CloneWithRouting("target_db", "target_table")
+	require.False(t, source.preSQLs.isInitialized.Load())
+	require.False(t, routed.preSQLs.isInitialized.Load())
+
+	require.Contains(t, routed.GetPreInsertSQL(), QuoteSchema("target_db", "target_table"))
+	require.True(t, routed.preSQLs.isInitialized.Load())
+	require.False(t, source.preSQLs.isInitialized.Load())
+
+	data, err := source.Marshal()
+	require.NoError(t, err)
+	require.False(t, source.preSQLs.isInitialized.Load())
+
+	decoded, err := UnmarshalJSONToTableInfo(data)
+	require.NoError(t, err)
+	require.False(t, decoded.preSQLs.isInitialized.Load())
+
+	require.Contains(t, decoded.GetPreUpdateSQL(), QuoteSchema("source_db", "source_table"))
+	require.True(t, decoded.preSQLs.isInitialized.Load())
+}
+
+func newPreSQLTestModelTableInfo(table string) *model.TableInfo {
 	idCol := &model.ColumnInfo{
 		ID:      1,
 		Name:    ast.NewCIStr("id"),
@@ -155,27 +206,12 @@ func TestUnmarshalJSONToTableInfoRoundTrip(t *testing.T) {
 	}
 	nameCol.FieldType = *types.NewFieldType(mysql.TypeVarchar)
 
-	source := WrapTableInfo("test", &model.TableInfo{
+	return &model.TableInfo{
 		ID:         1001,
-		Name:       ast.NewCIStr("t_roundtrip"),
+		Name:       ast.NewCIStr(table),
 		PKIsHandle: true,
 		Columns:    []*model.ColumnInfo{idCol, nameCol},
-	})
-	require.NotNil(t, source)
-
-	data, err := source.Marshal()
-	require.NoError(t, err)
-
-	decoded, err := UnmarshalJSONToTableInfo(data)
-	require.NoError(t, err)
-	require.NotNil(t, decoded)
-
-	require.Equal(t, source.TableName.Schema, decoded.TableName.Schema)
-	require.Equal(t, source.TableName.Table, decoded.TableName.Table)
-	require.Equal(t, source.TableName.TableID, decoded.TableName.TableID)
-	require.Equal(t, len(source.GetColumns()), len(decoded.GetColumns()))
-	require.Equal(t, source.GetColumns()[0].Name.O, decoded.GetColumns()[0].Name.O)
-	require.Equal(t, source.GetColumns()[1].Name.O, decoded.GetColumns()[1].Name.O)
+	}
 }
 
 func TestUnquoteName(t *testing.T) {

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -210,11 +210,10 @@ func buildDelete(tableInfo *common.TableInfo, row commonEvent.RowChange) (string
 
 func buildUpdate(tableInfo *common.TableInfo, row commonEvent.RowChange) (string, []interface{}) {
 	var builder strings.Builder
-	preUpdateSQL := tableInfo.GetPreUpdateSQL()
-	if preUpdateSQL == "" {
+	if tableInfo.GetPreUpdateSQL() == "" {
 		log.Panic("PreUpdateSQL should not be empty")
 	}
-	builder.WriteString(preUpdateSQL)
+	builder.WriteString(tableInfo.GetPreUpdateSQL())
 
 	args := getArgs(&row.Row, tableInfo)
 	if len(args) == 0 {

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -210,10 +210,11 @@ func buildDelete(tableInfo *common.TableInfo, row commonEvent.RowChange) (string
 
 func buildUpdate(tableInfo *common.TableInfo, row commonEvent.RowChange) (string, []interface{}) {
 	var builder strings.Builder
-	if tableInfo.GetPreUpdateSQL() == "" {
+	preUpdateSQL := tableInfo.GetPreUpdateSQL()
+	if preUpdateSQL == "" {
 		log.Panic("PreUpdateSQL should not be empty")
 	}
-	builder.WriteString(tableInfo.GetPreUpdateSQL())
+	builder.WriteString(preUpdateSQL)
 
 	args := getArgs(&row.Row, tableInfo)
 	if len(args) == 0 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5031

Currently `TableInfo.InitPrivateFields()` must be called explicitly at every construction and deserialization site to initialize preSQL statements. This is boilerplate scattered across multiple packages, and forgetting to call it leads to a panic at SQL build time.

### What is changed and how it works?

Make preSQLs initialization lazy: call it automatically on first access to `GetPreInsertSQL()` / `GetPreReplaceSQL()` / `GetPreUpdateSQL()`. Use double-checked locking (atomic.Bool + sync.Mutex) for thread safety.

Changes:
- Rename `InitPrivateFields()` to unexported `initPreSQLs()` with double-checked locking
- Call `initPreSQLs()` lazily in the three GetPre*SQL methods
- Remove all explicit `InitPrivateFields()` calls from DDL decode, DML assemble, handshake decode, dispatcher stat, and test helpers
- `CloneWithRouting` clone naturally gets its own preSQLs initialized with the routed table name on first access
- Preserve `newTableInfo()` in `NewTableInfo4Decoder` to avoid unintended finalizer on standalone columnSchemas

### Check List

#### Tests

- [x] Unit test (`TestPreSQLsAreInitializedLazily`, `TestUnmarshalJSONToTableInfoRoundTrip`, `TestCloneWithRouting`)

#### Questions

##### Will it cause performance regression or break compatibility?

No. The lazy init adds a single atomic.Load check on each GetPre*SQL call, which is negligible. PreSQLs are accessed only during SQL building, not on the hot path.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```