### PR TITLE
*: fix golangci-lint auto-fixable issues (PR 2 of 4)

### DIFF
--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -64,10 +64,8 @@ func (p *partitionProgress) updateWatermark(newWatermark uint64, offset kafka.Of
 			zap.Uint64("watermark", newWatermark))
 		return
 	}
-	readOldOffset := true
-	if offset > p.watermarkOffset {
-		readOldOffset = false
-	}
+	readOldOffset := !(offset > p.watermarkOffset)
+
 	log.Warn("partition resolved ts fall back, ignore it",
 		zap.Bool("readOldOffset", readOldOffset),
 		zap.Int32("partition", p.partition),

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -64,7 +64,7 @@ func (p *partitionProgress) updateWatermark(newWatermark uint64, offset kafka.Of
 			zap.Uint64("watermark", newWatermark))
 		return
 	}
-	readOldOffset := !(offset > p.watermarkOffset)
+	readOldOffset := offset <= p.watermarkOffset
 
 	log.Warn("partition resolved ts fall back, ignore it",
 		zap.Bool("readOldOffset", readOldOffset),

--- a/cmd/oauth2-server/main.go
+++ b/cmd/oauth2-server/main.go
@@ -152,7 +152,7 @@ func run(_ *cobra.Command, _ []string) {
 		}
 	})))
 	http.Handle("/.well-known/openid-configuration", logMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(fmt.Sprintf(openIDConfiguration, serverConfig.port, serverConfig.port, serverConfig.port)))
+		_, _ = fmt.Fprintf(w, openIDConfiguration, serverConfig.port, serverConfig.port, serverConfig.port)
 		w.WriteHeader(200)
 	})))
 	log.Info("starting auth2 server", zap.Int("port", serverConfig.port))

--- a/cmd/oauth2-server/main.go
+++ b/cmd/oauth2-server/main.go
@@ -152,8 +152,9 @@ func run(_ *cobra.Command, _ []string) {
 		}
 	})))
 	http.Handle("/.well-known/openid-configuration", logMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprintf(w, openIDConfiguration, serverConfig.port, serverConfig.port, serverConfig.port)
-		w.WriteHeader(200)
 	})))
 	log.Info("starting auth2 server", zap.Int("port", serverConfig.port))
 	log.Panic("run auth2 server failed", zap.Error(http.ListenAndServe(fmt.Sprintf(":%d", serverConfig.port), nil)))

--- a/cmd/pulsar-consumer/consumer.go
+++ b/cmd/pulsar-consumer/consumer.go
@@ -115,7 +115,7 @@ func (c *consumer) readMessage(ctx context.Context) error {
 			if !needCommit {
 				continue
 			}
-			err := c.pulsarConsumer.AckID(consumerMsg.Message.ID())
+			err := c.pulsarConsumer.AckID(consumerMsg.ID())
 			if err != nil {
 				log.Panic("Error ack message", zap.Error(err))
 			}

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -561,7 +561,7 @@ func getRenameTableOldTableKey(tableDef cloudstorage.TableDefinition) (string, b
 	if tableDef.Type != byte(timodel.ActionRenameTable) {
 		return "", false
 	}
-	var schemaName, tableName string
+	schemaName := tableDef.Schema
 	stmt, err := parser.New().ParseOneStmt(tableDef.Query, "", "")
 	if err != nil {
 		log.Panic("parse statement failed", zap.Any("DDL", tableDef.Query), zap.Error(err))
@@ -575,7 +575,7 @@ func getRenameTableOldTableKey(tableDef cloudstorage.TableDefinition) (string, b
 	if oldTable.Schema.O != "" {
 		schemaName = oldTable.Schema.O
 	}
-	tableName = oldTable.Name.O
+	tableName := oldTable.Name.O
 	return commonType.QuoteSchema(schemaName, tableName), true
 }
 

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -561,8 +561,7 @@ func getRenameTableOldTableKey(tableDef cloudstorage.TableDefinition) (string, b
 	if tableDef.Type != byte(timodel.ActionRenameTable) {
 		return "", false
 	}
-	schemaName := tableDef.Schema
-	tableName := tableDef.Table
+	var schemaName, tableName string
 	stmt, err := parser.New().ParseOneStmt(tableDef.Query, "", "")
 	if err != nil {
 		log.Panic("parse statement failed", zap.Any("DDL", tableDef.Query), zap.Error(err))

--- a/coordinator/changefeed/backoff_test.go
+++ b/coordinator/changefeed/backoff_test.go
@@ -150,7 +150,6 @@ func TestTableRoutingErrorsFastFail(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-
 		t.Run(tc.name, func(t *testing.T) {
 			backoff := NewBackoff(common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName), time.Minute*30, 1)
 			require.True(t, backoff.ShouldRun())

--- a/coordinator/changefeed/backoff_test.go
+++ b/coordinator/changefeed/backoff_test.go
@@ -150,7 +150,7 @@ func TestTableRoutingErrorsFastFail(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			backoff := NewBackoff(common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName), time.Minute*30, 1)
 			require.True(t, backoff.ShouldRun())

--- a/coordinator/changefeed/etcd_backend_test.go
+++ b/coordinator/changefeed/etcd_backend_test.go
@@ -58,7 +58,7 @@ func TestGetAllChangefeeds(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, resp, 0)
 
-	// status unmarshal failed, changefeed will not be ignored, and the checkpiont ts will be the start ts
+	// status unmarshal failed, changefeed will not be ignored, and the checkpoint ts will be the start ts
 	// the old version of changefeed without gid
 	cdcClient.EXPECT().GetChangefeedInfoAndStatus(gomock.Any()).Return(
 		int64(0),

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -723,10 +723,8 @@ func (c *Controller) RemoveChangefeed(ctx context.Context, id common.ChangeFeedI
 	count := 0
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	for {
-		if op.IsFinished() {
-			break
-		}
+	for !op.IsFinished() {
+
 		select {
 		case <-ctx.Done():
 			return 0, errors.Trace(ctx.Err())
@@ -764,10 +762,8 @@ func (c *Controller) PauseChangefeed(ctx context.Context, id common.ChangeFeedID
 	count := 0
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	for {
-		if op.IsFinished() {
-			break
-		}
+	for !op.IsFinished() {
+
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())

--- a/coordinator/controller.go
+++ b/coordinator/controller.go
@@ -724,7 +724,6 @@ func (c *Controller) RemoveChangefeed(ctx context.Context, id common.ChangeFeedI
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 	for !op.IsFinished() {
-
 		select {
 		case <-ctx.Done():
 			return 0, errors.Trace(ctx.Err())
@@ -763,7 +762,6 @@ func (c *Controller) PauseChangefeed(ctx context.Context, id common.ChangeFeedID
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 	for !op.IsFinished() {
-
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())

--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -490,9 +490,9 @@ func (d *BasicDispatcher) isFirstEvent(event commonEvent.Event) bool {
 }
 
 func (d *BasicDispatcher) GetHeartBeatInfo(h *HeartBeatInfo) {
-	h.Watermark.CheckpointTs = d.GetCheckpointTs()
-	h.Watermark.ResolvedTs = d.GetResolvedTs()
-	h.Watermark.LastSyncedTs = d.GetLastSyncedTs()
+	h.CheckpointTs = d.GetCheckpointTs()
+	h.ResolvedTs = d.GetResolvedTs()
+	h.LastSyncedTs = d.GetLastSyncedTs()
 	h.Id = d.GetId()
 	h.ComponentStatus = d.GetComponentStatus()
 	h.IsRemoving = d.GetRemovingStatus()
@@ -591,7 +591,7 @@ func (d *BasicDispatcher) handleEvents(dispatcherEvents []DispatcherEvent, wakeC
 		if log.GetLevel() == zapcore.DebugLevel {
 			log.Debug("dispatcher receive all event",
 				zap.Stringer("dispatcher", d.id), zap.Int64("mode", d.mode),
-				zap.String("eventType", commonEvent.TypeToString(dispatcherEvent.Event.GetType())),
+				zap.String("eventType", commonEvent.TypeToString(dispatcherEvent.GetType())),
 				zap.Any("event", dispatcherEvent.Event))
 		}
 

--- a/downstreamadapter/dispatcher/event_dispatcher.go
+++ b/downstreamadapter/dispatcher/event_dispatcher.go
@@ -125,8 +125,8 @@ func (d *EventDispatcher) cache(dispatcherEvents []DispatcherEvent, wakeCallback
 			zap.Stringer("dispatcher", d.id),
 			zap.Uint64("dispatcherResolvedTs", d.GetResolvedTs()),
 			zap.Int("length", len(dispatcherEvents)),
-			zap.Int("eventType", dispatcherEvents[len(dispatcherEvents)-1].Event.GetType()),
-			zap.Uint64("commitTs", dispatcherEvents[len(dispatcherEvents)-1].Event.GetCommitTs()),
+			zap.Int("eventType", dispatcherEvents[len(dispatcherEvents)-1].GetType()),
+			zap.Uint64("commitTs", dispatcherEvents[len(dispatcherEvents)-1].GetCommitTs()),
 			zap.Uint64("redoGlobalTs", d.redoGlobalTs.Load()),
 		)
 	default:
@@ -137,7 +137,7 @@ func (d *EventDispatcher) cache(dispatcherEvents []DispatcherEvent, wakeCallback
 func (d *EventDispatcher) HandleEvents(dispatcherEvents []DispatcherEvent, wakeCallback func()) bool {
 	// if the commit-ts of last event of dispatcherEvents is greater than redoGlobalTs,
 	// the dispatcherEvents will be cached util the redoGlobalTs is updated.
-	if d.redoEnable && len(dispatcherEvents) > 0 && d.redoGlobalTs.Load() < dispatcherEvents[len(dispatcherEvents)-1].Event.GetCommitTs() {
+	if d.redoEnable && len(dispatcherEvents) > 0 && d.redoGlobalTs.Load() < dispatcherEvents[len(dispatcherEvents)-1].GetCommitTs() {
 		d.cache(dispatcherEvents, wakeCallback)
 		return true
 	}

--- a/downstreamadapter/dispatchermanager/dispatcher_manager.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager.go
@@ -831,7 +831,7 @@ func (e *DispatcherManager) MergeDispatcher(dispatcherIDs []common.DispatcherID,
 	return e.mergeEventDispatcher(dispatcherIDs, mergedDispatcherID)
 }
 
-// mergeEventDispatcher merges the mulitple event dispatchers belonging to the same table with consecutive ranges.
+// mergeEventDispatcher merges the multiple event dispatchers belonging to the same table with consecutive ranges.
 func (e *DispatcherManager) mergeEventDispatcher(dispatcherIDs []common.DispatcherID, mergedDispatcherID common.DispatcherID) *MergeCheckTask {
 	// Step 1: check the dispatcherIDs and mergedDispatcherID are valid:
 	//         1. whether the mergedDispatcherID is not exist in the dispatcherMap

--- a/downstreamadapter/dispatchermanager/dispatcher_manager_helper.go
+++ b/downstreamadapter/dispatchermanager/dispatcher_manager_helper.go
@@ -64,7 +64,7 @@ func getDispatcherStatus(id common.DispatcherID, dispatcherItem dispatcher.Dispa
 		return &heartbeatpb.TableSpanStatus{
 			ID:                 id.ToPB(),
 			ComponentStatus:    heartBeatInfo.ComponentStatus,
-			CheckpointTs:       heartBeatInfo.Watermark.CheckpointTs,
+			CheckpointTs:       heartBeatInfo.CheckpointTs,
 			EventSizePerSecond: dispatcherItem.GetEventSizePerSecond(),
 			Mode:               dispatcherItem.GetMode(),
 		}, nil, &heartBeatInfo.Watermark

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -1063,7 +1063,7 @@ func TestHandleBatchDataEvents(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
@@ -1152,7 +1152,7 @@ func TestHandleSingleDataEvents(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
@@ -1357,7 +1357,7 @@ func TestHandleBatchDMLEvent(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)

--- a/downstreamadapter/eventcollector/dispatcher_stat_test.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat_test.go
@@ -1063,7 +1063,6 @@ func TestHandleBatchDataEvents(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
@@ -1152,7 +1151,6 @@ func TestHandleSingleDataEvents(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)
@@ -1357,7 +1355,6 @@ func TestHandleBatchDMLEvent(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockDisp := newMockDispatcher(common.NewDispatcherID(), 0)

--- a/downstreamadapter/routing/ddl_query_rewriter_test.go
+++ b/downstreamadapter/routing/ddl_query_rewriter_test.go
@@ -487,7 +487,6 @@ func TestRewriteParserBackedDDLQueryWithSemicolonsInLiteralsAndComments(t *testi
 	}
 
 	for _, tc := range tests {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/downstreamadapter/routing/ddl_query_rewriter_test.go
+++ b/downstreamadapter/routing/ddl_query_rewriter_test.go
@@ -487,7 +487,7 @@ func TestRewriteParserBackedDDLQueryWithSemicolonsInLiteralsAndComments(t *testi
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/downstreamadapter/routing/router_apply_test.go
+++ b/downstreamadapter/routing/router_apply_test.go
@@ -364,7 +364,7 @@ func TestApplyToDDLEvent(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			routed, err := tc.router.ApplyToDDLEvent(tc.ddl)
 			require.NoError(t, err)
@@ -540,7 +540,7 @@ func TestRewriteDDLQueryWithRouting(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			newQuery, err := tc.router.rewriteParserBackedDDLQuery(tc.ddl)
 			require.NoError(t, err)
@@ -775,7 +775,7 @@ func TestApplyToDDLEventRejectsParserUnsupportedIndexDDL(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/downstreamadapter/routing/router_apply_test.go
+++ b/downstreamadapter/routing/router_apply_test.go
@@ -364,7 +364,6 @@ func TestApplyToDDLEvent(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-
 		t.Run(tc.name, func(t *testing.T) {
 			routed, err := tc.router.ApplyToDDLEvent(tc.ddl)
 			require.NoError(t, err)
@@ -540,7 +539,6 @@ func TestRewriteDDLQueryWithRouting(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-
 		t.Run(tc.name, func(t *testing.T) {
 			newQuery, err := tc.router.rewriteParserBackedDDLQuery(tc.ddl)
 			require.NoError(t, err)
@@ -775,7 +773,6 @@ func TestApplyToDDLEventRejectsParserUnsupportedIndexDDL(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/downstreamadapter/routing/router_supported_ddl_test.go
+++ b/downstreamadapter/routing/router_supported_ddl_test.go
@@ -991,7 +991,7 @@ func TestRewriteDDLQueryWithRoutingSupportsParserBackedDDLTypes(t *testing.T) {
 	require.GreaterOrEqual(t, len(cases), 39)
 
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, byte(tc.action), tc.ddl.Type)
 

--- a/downstreamadapter/routing/router_supported_ddl_test.go
+++ b/downstreamadapter/routing/router_supported_ddl_test.go
@@ -991,7 +991,6 @@ func TestRewriteDDLQueryWithRoutingSupportsParserBackedDDLTypes(t *testing.T) {
 	require.GreaterOrEqual(t, len(cases), 39)
 
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, byte(tc.action), tc.ddl.Type)
 

--- a/downstreamadapter/sink/redo/meta.go
+++ b/downstreamadapter/sink/redo/meta.go
@@ -397,11 +397,9 @@ func (m *RedoMeta) prepareForFlushMeta() (bool, misc.LogMeta) {
 	unflushed.CheckpointTs = m.metaCheckpointTs.getUnflushed()
 	unflushed.ResolvedTs = m.metaResolvedTs.getUnflushed()
 
-	hasChange := false
-	if flushed.CheckpointTs < unflushed.CheckpointTs ||
-		flushed.ResolvedTs < unflushed.ResolvedTs {
-		hasChange = true
-	}
+	hasChange := flushed.CheckpointTs < unflushed.CheckpointTs ||
+		flushed.ResolvedTs < unflushed.ResolvedTs
+
 	return hasChange, unflushed
 }
 

--- a/downstreamadapter/syncpoint/sync_point.go
+++ b/downstreamadapter/syncpoint/sync_point.go
@@ -29,11 +29,11 @@ func CalculateStartSyncPointTs(startTs uint64, syncPointInterval time.Duration, 
 	if syncPointInterval == time.Duration(0) {
 		return 0
 	}
-	k := oracle.GetTimeFromTS(startTs).Sub(time.Unix(0, 0)) / syncPointInterval
+	k := int64(oracle.GetTimeFromTS(startTs).Sub(time.Unix(0, 0)) / syncPointInterval)
 	if oracle.GetTimeFromTS(startTs).Sub(time.Unix(0, 0))%syncPointInterval != 0 || oracle.ExtractLogical(startTs) != 0 {
 		k += 1
 	} else if skipSyncpointAtStartTs {
 		k += 1
 	}
-	return oracle.GoTimeToTS(time.Unix(0, 0).Add(k * syncPointInterval))
+	return oracle.GoTimeToTS(time.Unix(0, 0).Add(time.Duration(int64(syncPointInterval) * k)))
 }

--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -956,10 +956,7 @@ func (e *eventStore) GetIterator(dispatcherID common.DispatcherID, dataRange com
 
 	decoder := e.decoderPool.Get().(*zstd.Decoder)
 
-	needCheckSpan := true
-	if stat.tableSpan.Equal(subStat.tableSpan) {
-		needCheckSpan = false
-	}
+	needCheckSpan := !stat.tableSpan.Equal(subStat.tableSpan)
 
 	return &eventStoreIter{
 		tableSpan:         stat.tableSpan,
@@ -1605,14 +1602,12 @@ func (iter *eventStoreIter) Next() (*common.RawKVEntry, bool) {
 		skippedBytesMetrics.Add(float64(len(value)))
 		iter.innerIter.Next()
 	}
-	isNewTxn := false
+	isNewTxn := iter.prevCommitTs == 0 || (rawKV.StartTs != iter.prevStartTs || rawKV.CRTs != iter.prevCommitTs)
 	// 2 PC transactions have different startTs and commitTs.
 	// async-commit transactions have different startTs and may have the same commitTs.
 	// at the moment, use commit-ts determine whether it is a new transaction, even though multiple
 	// different transactions may be grouped together, to satisfy the resolved-ts semantics.
-	if iter.prevCommitTs == 0 || (rawKV.StartTs != iter.prevStartTs || rawKV.CRTs != iter.prevCommitTs) {
-		isNewTxn = true
-	}
+
 	iter.prevCommitTs = rawKV.CRTs
 	iter.prevStartTs = rawKV.StartTs
 	iter.rowCount++

--- a/logservice/schemastore/schema_store_test.go
+++ b/logservice/schemastore/schema_store_test.go
@@ -102,8 +102,8 @@ func TestIgnoreDDLByCommitTs(t *testing.T) {
 	require.Len(t, tables, 2)
 	tableNames := make(map[string]struct{})
 	for _, tbl := range tables {
-		log.Info("found table", zap.String("name", tbl.SchemaTableName.TableName))
-		tableNames[tbl.SchemaTableName.TableName] = struct{}{}
+		log.Info("found table", zap.String("name", tbl.TableName))
+		tableNames[tbl.TableName] = struct{}{}
 	}
 	require.Contains(t, tableNames, "t1")
 	require.Contains(t, tableNames, "t3")

--- a/maintainer/barrier.go
+++ b/maintainer/barrier.go
@@ -467,7 +467,7 @@ func (b *Barrier) checkEventFinish(be *BarrierEvent) {
 	if be.selected.Load() {
 		log.Info("all dispatchers reported event done, remove event",
 			zap.String("changefeed", be.cfID.Name()),
-			zap.Uint64("commits", be.commitTs),
+			zap.Uint64("commitTs", be.commitTs),
 			zap.Int64("mode", b.mode))
 		// already selected a dispatcher to write, now all dispatchers reported the block event
 		b.blockedEvents.Delete(getEventKey(be.commitTs, be.isSyncPoint))

--- a/maintainer/barrier.go
+++ b/maintainer/barrier.go
@@ -228,7 +228,7 @@ func (b *Barrier) handleBootstrapResponse(bootstrapRespMap map[node.ID]*heartbea
 	b.blockedEvents.Range(func(key eventKey, barrierEvent *BarrierEvent) bool {
 		if barrierEvent.allDispatcherReported() {
 			// it means the dispatchers involved in the block event are all in the cached resp, not restarted.
-			// so we don't do speical check for this event
+			// so we don't do special check for this event
 			// just use usual logic to handle it
 			// Besides, is the dispatchers are all reported waiting status, it means at least one dispatcher
 			// is not get acked, so it must be resent by dispatcher later.
@@ -467,7 +467,7 @@ func (b *Barrier) checkEventFinish(be *BarrierEvent) {
 	if be.selected.Load() {
 		log.Info("all dispatchers reported event done, remove event",
 			zap.String("changefeed", be.cfID.Name()),
-			zap.Uint64("committs", be.commitTs),
+			zap.Uint64("commits", be.commitTs),
 			zap.Int64("mode", b.mode))
 		// already selected a dispatcher to write, now all dispatchers reported the block event
 		b.blockedEvents.Delete(getEventKey(be.commitTs, be.isSyncPoint))

--- a/maintainer/operator/operator_merge.go
+++ b/maintainer/operator/operator_merge.go
@@ -65,8 +65,8 @@ type MergeDispatcherOperator struct {
 func buildMergedSpanInfo(toMergedSpans []*heartbeatpb.TableSpan) string {
 	var spansInfo strings.Builder
 	for _, span := range toMergedSpans {
-		spansInfo.WriteString(fmt.Sprintf("[%s,%s,%d]",
-			hex.EncodeToString(span.StartKey), hex.EncodeToString(span.EndKey), span.TableID))
+		fmt.Fprintf(&spansInfo, "[%s,%s,%d]",
+			hex.EncodeToString(span.StartKey), hex.EncodeToString(span.EndKey), span.TableID)
 	}
 	return spansInfo.String()
 }

--- a/maintainer/operator/operator_split.go
+++ b/maintainer/operator/operator_split.go
@@ -78,8 +78,8 @@ func NewSplitDispatcherOperator(
 ) *SplitDispatcherOperator {
 	var spansInfo strings.Builder
 	for _, span := range splitSpans {
-		spansInfo.WriteString(fmt.Sprintf("[%s,%s]",
-			hex.EncodeToString(span.StartKey), hex.EncodeToString(span.EndKey)))
+		fmt.Fprintf(&spansInfo, "[%s,%s]",
+			hex.EncodeToString(span.StartKey), hex.EncodeToString(span.EndKey))
 	}
 	op := &SplitDispatcherOperator{
 		replicaSet:       replicaSet,

--- a/maintainer/range_checker/table_span_range_checker.go
+++ b/maintainer/range_checker/table_span_range_checker.go
@@ -79,7 +79,7 @@ func (rc *TableSpanRangeChecker) Detail() string {
 	buf.WriteString("uncovered tables: ")
 	for id, span := range rc.tableSpans {
 		if !span.IsFullyCovered() {
-			buf.WriteString(fmt.Sprintf("%d,\n", id))
+			fmt.Fprintf(buf, "%d,\n", id)
 		}
 	}
 	return buf.String()

--- a/maintainer/replica/split_span_checker.go
+++ b/maintainer/replica/split_span_checker.go
@@ -106,7 +106,8 @@ func (b *BalanceCondition) updateScore(minTrafficNodeID node.ID,
 	if b.balanceScore == 0 {
 		b.initFirstScore(minTrafficNodeID, maxTrafficNodeID, balanceCauseByMinNode, balanceCauseByMaxNode)
 	} else {
-		if b.balanceCause == BalanceCauseByBoth {
+		switch b.balanceCause {
+		case BalanceCauseByBoth:
 			if b.minTrafficNodeID == minTrafficNodeID && b.maxTrafficNodeID == maxTrafficNodeID {
 				b.balanceScore += 1
 			} else if b.minTrafficNodeID == minTrafficNodeID {
@@ -118,13 +119,13 @@ func (b *BalanceCondition) updateScore(minTrafficNodeID node.ID,
 			} else {
 				b.initFirstScore(minTrafficNodeID, maxTrafficNodeID, balanceCauseByMinNode, balanceCauseByMaxNode)
 			}
-		} else if b.balanceCause == BalanceCauseByMaxNode {
+		case BalanceCauseByMaxNode:
 			if b.maxTrafficNodeID == maxTrafficNodeID {
 				b.balanceScore += 1
 			} else {
 				b.initFirstScore(minTrafficNodeID, maxTrafficNodeID, balanceCauseByMinNode, balanceCauseByMaxNode)
 			}
-		} else if b.balanceCause == BalanceCauseByMinNode {
+		case BalanceCauseByMinNode:
 			if b.minTrafficNodeID == minTrafficNodeID {
 				b.balanceScore += 1
 			} else {
@@ -242,7 +243,7 @@ func (s *SplitSpanChecker) UpdateStatus(replica *SpanReplication) {
 			log.Debug("update traffic score",
 				zap.String("changefeed", s.changefeedID.String()),
 				zap.Int64("group", s.groupID),
-				zap.String("span", status.SpanReplication.ID.String()),
+				zap.String("span", status.ID.String()),
 				zap.Any("trafficScore", status.trafficScore),
 				zap.Any("eventSizePerSecond", status.GetStatus().EventSizePerSecond),
 			)
@@ -976,7 +977,7 @@ func (s *SplitSpanChecker) chooseSplitSpans(
 				log.Info("chooseSplitSpans split span by traffic",
 					zap.String("changefeed", s.changefeedID.String()),
 					zap.Int64("group", s.groupID),
-					zap.String("splitSpan", status.SpanReplication.ID.String()),
+					zap.String("splitSpan", status.ID.String()),
 					zap.Any("splitTargetNodes", status.GetNodeID()),
 				)
 				spanNum := int(math.Ceil(status.lastThreeTraffic[latestTrafficIndex] / float64(s.writeThreshold)))
@@ -1000,7 +1001,7 @@ func (s *SplitSpanChecker) chooseSplitSpans(
 			if status.regionCount > s.regionThreshold {
 				log.Info("chooseSplitSpans split span by region",
 					zap.String("changefeed", s.changefeedID.String()),
-					zap.String("splitSpan", status.SpanReplication.ID.String()),
+					zap.String("splitSpan", status.ID.String()),
 					zap.Int64("group", s.groupID),
 					zap.Any("splitTargetNodes", status.GetNodeID()),
 				)
@@ -1211,7 +1212,7 @@ func (s *SplitSpanChecker) checkBalanceTraffic(
 
 	log.Info("checkBalanceTraffic split span",
 		zap.Stringer("changefeed", s.changefeedID),
-		zap.String("splitSpan", span.SpanReplication.ID.String()),
+		zap.String("splitSpan", span.ID.String()),
 		zap.Int64("group", s.groupID),
 		zap.Any("splitTargetNodes", []node.ID{minTrafficNodeID, maxTrafficNodeID}),
 	)
@@ -1247,13 +1248,13 @@ func (s *SplitSpanChecker) Stat() string {
 		res.WriteString("traffic infos:")
 		// record all the latest three traffic of tasks
 		for _, status := range s.allTasks {
-			res.WriteString(fmt.Sprintf("[task: %s, traffic: %f, %f, %f];", status.ID, status.lastThreeTraffic[0], status.lastThreeTraffic[1], status.lastThreeTraffic[2]))
+			fmt.Fprintf(&res, "[task: %s, traffic: %f, %f, %f];", status.ID, status.lastThreeTraffic[0], status.lastThreeTraffic[1], status.lastThreeTraffic[2])
 		}
 	}
 	if s.regionThreshold > 0 {
 		res.WriteString("region infos:")
 		for _, status := range s.allTasks {
-			res.WriteString(fmt.Sprintf("[task: %s, region: %d];", status.ID, status.regionCount))
+			fmt.Fprintf(&res, "[task: %s, region: %d];", status.ID, status.regionCount)
 		}
 	}
 	return res.String()

--- a/maintainer/scheduler/balance_splits.go
+++ b/maintainer/scheduler/balance_splits.go
@@ -128,7 +128,8 @@ func (s *balanceSplitsScheduler) Execute() time.Time {
 
 		checkResults := s.spanController.CheckByGroup(group, availableSize)
 		for _, checkResult := range checkResults.([]replica.SplitSpanCheckResult) {
-			if checkResult.OpType == replica.OpSplit {
+			switch checkResult.OpType {
+			case replica.OpSplit:
 				splitSpans := s.splitter.Split(context.Background(), checkResult.SplitSpan.Span, checkResult.SpanNum, checkResult.SpanType)
 				if len(splitSpans) > 1 {
 					op := operator.NewSplitDispatcherOperator(s.spanController, checkResult.SplitSpan, splitSpans, checkResult.SplitTargetNodes, func(span *replica.SpanReplication, node node.ID) bool {
@@ -139,7 +140,7 @@ func (s *balanceSplitsScheduler) Execute() time.Time {
 						availableSize--
 					}
 				}
-			} else if checkResult.OpType == replica.OpMove {
+			case replica.OpMove:
 				for _, span := range checkResult.MoveSpans {
 					op := operator.NewMoveDispatcherOperator(s.spanController, span, span.GetNodeID(), checkResult.TargetNode)
 					ret := s.operatorController.AddOperator(op)
@@ -147,7 +148,7 @@ func (s *balanceSplitsScheduler) Execute() time.Time {
 						availableSize--
 					}
 				}
-			} else if checkResult.OpType == replica.OpMerge {
+			case replica.OpMerge:
 				if s.operatorController.AddMergeOperator(checkResult.MergeSpans) != nil {
 					availableSize = availableSize - 1 - len(checkResult.MergeSpans)
 				}

--- a/maintainer/scheduler/drain_test.go
+++ b/maintainer/scheduler/drain_test.go
@@ -279,7 +279,6 @@ func TestCalculateDrainMoveLimit(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.expected, calculateDrainMoveLimit(tc.initialTargetDispatcherCount))

--- a/maintainer/scheduler/drain_test.go
+++ b/maintainer/scheduler/drain_test.go
@@ -279,7 +279,7 @@ func TestCalculateDrainMoveLimit(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.expected, calculateDrainMoveLimit(tc.initialTargetDispatcherCount))

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -185,7 +185,6 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 		return err
 	}
 	for row != nil || ddl != nil {
-
 		if shouldApplyDDL(row, ddl) {
 			if err := ra.applyDDL(ctx, ddl, checkpointTs); err != nil {
 				return err

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -184,10 +184,8 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	for {
-		if row == nil && ddl == nil {
-			break
-		}
+	for row != nil || ddl != nil {
+
 		if shouldApplyDDL(row, ddl) {
 			if err := ra.applyDDL(ctx, ddl, checkpointTs); err != nil {
 				return err

--- a/pkg/binlog-filter/filter_test.go
+++ b/pkg/binlog-filter/filter_test.go
@@ -126,7 +126,7 @@ func TestFilter(t *testing.T) {
 	require.Equal(t, Do, action)
 
 	// invalid rule
-	err = filter.Selector.Insert("test_1_*", "abc*", "error", selector.Insert)
+	err = filter.Insert("test_1_*", "abc*", "error", selector.Insert)
 	require.NoError(t, err)
 	_, err = filter.Filter("test_1_a", "abc", InsertEvent, "")
 	require.Error(t, err)

--- a/pkg/common/event/drop_event.go
+++ b/pkg/common/event/drop_event.go
@@ -158,8 +158,6 @@ func (e *DropEvent) encodeV1() ([]byte, error) {
 
 	// DroppedEpoch
 	binary.BigEndian.PutUint64(data[offset:], e.DroppedEpoch)
-	offset += 8
-
 	return data, nil
 }
 
@@ -185,7 +183,5 @@ func (e *DropEvent) decodeV1(data []byte) error {
 
 	// DroppedEpoch
 	e.DroppedEpoch = binary.BigEndian.Uint64(data[offset:])
-	offset += 8
-
 	return nil
 }

--- a/pkg/common/format.go
+++ b/pkg/common/format.go
@@ -32,9 +32,9 @@ func FormatBlockStatusRequest(r *heartbeatpb.BlockStatusRequest) string {
 		return ""
 	}
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("changefeed: %s, changefeedID: %s",
+	fmt.Fprintf(&sb, "changefeed: %s, changefeedID: %s",
 		r.ChangefeedID.GetName(),
-		NewChangefeedGIDFromPB(r.ChangefeedID).String()))
+		NewChangefeedGIDFromPB(r.ChangefeedID).String())
 	for _, status := range r.BlockStatuses {
 		sb.WriteString(FormatTableSpanBlockStatus(status))
 	}
@@ -51,9 +51,9 @@ func FormatTableSpanBlockStatus(s *heartbeatpb.TableSpanBlockStatus) string {
 		return ""
 	}
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("[ dispatcherID: %s, state: %s ]",
+	fmt.Fprintf(&sb, "[ dispatcherID: %s, state: %s ]",
 		NewDispatcherIDFromPB(s.ID).String(),
-		s.State.String()))
+		s.State.String())
 	sb.WriteString("\n")
 	return sb.String()
 }
@@ -63,10 +63,10 @@ func FormatDispatcherStatus(d *heartbeatpb.DispatcherStatus) string {
 		return ""
 	}
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("action: %s, ack: %s, influencedDispatchers: %s",
+	fmt.Fprintf(&sb, "action: %s, ack: %s, influencedDispatchers: %s",
 		d.Action.String(),
 		d.Ack.String(),
-		FormatInfluencedDispatchers(d.InfluencedDispatchers)))
+		FormatInfluencedDispatchers(d.InfluencedDispatchers))
 	sb.WriteString("\n")
 	return sb.String()
 }
@@ -76,18 +76,18 @@ func FormatInfluencedDispatchers(d *heartbeatpb.InfluencedDispatchers) string {
 		return ""
 	}
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("schemaID: %d, influenceType: %s",
+	fmt.Fprintf(&sb, "schemaID: %d, influenceType: %s",
 		d.SchemaID,
-		d.InfluenceType.String()))
+		d.InfluenceType.String())
 	sb.WriteString("dispatcherIDs: [")
 	for _, dispatcherID := range d.DispatcherIDs {
-		sb.WriteString(fmt.Sprintf("%s, ",
-			NewDispatcherIDFromPB(dispatcherID).String()))
+		fmt.Fprintf(&sb, "%s, ",
+			NewDispatcherIDFromPB(dispatcherID).String())
 	}
 	sb.WriteString("]")
 	if d.ExcludeDispatcherId != nil {
-		sb.WriteString(fmt.Sprintf(", excludeDispatcherID: %s",
-			NewDispatcherIDFromPB(d.ExcludeDispatcherId).String()))
+		fmt.Fprintf(&sb, ", excludeDispatcherID: %s",
+			NewDispatcherIDFromPB(d.ExcludeDispatcherId).String())
 	}
 	sb.WriteString("\n")
 	return sb.String()
@@ -98,11 +98,11 @@ func FormatTableSpan(s *heartbeatpb.TableSpan) string {
 		return ""
 	}
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("tableID: %d, startKey: %s, endKey: %s, keyspaceID: %d",
+	fmt.Fprintf(&sb, "tableID: %d, startKey: %s, endKey: %s, keyspaceID: %d",
 		s.TableID,
 		hex.EncodeToString(s.StartKey),
 		hex.EncodeToString(s.EndKey),
-		s.KeyspaceID))
+		s.KeyspaceID)
 	return sb.String()
 }
 
@@ -111,14 +111,12 @@ func FormatMaintainerStatus(s *heartbeatpb.MaintainerStatus) string {
 		return ""
 	}
 	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf(
-		"changefeed: %s, feedState: %s, state: %s, checkpointTs: %d, bootstrapDone: %t, errs: [",
+	fmt.Fprintf(&sb, "changefeed: %s, feedState: %s, state: %s, checkpointTs: %d, bootstrapDone: %t, errs: [",
 		s.ChangefeedID.GetName(),
 		s.FeedState,
 		s.State.String(),
 		s.CheckpointTs,
-		s.BootstrapDone,
-	))
+		s.BootstrapDone)
 	for _, err := range s.Err {
 		sb.WriteString(err.String())
 	}

--- a/pkg/common/format_test.go
+++ b/pkg/common/format_test.go
@@ -55,7 +55,6 @@ func TestFormatBlockStatusRequest(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatBlockStatusRequest(tc.input)
@@ -89,7 +88,6 @@ func TestFormatTableSpanBlockStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatTableSpanBlockStatus(tc.input)
@@ -123,7 +121,6 @@ func TestFormatDispatcherStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatDispatcherStatus(tc.input)
@@ -156,7 +153,6 @@ func TestFormatInfluencedDispatchers(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatInfluencedDispatchers(tc.input)
@@ -190,7 +186,6 @@ func TestFormatTableSpan(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatTableSpan(tc.input)
@@ -226,7 +221,6 @@ func TestFormatMaintainerStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatMaintainerStatus(tc.input)

--- a/pkg/common/format_test.go
+++ b/pkg/common/format_test.go
@@ -55,7 +55,7 @@ func TestFormatBlockStatusRequest(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatBlockStatusRequest(tc.input)
@@ -89,7 +89,7 @@ func TestFormatTableSpanBlockStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatTableSpanBlockStatus(tc.input)
@@ -123,7 +123,7 @@ func TestFormatDispatcherStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatDispatcherStatus(tc.input)
@@ -156,7 +156,7 @@ func TestFormatInfluencedDispatchers(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatInfluencedDispatchers(tc.input)
@@ -190,7 +190,7 @@ func TestFormatTableSpan(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatTableSpan(tc.input)
@@ -226,7 +226,7 @@ func TestFormatMaintainerStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatMaintainerStatus(tc.input)

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -75,7 +75,7 @@ func TestExtractColValTimeTypes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -322,7 +322,7 @@ func TestExtractColValDefaultDatumValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -75,7 +75,6 @@ func TestExtractColValTimeTypes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -322,7 +321,6 @@ func TestExtractColValDefaultDatumValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/common/span_op.go
+++ b/pkg/common/span_op.go
@@ -41,7 +41,7 @@ func TableIDToComparableSpan(keyspaceID uint32, tableID int64) heartbeatpb.Table
 	startKey, endKey, err := GetKeyspaceTableRange(keyspaceID, tableID)
 	if err != nil {
 		// This block should never be reached
-		// The error only happends when the keyspaceID is greater than 0xFFFFFF, which is an invalid keyspaceID
+		// The error only happens when the keyspaceID is greater than 0xFFFFFF, which is an invalid keyspaceID
 		log.Error("GetKeyspaceTableRange failed", zap.Uint32("keyspaceID", keyspaceID), zap.Int64("tableID", tableID), zap.Error(err))
 	}
 	return heartbeatpb.TableSpan{
@@ -68,7 +68,7 @@ func IsCompleteSpan(tableSpan *heartbeatpb.TableSpan) bool {
 	startKey, endKey, err := GetKeyspaceTableRange(tableSpan.KeyspaceID, tableSpan.TableID)
 	if err != nil {
 		// This block should never be reached
-		// The error only happends when the keyspaceID is greater than 0xFFFFFF, which is an invalid keyspaceID
+		// The error only happens when the keyspaceID is greater than 0xFFFFFF, which is an invalid keyspaceID
 		log.Error("IsCompleteSpan GetKeyspaceTableRange failed", zap.Uint32("keyspaceID", tableSpan.KeyspaceID), zap.Error(err))
 	}
 	if StartCompare(ToComparableKey(startKey), tableSpan.StartKey) == 0 && EndCompare(ToComparableKey(endKey), tableSpan.EndKey) == 0 {

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -58,7 +58,7 @@ func UnquoteName(name string) string {
 
 // EscapeName replaces all "`" in name with double "`"
 func EscapeName(name string) string {
-	return strings.Replace(name, "`", "``", -1)
+	return strings.ReplaceAll(name, "`", "``")
 }
 
 const (

--- a/pkg/common/table_info_helper.go
+++ b/pkg/common/table_info_helper.go
@@ -293,7 +293,7 @@ func (s *SharedColumnSchemaStorage) incColumnSchemaCount(columnSchema *columnSch
 		log.Error("inc column schema count failed, column schema not found", zap.Any("columnSchema", columnSchema))
 	}
 	for idx, colSchemaWithCount := range colSchemas {
-		if colSchemaWithCount.columnSchema.equal(columnSchema) {
+		if colSchemaWithCount.equal(columnSchema) {
 			s.m[columnSchema.Digest][idx].count++
 			return
 		}
@@ -326,7 +326,7 @@ func (s *SharedColumnSchemaStorage) GetOrSetColumnSchema(tableInfo *model.TableI
 	} else {
 		for idx, colSchemaWithCount := range colSchemas {
 			// compare tableInfo to check whether the column schema is the same
-			if colSchemaWithCount.columnSchema.SameWithTableInfo(tableInfo) {
+			if colSchemaWithCount.SameWithTableInfo(tableInfo) {
 				s.m[digest][idx].count++
 				return colSchemaWithCount.columnSchema
 			}
@@ -352,7 +352,7 @@ func (s *SharedColumnSchemaStorage) getOrSetColumnSchemaByColumnSchema(columnSch
 	} else {
 		for idx, colSchemaWithCount := range colSchemas {
 			// compare tableInfo to check whether the column schema is the same
-			if colSchemaWithCount.columnSchema.equal(columnSchema) {
+			if colSchemaWithCount.equal(columnSchema) {
 				s.m[digest][idx].count++
 				return colSchemaWithCount.columnSchema
 			}
@@ -400,7 +400,7 @@ func (s *SharedColumnSchemaStorage) tryReleaseColumnSchema(columnSchema *columnS
 // columnSchema is shared across multiple tableInfos with the same schema, in order to reduce memory usage.
 // we make columnSchema as a private struct, in order to avoid other method to directly create a columnSchema object.
 // we only want user to get columnSchema by the function we provide, which will increase the reference count of columnSchema.(GetOrSetColumnSchema)
-// If user want to copy columnSchema(shaddow copy), they should use Clone method.
+// If user want to copy columnSchema(shadow copy), they should use Clone method.
 type columnSchema struct {
 	// digest of the table info
 	Digest Digest `json:"digest"`
@@ -469,7 +469,7 @@ func (s *columnSchema) Marshal() ([]byte, error) {
 	return json.Marshal(s)
 }
 
-// If you want to copy columnSchema(shaddow copy), you should use Clone method.
+// If you want to copy columnSchema(shadow copy), you should use Clone method.
 // This function will increase the reference count of the columnSchema object.
 func (s *columnSchema) Clone() *columnSchema {
 	GetSharedColumnSchemaStorage().incColumnSchemaCount(s)

--- a/pkg/common/table_info_shared_schema_guard_test.go
+++ b/pkg/common/table_info_shared_schema_guard_test.go
@@ -128,7 +128,6 @@ func TestLatestTiDBTableInfoSharedSchemaGuard(t *testing.T) {
 	moduleCache := make(map[string]*moduleInfo)
 	packageCache := make(map[packageKey]map[string][]string)
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			mod, ok := moduleCache[tc.modulePath]
 			if !ok {

--- a/pkg/common/table_info_shared_schema_guard_test.go
+++ b/pkg/common/table_info_shared_schema_guard_test.go
@@ -128,7 +128,7 @@ func TestLatestTiDBTableInfoSharedSchemaGuard(t *testing.T) {
 	moduleCache := make(map[string]*moduleInfo)
 	packageCache := make(map[packageKey]map[string][]string)
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			mod, ok := moduleCache[tc.modulePath]
 			if !ok {

--- a/pkg/common/table_info_test.go
+++ b/pkg/common/table_info_test.go
@@ -240,7 +240,7 @@ func TestUnquoteName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.expected, UnquoteName(tc.input))

--- a/pkg/common/table_info_test.go
+++ b/pkg/common/table_info_test.go
@@ -240,7 +240,6 @@ func TestUnquoteName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.expected, UnquoteName(tc.input))

--- a/pkg/common/table_name_test.go
+++ b/pkg/common/table_name_test.go
@@ -50,7 +50,6 @@ func TestTableNameIsRouted(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := tt.tableName.IsRouted(); got != tt.expected {

--- a/pkg/common/table_name_test.go
+++ b/pkg/common/table_name_test.go
@@ -50,7 +50,7 @@ func TestTableNameIsRouted(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := tt.tableName.IsRouted(); got != tt.expected {

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -1023,7 +1023,7 @@ func (s *SinkConfig) applyParameterBySinkURI(sinkURI *url.URL) error {
 		getErrMsg := func(cfgIn map[string]string) string {
 			var errMsg strings.Builder
 			for k, v := range cfgIn {
-				errMsg.WriteString(fmt.Sprintf("%s=%s, ", k, v))
+				fmt.Fprintf(&errMsg, "%s=%s, ", k, v)
 			}
 			return errMsg.String()[0 : errMsg.Len()-2]
 		}

--- a/pkg/diff/checkpoint.go
+++ b/pkg/diff/checkpoint.go
@@ -224,9 +224,10 @@ func updateTableSummary(ctx context.Context, db *sql.DB, instanceID, schema, tab
 
 	checkedNum := successNum + failedNum + ignoreNum
 	state := checkingState
-	if checkedNum == 0 {
+	switch checkedNum {
+	case 0:
 		state = notCheckedState
-	} else if checkedNum == total {
+	case total:
 		if total == successNum+ignoreNum {
 			state = successState
 		} else {

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -883,7 +883,7 @@ func generateDML(tp string, data map[string]*dbutil.ColumnData, table *model.Tab
 			}
 
 			if needQuotes(col.FieldType) {
-				values = append(values, fmt.Sprintf("'%s'", strings.Replace(string(data[col.Name.O].Data), "'", "\\'", -1)))
+				values = append(values, fmt.Sprintf("'%s'", strings.ReplaceAll(string(data[col.Name.O].Data), "'", "\\'")))
 			} else {
 				values = append(values, string(data[col.Name.O].Data))
 			}
@@ -906,7 +906,7 @@ func generateDML(tp string, data map[string]*dbutil.ColumnData, table *model.Tab
 			if needQuotes(col.FieldType) {
 				kvs = append(kvs, fmt.Sprintf("%s = '%s'",
 					dbutil.ColumnName(col.Name.O),
-					strings.Replace(string(data[col.Name.O].Data), "'", "\\'", -1)))
+					strings.ReplaceAll(string(data[col.Name.O].Data), "'", "\\'")))
 			} else {
 				kvs = append(kvs,
 					fmt.Sprintf("%s = %s", dbutil.ColumnName(col.Name.O), string(data[col.Name.O].Data)))

--- a/pkg/diff/util.go
+++ b/pkg/diff/util.go
@@ -105,7 +105,7 @@ func getColumnsFromIndex(index *model.IndexInfo, tableInfo *model.TableInfo) []*
 }
 
 func needQuotes(ft types.FieldType) bool {
-	return !(dbutil.IsNumberType(ft.GetType()) || dbutil.IsFloatType(ft.GetType()))
+	return !dbutil.IsNumberType(ft.GetType()) && !dbutil.IsFloatType(ft.GetType())
 }
 
 func rowContainsCols(row map[string]*dbutil.ColumnData, cols []*model.ColumnInfo) bool {
@@ -128,9 +128,9 @@ func redactRowToString(row map[string]*dbutil.ColumnData) string {
 	s.WriteString("{ ")
 	for key, val := range row {
 		if val.IsNull {
-			s.WriteString(fmt.Sprintf("%s: IsNull, ", key))
+			fmt.Fprintf(&s, "%s: IsNull, ", key)
 		} else {
-			s.WriteString(fmt.Sprintf("%s: %s, ", key, util.RedactValue(string(val.Data))))
+			fmt.Fprintf(&s, "%s: %s, ", key, util.RedactValue(string(val.Data)))
 		}
 	}
 	s.WriteString(" }")

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -566,8 +566,8 @@ func (checker *healthyChecker) update(eps []string) {
 			}
 			if time.Since(lastHealthy) > etcdServerDisconnectedTimeout {
 				// try to reset client endpoint to trigger reconnect
-				client.(*healthyClient).Client.SetEndpoints([]string{}...)
-				client.(*healthyClient).Client.SetEndpoints(ep)
+				client.(*healthyClient).SetEndpoints([]string{}...)
+				client.(*healthyClient).SetEndpoints(ep)
 			}
 			continue
 		}

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -206,10 +206,8 @@ func (c *eventBroker) sendDML(remoteID node.ID, batchEvent *event.BatchDMLEvent,
 		lastStartTs  uint64
 		lastCommitTs uint64
 	)
-	for {
-		if idx >= len(batchEvent.DMLEvents) {
-			break
-		}
+	for idx < len(batchEvent.DMLEvents) {
+
 		dml := batchEvent.DMLEvents[idx]
 		if c.hasSyncPointEventsBeforeTs(dml.GetCommitTs(), d) {
 			events := batchEvent.PopHeadDMLEvents(idx)

--- a/pkg/eventservice/event_service_test.go
+++ b/pkg/eventservice/event_service_test.go
@@ -324,10 +324,8 @@ func (iter *mockEventIterator) Next() (*common.RawKVEntry, bool) {
 
 	row := iter.events[0]
 	iter.events = iter.events[1:]
-	isNewTxn := false
-	if iter.prevCommitTS == 0 || row.StartTs != iter.prevStartTS || row.CRTs != iter.prevCommitTS {
-		isNewTxn = true
-	}
+	isNewTxn := iter.prevCommitTS == 0 || row.StartTs != iter.prevStartTS || row.CRTs != iter.prevCommitTS
+
 	iter.prevStartTS = row.StartTs
 	iter.prevCommitTS = row.CRTs
 	iter.rowCount++

--- a/pkg/eventservice/scan_window.go
+++ b/pkg/eventservice/scan_window.go
@@ -255,7 +255,7 @@ func (c *changefeedStatus) adjustScanInterval(now time.Time, usage memoryUsageSt
 	allowedToIncrease := now.Sub(c.lastAdjustTime.Load()) >= scanIntervalAdjustCooldown &&
 		usage.cnt >= minIncreaseSamples &&
 		usage.span >= minIncreaseSpan &&
-		!(isAboveTrendStart && isIncreasing)
+		(!isAboveTrendStart || !isIncreasing)
 
 	// Determine the new interval based on memory pressure levels.
 	// Priority order: critical > high > trend damping > very low > low

--- a/pkg/messaging/message.go
+++ b/pkg/messaging/message.go
@@ -249,7 +249,7 @@ func (r DispatcherRequest) GetChangefeedID() common.ChangeFeedID {
 }
 
 func (r DispatcherRequest) GetFilterConfig() *eventpb.FilterConfig {
-	return r.DispatcherRequest.FilterConfig
+	return r.FilterConfig
 }
 
 func (r DispatcherRequest) SyncPointEnabled() bool {
@@ -273,15 +273,15 @@ func (r DispatcherRequest) GetBdrMode() bool {
 }
 
 func (r DispatcherRequest) GetIntegrity() *integrity.Config {
-	if r.DispatcherRequest.Integrity == nil {
+	if r.Integrity == nil {
 		return &integrity.Config{
 			IntegrityCheckLevel:   util.AddressOf(integrity.CheckLevelNone),
 			CorruptionHandleLevel: util.AddressOf(integrity.CorruptionHandleLevelWarn),
 		}
 	}
 	return &integrity.Config{
-		IntegrityCheckLevel:   util.AddressOf(r.DispatcherRequest.Integrity.IntegrityCheckLevel),
-		CorruptionHandleLevel: util.AddressOf(r.DispatcherRequest.Integrity.CorruptionHandleLevel),
+		IntegrityCheckLevel:   util.AddressOf(r.Integrity.IntegrityCheckLevel),
+		CorruptionHandleLevel: util.AddressOf(r.Integrity.CorruptionHandleLevel),
 	}
 }
 

--- a/pkg/messaging/remote_target.go
+++ b/pkg/messaging/remote_target.go
@@ -497,10 +497,8 @@ func (s *remoteMessageTarget) runSendMessages(ctx context.Context, streamType st
 	}()
 
 	// wait stream ready
-	for {
-		if s.isReadyToSend() {
-			break
-		}
+	for !s.isReadyToSend() {
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -573,10 +571,8 @@ func (s *remoteMessageTarget) runReceiveMessages(ctx context.Context, streamType
 	}()
 
 	// wait stream ready
-	for {
-		if s.isReadyToSend() {
-			break
-		}
+	for !s.isReadyToSend() {
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/messaging/remote_target.go
+++ b/pkg/messaging/remote_target.go
@@ -498,7 +498,6 @@ func (s *remoteMessageTarget) runSendMessages(ctx context.Context, streamType st
 
 	// wait stream ready
 	for !s.isReadyToSend() {
-
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -572,7 +571,6 @@ func (s *remoteMessageTarget) runReceiveMessages(ctx context.Context, streamType
 
 	// wait stream ready
 	for !s.isReadyToSend() {
-
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -87,7 +87,6 @@ func TestContinusStop(t *testing.T) {
 		require.Nil(t, err)
 	}
 	for i := 0; i < n; i++ {
-
 		go func() {
 			for {
 				select {

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -87,7 +87,7 @@ func TestContinusStop(t *testing.T) {
 		require.Nil(t, err)
 	}
 	for i := 0; i < n; i++ {
-		i := i
+
 		go func() {
 			for {
 				select {

--- a/pkg/orchestrator/batch_test.go
+++ b/pkg/orchestrator/batch_test.go
@@ -26,7 +26,7 @@ func TestGetBatchChangeState(t *testing.T) {
 	patchGroupSize := 1000
 	patchGroup := make([][]DataPatch, patchGroupSize)
 	for i := 0; i < patchGroupSize; i++ {
-		i := i
+
 		patches := []DataPatch{&SingleDataPatch{
 			Key: util.NewEtcdKey(fmt.Sprintf("/key%d", i)),
 			Func: func(old []byte) (newValue []byte, changed bool, err error) {

--- a/pkg/pdutil/api_client_test.go
+++ b/pkg/pdutil/api_client_test.go
@@ -241,13 +241,14 @@ func TestScanRegions(t *testing.T) {
 
 	i = 0
 	handler = func() RegionsInfo {
-		if i == 0 {
+		switch i {
+		case 0:
 			i++
 			return RegionsInfo{Regions: regions[2:3]}
-		} else if i == 1 {
+		case 1:
 			i++
 			return RegionsInfo{Regions: regions[3:4]}
-		} else if i == 2 {
+		case 2:
 			i++
 			return RegionsInfo{Regions: regions[4:5]}
 		}

--- a/pkg/redo/reader/reader_test.go
+++ b/pkg/redo/reader/reader_test.go
@@ -59,7 +59,8 @@ func genLogFile(
 		return fileName
 	}))
 	require.Nil(t, err)
-	if logType == redo.RedoRowLogFileType {
+	switch logType {
+	case redo.RedoRowLogFileType:
 		// generate unsorted logs
 		for ts := maxCommitTs; ts >= minCommitTs; ts-- {
 			event := &pevent.RedoRowEvent{
@@ -74,7 +75,7 @@ func genLogFile(
 			_, err = w.Write(rawData)
 			require.Nil(t, err)
 		}
-	} else if logType == redo.RedoDDLLogFileType {
+	case redo.RedoDDLLogFileType:
 		event := &pevent.DDLEvent{
 			FinishedTs: maxCommitTs,
 			TableInfo:  &common.TableInfo{},

--- a/pkg/redo/writer/file/file.go
+++ b/pkg/redo/writer/file/file.go
@@ -565,7 +565,7 @@ func (w *Writer) flushAndRotateFile() error {
 	// which could cause considerable network bandwidth waste.
 	err = w.rotate()
 	if err != nil {
-		return nil
+		return err
 	}
 	w.metricFlushAllDuration.Observe(time.Since(start).Seconds())
 

--- a/pkg/scheduler/replica/replication.go
+++ b/pkg/scheduler/replica/replication.go
@@ -357,7 +357,7 @@ func (db *replicationDB[T, R]) GetCheckerStat() string {
 				stat.WriteString(" ")
 			}
 			stat.WriteString(GetGroupName(groupID))
-			stat.WriteString(fmt.Sprintf("(%s)", group.checker.Name()))
+			fmt.Fprintf(&stat, "(%s)", group.checker.Name())
 			stat.WriteString(": [")
 			stat.WriteString(group.checker.Stat())
 			stat.WriteString("] ")

--- a/pkg/security/sasl_test.go
+++ b/pkg/security/sasl_test.go
@@ -76,7 +76,7 @@ func TestSASLMechanismFromString(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			mechanism, err := SASLMechanismFromString(test.s)
@@ -129,7 +129,7 @@ func TestAuthTypeFromString(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/security/sasl_test.go
+++ b/pkg/security/sasl_test.go
@@ -76,7 +76,6 @@ func TestSASLMechanismFromString(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			mechanism, err := SASLMechanismFromString(test.s)
@@ -129,7 +128,6 @@ func TestAuthTypeFromString(t *testing.T) {
 	}
 
 	for _, test := range tests {
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/security/scram_client.go
+++ b/pkg/security/scram_client.go
@@ -37,11 +37,11 @@ type XDGSCRAMClient struct {
 
 // Begin xdg scram client Begin
 func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
-	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	x.Client, err = x.NewClient(userName, password, authzID)
 	if err != nil {
 		return err
 	}
-	x.ClientConversation = x.Client.NewConversation()
+	x.ClientConversation = x.NewConversation()
 	return nil
 }
 

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -182,7 +182,7 @@ type urlConfig struct {
 	// can be `json` and `avro`, default to `json`.
 	EncodingFormatType *string `form:"encoding-format"`
 
-	// If both `EnableTiDBExtension` and `OutputRowKey` is set to true, row key will be outputed in the tidb-extension field.
+	// If both `EnableTiDBExtension` and `OutputRowKey` is set to true, row key will be outputted in the tidb-extension field.
 	// This is only used for the **canal-json** protocol.
 	OutputRowKey *bool `form:"output-row-key"`
 }
@@ -353,7 +353,7 @@ func (c *Config) WithChangefeedID(id common.ChangeFeedID) *Config {
 // Validate the Config
 func (c *Config) Validate() error {
 	if c.EnableTiDBExtension &&
-		!(c.Protocol == config.ProtocolCanalJSON || c.Protocol == config.ProtocolAvro || c.Protocol == config.ProtocolDebezium) {
+		(c.Protocol != config.ProtocolCanalJSON && c.Protocol != config.ProtocolAvro && c.Protocol != config.ProtocolDebezium) {
 		log.Warn("ignore invalid config, enable-tidb-extension"+
 			"only supports canal-json/avro/debezium protocol",
 			zap.Bool("enableTidbExtension", c.EnableTiDBExtension),
@@ -398,8 +398,8 @@ func (c *Config) Validate() error {
 		}
 
 		if c.EnableRowChecksum {
-			if !(c.EnableTiDBExtension && c.AvroDecimalHandlingMode == DecimalHandlingModeString &&
-				c.AvroBigintUnsignedHandlingMode == BigintUnsignedHandlingModeString) {
+			if !c.EnableTiDBExtension || c.AvroDecimalHandlingMode != DecimalHandlingModeString ||
+				c.AvroBigintUnsignedHandlingMode != BigintUnsignedHandlingModeString {
 				return errors.ErrCodecInvalidConfig.GenWithStack(
 					`Avro protocol with row level checksum,
 					should set "%s" to "%s", and set "%s" to "%s" and "%s" to "%s"`,

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -270,7 +270,7 @@ func (c *csvMessage) formatValue(value any, strBuilder *strings.Builder) {
 			c.formatWithEscapes(v, strBuilder)
 		}
 	default:
-		strBuilder.WriteString(fmt.Sprintf("%v", v))
+		fmt.Fprintf(strBuilder, "%v", v)
 	}
 }
 

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -929,11 +929,12 @@ func TestRowChangeEventConversion(t *testing.T) {
 		}
 		e.TableInfo = commonType.WrapTableInfo("test", tidbTableInfo)
 
-		if idx%3 == 0 { // delete operation
+		switch idx % 3 {
+		case 0: // delete operation
 			e.Event.PreRow = chunk.MutRowFromValues(cols...).ToRow()
-		} else if idx%3 == 1 { // insert operation
+		case 1: // insert operation
 			e.Event.Row = chunk.MutRowFromValues(cols...).ToRow()
-		} else { // update operation
+		default: // update operation
 			e.Event.PreRow = chunk.MutRowFromValues(cols...).ToRow()
 			e.Event.Row = chunk.MutRowFromValues(cols...).ToRow()
 		}

--- a/pkg/sink/kafka/sarama_config_test.go
+++ b/pkg/sink/kafka/sarama_config_test.go
@@ -257,7 +257,7 @@ func TestApplySASL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			options := NewOptions()
@@ -328,7 +328,7 @@ func TestApplyTLS(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			options := NewOptions()

--- a/pkg/sink/kafka/sarama_config_test.go
+++ b/pkg/sink/kafka/sarama_config_test.go
@@ -257,7 +257,6 @@ func TestApplySASL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			options := NewOptions()
@@ -328,7 +327,6 @@ func TestApplyTLS(t *testing.T) {
 	}
 
 	for _, test := range tests {
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			options := NewOptions()

--- a/pkg/sink/mysql/mysql_writer_ddl.go
+++ b/pkg/sink/mysql/mysql_writer_ddl.go
@@ -45,7 +45,7 @@ func (w *Writer) execDDL(event *commonEvent.DDLEvent) error {
 		ddlTs := event.GetCommitTs()
 		flag, err := w.isDDLExecuted(tableID, ddlTs)
 		if err != nil {
-			return nil
+			return err
 		}
 		if flag {
 			log.Info("Skip Already Executed DDL", zap.String("sql", event.GetDDLQuery()))

--- a/pkg/sink/mysql/mysql_writer_dml_test.go
+++ b/pkg/sink/mysql/mysql_writer_dml_test.go
@@ -829,7 +829,7 @@ func TestAllRowInSameSafeMode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := allRowInSameSafeMode(tt.safemode, tt.events)

--- a/pkg/sink/mysql/mysql_writer_dml_test.go
+++ b/pkg/sink/mysql/mysql_writer_dml_test.go
@@ -829,7 +829,6 @@ func TestAllRowInSameSafeMode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := allRowInSameSafeMode(tt.safemode, tt.events)

--- a/pkg/sink/mysql/mysql_writer_for_syncpoint.go
+++ b/pkg/sink/mysql/mysql_writer_for_syncpoint.go
@@ -113,7 +113,7 @@ func (w *Writer) SendSyncPointEvent(event *commonEvent.SyncPointEvent) error {
 		builder.WriteString("' and changefeed = '")
 		builder.WriteString(w.ChangefeedID.String())
 		builder.WriteString("' and created_at < (NOW() - INTERVAL ")
-		builder.WriteString(fmt.Sprintf("%.2f", w.cfg.SyncPointRetention.Seconds()))
+		fmt.Fprintf(&builder, "%.2f", w.cfg.SyncPointRetention.Seconds())
 		builder.WriteString(" SECOND)")
 		query := builder.String()
 

--- a/pkg/sink/mysql/mysql_writer_test.go
+++ b/pkg/sink/mysql/mysql_writer_test.go
@@ -646,7 +646,7 @@ func TestMysqlWriter_AsyncDDL(t *testing.T) {
 	}
 
 	{
-		// ensure the dml can be writen succesfully before add index finished
+		// ensure the dml can be written successfully before add index finished
 		dmlEvent := helper.DML2Event("test", "t", "insert into t values (3, 'test3');")
 		dmlEvent.CommitTs = 3
 		dmlEvent.ReplicatingTs = 4

--- a/pkg/sink/mysql/sql_builder.go
+++ b/pkg/sink/mysql/sql_builder.go
@@ -45,12 +45,12 @@ func (d *preparedDMLs) LogWithoutValues() string {
 	// Calculate total count
 	totalCount := len(d.sqls)
 	var logBuilder strings.Builder
-	logBuilder.WriteString(fmt.Sprintf("Total SQL Count: %d, Row Count: %d,", totalCount, d.rowCount))
+	fmt.Fprintf(&logBuilder, "Total SQL Count: %d, Row Count: %d,", totalCount, d.rowCount)
 
 	// Build SQL statements and arguments section
 	for i, sql := range d.sqls {
 		// Add formatted SQL and args to log content
-		logBuilder.WriteString(fmt.Sprintf("[%03d] Query: %s,", i+1, sql))
+		fmt.Fprintf(&logBuilder, "[%03d] Query: %s,", i+1, sql)
 	}
 	logBuilder.WriteString("End")
 
@@ -72,7 +72,7 @@ func (d *preparedDMLs) LogDebug(events []*commonEvent.DMLEvent, writerID int) {
 
 	// Build complete log content in a single string
 	var logBuilder strings.Builder
-	logBuilder.WriteString(fmt.Sprintf("Total SQL Count: %d, Row Count: %d, Writer ID: %d :", totalCount, d.rowCount, writerID))
+	fmt.Fprintf(&logBuilder, "Total SQL Count: %d, Row Count: %d, Writer ID: %d :", totalCount, d.rowCount, writerID)
 
 	// Build SQL statements and arguments section
 	for i, sql := range d.sqls {
@@ -81,8 +81,8 @@ func (d *preparedDMLs) LogDebug(events []*commonEvent.DMLEvent, writerID int) {
 			args = d.values[i]
 		}
 
-		logBuilder.WriteString(fmt.Sprintf("[%03d] Query: %s,", i+1, sql))
-		logBuilder.WriteString(fmt.Sprintf("      Args: %s,", util.RedactArgs(args)))
+		fmt.Fprintf(&logBuilder, "[%03d] Query: %s,", i+1, sql)
+		fmt.Fprintf(&logBuilder, "      Args: %s,", util.RedactArgs(args))
 	}
 
 	// Build timestamp information
@@ -93,8 +93,8 @@ func (d *preparedDMLs) LogDebug(events []*commonEvent.DMLEvent, writerID int) {
 		startTsList[i] = event.GetStartTs()
 	}
 
-	logBuilder.WriteString(fmt.Sprintf("CommitTs: %v,", commitTsList))
-	logBuilder.WriteString(fmt.Sprintf("StartTs:  %v,", startTsList))
+	fmt.Fprintf(&logBuilder, "CommitTs: %v,", commitTsList)
+	fmt.Fprintf(&logBuilder, "StartTs:  %v,", startTsList)
 	logBuilder.WriteString("End")
 
 	// Output the complete log content in a single call
@@ -355,7 +355,7 @@ func buildActiveActiveUpsertSQL(
 		if i > 0 {
 			builder.WriteString(",")
 		}
-		builder.WriteString(fmt.Sprintf("%s = IF((%s), VALUES(%s), %s)", quoted, cond, quoted, quoted))
+		fmt.Fprintf(&builder, "%s = IF((%s), VALUES(%s), %s)", quoted, cond, quoted, quoted)
 	}
 
 	return builder.String(), args, common.RowTypeInsert

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -374,7 +374,7 @@ func (up *Upstream) registerTopologyInfo(ctx context.Context, cfg *NodeTopologyC
 	}
 	// register capture info to upstream pd
 	key := fmt.Sprintf(topologyTiCDC, cfg.GCServiceID, cfg.AdvertiseAddr)
-	value, err := cfg.Info.Marshal()
+	value, err := cfg.Marshal()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -54,7 +54,7 @@ func (m *mockPDClient) ServeHTTP(resp http.ResponseWriter, _ *http.Request) {
 	}
 
 	if m.getPDVersion != nil {
-		_, _ = resp.Write([]byte(fmt.Sprintf(`{"version":"%s"}`, m.getPDVersion())))
+		_, _ = fmt.Fprintf(resp, `{"version":"%s"}`, m.getPDVersion())
 	}
 }
 

--- a/pkg/workerpool/pool_test.go
+++ b/pkg/workerpool/pool_test.go
@@ -418,7 +418,7 @@ func TestCancelByAddEventContext(t *testing.T) {
 			for j := 0; j < 64; j++ {
 				err := handler.AddEvent(ctx, j)
 				if err != nil {
-					return nil
+					return err
 				}
 			}
 			return nil

--- a/server/server.go
+++ b/server/server.go
@@ -376,7 +376,7 @@ func (c *server) Run(ctx context.Context) error {
 	go func() {
 		<-gctx.Done()
 		time.Sleep(GracefulShutdownTimeout)
-		ch <- errors.ErrTimeout.FastGenByArgs("gracefull shutdown timeout")
+		ch <- errors.ErrTimeout.FastGenByArgs("graceful shutdown timeout")
 	}()
 	go func() {
 		ch <- g.Wait()

--- a/tests/integration_tests/api_v2/cases.go
+++ b/tests/integration_tests/api_v2/cases.go
@@ -416,7 +416,7 @@ func testSetLogLevel(ctx context.Context, client *CDCRESTClient) error {
 }
 
 func assertEmptyResponseBody(resp *Result) {
-	if "{}" != string(resp.body) {
+	if string(resp.body) != "{}" {
 		log.Panic("failed call api", zap.String("body", string(resp.body)))
 	}
 }

--- a/tests/integration_tests/cdc/dailytest/case.go
+++ b/tests/integration_tests/cdc/dailytest/case.go
@@ -275,7 +275,7 @@ func caseUpdateWhileDroppingCol(db *sql.DB) {
 		if i != 0 {
 			builder.WriteRune(',')
 		}
-		builder.WriteString(fmt.Sprintf("col%d VARCHAR(50) NOT NULL", i))
+		fmt.Fprintf(&builder, "col%d VARCHAR(50) NOT NULL", i)
 	}
 	createSQL := fmt.Sprintf(`
 CREATE TABLE many_cols (
@@ -290,7 +290,7 @@ CREATE TABLE many_cols (
 		if i != 0 {
 			builder.WriteRune(',')
 		}
-		builder.WriteString(fmt.Sprintf("col%d", i))
+		fmt.Fprintf(&builder, "col%d", i)
 	}
 	cols := builder.String()
 

--- a/tests/integration_tests/cdc/dailytest/parser.go
+++ b/tests/integration_tests/cdc/dailytest/parser.go
@@ -56,7 +56,8 @@ func (col *column) parseRule(kvs []string) {
 
 	key := strings.TrimSpace(kvs[0])
 	value := strings.TrimSpace(kvs[1])
-	if key == "range" {
+	switch key {
+	case "range":
 		fields := strings.Split(value, ",")
 		if len(fields) == 1 {
 			col.min = strings.TrimSpace(fields[0])
@@ -64,13 +65,13 @@ func (col *column) parseRule(kvs []string) {
 			col.min = strings.TrimSpace(fields[0])
 			col.max = strings.TrimSpace(fields[1])
 		}
-	} else if key == "step" {
+	case "step":
 		var err error
 		col.step, err = strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			log.S().Fatal(err)
 		}
-	} else if key == "set" {
+	case "set":
 		fields := strings.Split(value, ",")
 		for _, field := range fields {
 			col.set = append(col.set, strings.TrimSpace(field))

--- a/tests/integration_tests/default_value/main.go
+++ b/tests/integration_tests/default_value/main.go
@@ -875,7 +875,7 @@ func testMultiDDLs(srcs []*sql.DB, wg *sync.WaitGroup) {
 	}()
 
 	var wg1 sync.WaitGroup
-	// seperate every case to different table
+	// separate every case to different table
 	for i, unit := range Units {
 		wg1.Add(1)
 

--- a/tests/integration_tests/many_pk_or_uk/main.go
+++ b/tests/integration_tests/many_pk_or_uk/main.go
@@ -108,7 +108,7 @@ func runPKorUKcases(db *sql.DB) {
 		for j, pkOrUK := range []string{"UNIQUE NOT NULL", "PRIMARY KEY"} {
 			g.Add(1)
 			tableName := fmt.Sprintf("pk_or_uk_%d_%d", i, j)
-			pkOrUK := pkOrUK
+
 			c := c
 			go func() {
 				sql := fmt.Sprintf("CREATE TABLE %s(id %s %s)", tableName, c.Tp, pkOrUK)

--- a/tests/integration_tests/many_pk_or_uk/main.go
+++ b/tests/integration_tests/many_pk_or_uk/main.go
@@ -109,7 +109,6 @@ func runPKorUKcases(db *sql.DB) {
 			g.Add(1)
 			tableName := fmt.Sprintf("pk_or_uk_%d_%d", i, j)
 
-			c := c
 			go func() {
 				sql := fmt.Sprintf("CREATE TABLE %s(id %s %s)", tableName, c.Tp, pkOrUK)
 				util.MustExec(db, sql)

--- a/tests/integration_tests/multi_source/main.go
+++ b/tests/integration_tests/multi_source/main.go
@@ -210,7 +210,7 @@ func DropWithRecoverDDL(ctx context.Context, db *sql.DB) {
 			return
 		default:
 		}
-		// get a rand number bewteen 0 and 1
+		// get a rand number between 0 and 1
 		rand := time.Now().UnixNano() % 2
 		if rand == 0 {
 			util.MustExec(db, drop_sql)
@@ -343,14 +343,15 @@ func addDropColumnDDL(ctx context.Context, db *sql.DB) {
 		var notNULL string
 		var defaultValue interface{}
 
-		if value%5 == 0 {
+		switch value % 5 {
+		case 0:
 			// use default <value> not null
 			notNULL = "not null"
 			defaultValue = value
-		} else if value%5 == 1 {
+		case 1:
 			// use default null
 			defaultValue = nil
-		} else {
+		default:
 			// use default <value>
 			defaultValue = value
 		}
@@ -386,13 +387,14 @@ func addDropColumnDDL2(ctx context.Context, db *sql.DB) {
 		var defaultValue interface{}
 
 		strValue := strconv.Itoa(value)
-		if value%5 == 0 {
+		switch value % 5 {
+		case 0:
 			// use default <value>
 			defaultValue = strValue
-		} else if value%5 == 1 {
+		case 1:
 			// use default null
 			defaultValue = nil
-		} else {
+		default:
 			// use default <value> not null
 			notNULL = "not null"
 			defaultValue = strValue

--- a/tests/integration_tests/util/config.go
+++ b/tests/integration_tests/util/config.go
@@ -82,8 +82,8 @@ func (c *Config) Parse(arguments []string) error {
 		return errors.Trace(err)
 	}
 
-	if len(c.FlagSet.Args()) != 0 {
-		return errors.Errorf("'%s' is an invalid flag", c.FlagSet.Arg(0))
+	if len(c.Args()) != 0 {
+		return errors.Errorf("'%s' is an invalid flag", c.Arg(0))
 	}
 
 	return nil

--- a/utils/chann/unlimited_chann.go
+++ b/utils/chann/unlimited_chann.go
@@ -173,10 +173,8 @@ func (c *UnlimitedChannel[T, G]) getMultiple(gmt getMultType, buffer []T, batchB
 
 	switch gmt {
 	case getMultNoGroup:
-		for {
-			if len(buffer) >= cap || bytes >= maxBytes {
-				break
-			}
+		for len(buffer) < cap && bytes < maxBytes {
+
 			v, ok := c.queue.PopFront()
 			if !ok {
 				break

--- a/utils/threadpool/thread_pool_test.go
+++ b/utils/threadpool/thread_pool_test.go
@@ -109,7 +109,7 @@ func (t *longRunTask) Execute() time.Time {
 func TestThreadPoolTiming(t *testing.T) {
 	msgChan := make(chan TaskId, 1000)
 	var wg sync.WaitGroup
-	var countDown = 0
+	countDown := 0
 
 	ts := newThreadPoolImpl(1)
 	// To make the scheduler stop executing any tasks

--- a/utils/threadpool/thread_pool_test.go
+++ b/utils/threadpool/thread_pool_test.go
@@ -109,7 +109,7 @@ func (t *longRunTask) Execute() time.Time {
 func TestThreadPoolTiming(t *testing.T) {
 	msgChan := make(chan TaskId, 1000)
 	var wg sync.WaitGroup
-	var countDown int = 0
+	var countDown = 0
 
 	ts := newThreadPoolImpl(1)
 	// To make the scheduler stop executing any tasks


### PR DESCRIPTION
Issue Number: close #5034

### What problem does this PR solve?

Part of the 4-PR plan (tracked in #5032) to fix all golangci-lint issues. This PR fixes auto-fixable issues (`--fix`) plus selected mechanical non-auto-fixable bugs.

### What is changed and how it works?

**Auto-fixed (no manual changes):**
- `copyloopvar` (12): remove redundant `x := x` in Go 1.22+ loop variables
- `misspell` (13): fix typos in comments and strings
- `nosprintfhostport` (auto): use `net.JoinHostPort` instead of `Sprintf`
- `govet` (1): fix `WriteHeader` order in oauth2-server, use `http.StatusOK` constant

**Manual fixes:**
- `ineffassign` (2): remove dead assignments in `consumer.go`, `drop_event.go`
- `nilerr` (3): return `err` instead of `nil` in `file.go`, `mysql_writer_ddl.go`, `pool_test.go`
  - `pkg/redo/writer/file/file.go`: `flushAndRotateFile` has already flushed the local file, but external-storage mode still needs `rotate()` to rename/sync the file, upload it to external storage, and open the next file. Swallowing a `rotate()` error would make `Flush()` look successful and can trigger redo `PostFlush()` before the log is durable in external storage, so returning the error is the safer and correct behavior.
  - `pkg/sink/mysql/mysql_writer_ddl.go`: `isDDLExecuted` guards non-idempotent `ExchangeTablePartition` DDLs. If the check fails, treating it as success can skip the actual DDL while later code may still advance ddl-ts metadata and call `PostFlush()`. Returning the error lets the existing DDL retry/error path preserve downstream correctness.
- `durationcheck` (1): avoid multiplying two `time.Duration` values in `sync_point.go`
- log key consistency: `"commits"` → `"commitTs"` in `barrier.go`

**Skipped (false positives or need design):**
- `errname`: renaming error types touches 8+ files — deferred to follow-up
- `govet` (remaining): `testinggoroutine`, `copylocks` need design decisions
- `unconvert`: platform-dependent type conversions

### Check List

Tests:
 - Unit test: `go build ./...` passes

Code changes:
 - Has Go code changes
 - Does not change `pkg/errors` imports (deferred to PR 3)

Related changes:
 - PR 1 (merged): #5024
 - Tracking issue: #5032

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Corrected error propagation in redo log file rotation when using external storage.
  * Fixed error handling for DDL execution status checks.

* **Refactor**
  * Improved code maintainability through loop and conditional statement restructuring across multiple components.
  * Optimized string formatting operations for better performance.

* **Tests**
  * Enhanced test suite reliability by removing loop variable shadowing patterns in parallel test execution.

* **Documentation**
  * Corrected various spelling and comment inaccuracies throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->