### PR TITLE
scheduler: limit merge operators per split table group

### DIFF
--- a/maintainer/replica/split_span_checker.go
+++ b/maintainer/replica/split_span_checker.go
@@ -46,8 +46,10 @@ var (
 	minTrafficBalanceThreshold         = float64(1024 * 1024) // 1MB
 	maxMoveSpansCountForTrafficBalance = 4
 	maxMoveSpansCountForMerge          = 16
-	maxLagThreshold                    = float64(30) // 30s
-	mergeThreshold                     = 5
+	// maxMergeOperatorsPerGroup limits how many merge operators one split-table group can create per check.
+	maxMergeOperatorsPerGroup = 8
+	maxLagThreshold           = float64(30) // 30s
+	mergeThreshold            = 5
 )
 
 type BalanceCause string
@@ -765,6 +767,7 @@ func (s *SplitSpanChecker) isTrafficBalanceMaintained(
 func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckResult, []*splitSpanStatus) {
 	log.Debug("chooseMergedSpans try to choose merge spans", zap.Any("changefeedID", s.changefeedID), zap.Any("groupID", s.groupID))
 	results := make([]SplitSpanCheckResult, 0)
+	mergeBatchSize := min(batchSize, maxMergeOperatorsPerGroup)
 
 	sortedSpanByStartKey := make([]*splitSpanStatus, 0, len(s.allTasks))
 	for _, status := range s.allTasks {
@@ -782,19 +785,28 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 	traffic := prev.lastThreeTraffic[latestTrafficIndex]
 	mergeSpans = append(mergeSpans, prev.SpanReplication)
 
-	submitAndClear := func(cur *splitSpanStatus) {
-		if len(mergeSpans) > 1 {
-			log.Info("chooseMergedSpans merge spans",
-				zap.String("changefeed", s.changefeedID.String()),
-				zap.Int64("group", int64(s.groupID)),
-				zap.Any("mergeSpans", mergeSpans),
-				zap.Any("node", mergeSpans[0].GetNodeID()),
-			)
-			results = append(results, SplitSpanCheckResult{
-				OpType:     OpMerge,
-				MergeSpans: append([]*SpanReplication{}, mergeSpans...),
-			})
+	appendMergeResult := func() bool {
+		if len(mergeSpans) <= 1 {
+			return len(results) >= mergeBatchSize
 		}
+		if len(results) >= mergeBatchSize {
+			return true
+		}
+		log.Info("chooseMergedSpans merge spans",
+			zap.String("changefeed", s.changefeedID.String()),
+			zap.Int64("group", int64(s.groupID)),
+			zap.Any("mergeSpans", mergeSpans),
+			zap.Any("node", mergeSpans[0].GetNodeID()),
+		)
+		results = append(results, SplitSpanCheckResult{
+			OpType:     OpMerge,
+			MergeSpans: append([]*SpanReplication{}, mergeSpans...),
+		})
+		return len(results) >= mergeBatchSize
+	}
+
+	submitAndClear := func(cur *splitSpanStatus) {
+		appendMergeResult()
 		mergeSpans = mergeSpans[:0]
 		mergeSpans = append(mergeSpans, cur.SpanReplication)
 		regionCount = cur.regionCount
@@ -817,6 +829,9 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 		// not in the same node, can't merge
 		if prev.GetNodeID() != cur.GetNodeID() {
 			submitAndClear(cur)
+			if len(results) >= mergeBatchSize {
+				return results, sortedSpanByStartKey
+			}
 			prev = cur
 			idx++
 			continue
@@ -825,6 +840,9 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 		// we can't merge if beyond the threshold
 		if s.regionThreshold > 0 && regionCount+cur.regionCount > s.regionThreshold/4*3 {
 			submitAndClear(cur)
+			if len(results) >= mergeBatchSize {
+				return results, sortedSpanByStartKey
+			}
 			prev = cur
 			idx++
 			continue
@@ -832,6 +850,9 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 
 		if s.writeThreshold > 0 && traffic+cur.lastThreeTraffic[latestTrafficIndex] > float64(s.writeThreshold)/4*3 {
 			submitAndClear(cur)
+			if len(results) >= mergeBatchSize {
+				return results, sortedSpanByStartKey
+			}
 			prev = cur
 			idx++
 			continue
@@ -845,23 +866,12 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 		prev = cur
 		idx++
 
-		if len(results) >= batchSize {
+		if len(results) >= mergeBatchSize {
 			return results, sortedSpanByStartKey
 		}
 	}
 
-	if len(mergeSpans) > 1 {
-		log.Info("chooseMergedSpans merge spans",
-			zap.String("changefeed", s.changefeedID.String()),
-			zap.Int64("group", s.groupID),
-			zap.Any("mergeSpans", mergeSpans),
-			zap.Any("node", mergeSpans[0].GetNodeID()),
-		)
-		results = append(results, SplitSpanCheckResult{
-			OpType:     OpMerge,
-			MergeSpans: mergeSpans,
-		})
-	}
+	appendMergeResult()
 
 	return results, sortedSpanByStartKey
 }

--- a/maintainer/replica/split_span_checker.go
+++ b/maintainer/replica/split_span_checker.go
@@ -47,6 +47,7 @@ var (
 	maxMoveSpansCountForTrafficBalance = 4
 	maxMoveSpansCountForMerge          = 16
 	// maxMergeOperatorsPerGroup limits how many merge operators one split-table group can create per check.
+	// The value limits concurrent incremental scan tasks while still making merge progress each scheduler round.
 	maxMergeOperatorsPerGroup = 8
 	maxLagThreshold           = float64(30) // 30s
 	mergeThreshold            = 5
@@ -318,7 +319,7 @@ func (s *SplitSpanChecker) Check(batch int) replica.GroupCheckResult {
 	if !s.checkAllTaskAvailableLocked() {
 		log.Debug("some task is not available, skip check",
 			zap.String("changefeed", s.changefeedID.String()),
-			zap.Int64("group", int64(s.groupID)),
+			zap.Int64("group", s.groupID),
 		)
 		return results
 	}
@@ -390,7 +391,7 @@ func (s *SplitSpanChecker) Check(batch int) replica.GroupCheckResult {
 	if s.regionThreshold > 0 {
 		countByRegion := int(math.Ceil(float64(totalRegionCount) / float64(s.regionThreshold)))
 		if countByRegion > upperSpanCount {
-			upperSpanCount = int(countByRegion)
+			upperSpanCount = countByRegion
 		}
 	}
 
@@ -787,14 +788,14 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 
 	appendMergeResult := func() bool {
 		if len(mergeSpans) <= 1 {
-			return len(results) >= mergeBatchSize
+			return false
 		}
 		if len(results) >= mergeBatchSize {
 			return true
 		}
 		log.Info("chooseMergedSpans merge spans",
 			zap.String("changefeed", s.changefeedID.String()),
-			zap.Int64("group", int64(s.groupID)),
+			zap.Int64("group", s.groupID),
 			zap.Any("mergeSpans", mergeSpans),
 			zap.Any("node", mergeSpans[0].GetNodeID()),
 		)

--- a/maintainer/replica/split_span_checker.go
+++ b/maintainer/replica/split_span_checker.go
@@ -805,12 +805,13 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 		return len(results) >= mergeBatchSize
 	}
 
-	submitAndClear := func(cur *splitSpanStatus) {
-		appendMergeResult()
+	submitAndClear := func(cur *splitSpanStatus) bool {
+		reachedLimit := appendMergeResult()
 		mergeSpans = mergeSpans[:0]
 		mergeSpans = append(mergeSpans, cur.SpanReplication)
 		regionCount = cur.regionCount
 		traffic = cur.lastThreeTraffic[latestTrafficIndex]
+		return reachedLimit
 	}
 
 	idx := 1
@@ -828,8 +829,7 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 		}
 		// not in the same node, can't merge
 		if prev.GetNodeID() != cur.GetNodeID() {
-			submitAndClear(cur)
-			if len(results) >= mergeBatchSize {
+			if submitAndClear(cur) {
 				return results, sortedSpanByStartKey
 			}
 			prev = cur
@@ -839,8 +839,7 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 
 		// we can't merge if beyond the threshold
 		if s.regionThreshold > 0 && regionCount+cur.regionCount > s.regionThreshold/4*3 {
-			submitAndClear(cur)
-			if len(results) >= mergeBatchSize {
+			if submitAndClear(cur) {
 				return results, sortedSpanByStartKey
 			}
 			prev = cur
@@ -849,8 +848,7 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 		}
 
 		if s.writeThreshold > 0 && traffic+cur.lastThreeTraffic[latestTrafficIndex] > float64(s.writeThreshold)/4*3 {
-			submitAndClear(cur)
-			if len(results) >= mergeBatchSize {
+			if submitAndClear(cur) {
 				return results, sortedSpanByStartKey
 			}
 			prev = cur
@@ -865,10 +863,6 @@ func (s *SplitSpanChecker) chooseMergedSpans(batchSize int) ([]SplitSpanCheckRes
 
 		prev = cur
 		idx++
-
-		if len(results) >= mergeBatchSize {
-			return results, sortedSpanByStartKey
-		}
 	}
 
 	appendMergeResult()

--- a/maintainer/replica/split_span_checker_test.go
+++ b/maintainer/replica/split_span_checker_test.go
@@ -994,6 +994,110 @@ func TestSplitSpanChecker_ChooseMergedSpans_Continuous(t *testing.T) {
 	require.Contains(t, mergeResult.MergeSpans, replicas[2])
 }
 
+func TestSplitSpanChecker_ChooseMergedSpans_LimitsMergeResultsPerGroup(t *testing.T) {
+	testutil.SetUpTestServices(t)
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+
+	schedulerCfg := &config.ChangefeedSchedulerConfig{
+		WriteKeyThreshold:     util.AddressOf(1000),
+		RegionThreshold:       util.AddressOf(20),
+		BalanceScoreThreshold: util.AddressOf(1),
+		MinTrafficPercentage:  util.AddressOf(0.8),
+		MaxTrafficPercentage:  util.AddressOf(1.2),
+	}
+
+	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
+	nodeManager.GetAliveNodes()["node1"] = node.NewInfo("node1", "127.0.0.1:8300")
+	nodeManager.GetAliveNodes()["node2"] = node.NewInfo("node2", "127.0.0.1:8301")
+
+	replicas := createTestSplitSpanReplications(cfID, 100000, 18)
+	groupID := replicas[0].GetGroupID()
+	checker := newTestSplitChecker(t, cfID, groupID, schedulerCfg)
+
+	for _, replica := range replicas {
+		checker.AddReplica(replica)
+	}
+
+	currentTime := time.Now()
+	for idx, replica := range replicas {
+		if idx%4 < 2 {
+			replica.SetNodeID("node1")
+		} else {
+			replica.SetNodeID("node2")
+		}
+
+		spanStatus := checker.allTasks[replica.ID]
+		spanStatus.trafficScore = 0
+		spanStatus.regionCount = 3
+		spanStatus.lastThreeTraffic = []float64{200, 200, 200}
+		replica.UpdateStatus(&heartbeatpb.TableSpanStatus{
+			ID:                 replica.ID.ToPB(),
+			ComponentStatus:    heartbeatpb.ComponentState_Working,
+			EventSizePerSecond: 200,
+			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+		})
+	}
+
+	results := checker.Check(20)
+	require.Len(t, results, 8)
+	for _, result := range results.([]SplitSpanCheckResult) {
+		require.Equal(t, OpMerge, result.OpType)
+		require.Len(t, result.MergeSpans, 2)
+	}
+}
+
+func TestSplitSpanChecker_ChooseMergedSpans_RespectsBatchSizeBelowMergeLimit(t *testing.T) {
+	testutil.SetUpTestServices(t)
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+
+	schedulerCfg := &config.ChangefeedSchedulerConfig{
+		WriteKeyThreshold:     util.AddressOf(1000),
+		RegionThreshold:       util.AddressOf(20),
+		BalanceScoreThreshold: util.AddressOf(1),
+		MinTrafficPercentage:  util.AddressOf(0.8),
+		MaxTrafficPercentage:  util.AddressOf(1.2),
+	}
+
+	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
+	nodeManager.GetAliveNodes()["node1"] = node.NewInfo("node1", "127.0.0.1:8300")
+	nodeManager.GetAliveNodes()["node2"] = node.NewInfo("node2", "127.0.0.1:8301")
+
+	replicas := createTestSplitSpanReplications(cfID, 100000, 8)
+	groupID := replicas[0].GetGroupID()
+	checker := newTestSplitChecker(t, cfID, groupID, schedulerCfg)
+
+	for _, replica := range replicas {
+		checker.AddReplica(replica)
+	}
+
+	currentTime := time.Now()
+	for idx, replica := range replicas {
+		if idx%4 < 2 {
+			replica.SetNodeID("node1")
+		} else {
+			replica.SetNodeID("node2")
+		}
+
+		spanStatus := checker.allTasks[replica.ID]
+		spanStatus.trafficScore = 0
+		spanStatus.regionCount = 3
+		spanStatus.lastThreeTraffic = []float64{200, 200, 200}
+		replica.UpdateStatus(&heartbeatpb.TableSpanStatus{
+			ID:                 replica.ID.ToPB(),
+			ComponentStatus:    heartbeatpb.ComponentState_Working,
+			EventSizePerSecond: 200,
+			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+		})
+	}
+
+	results := checker.Check(3)
+	require.Len(t, results, 3)
+	for _, result := range results.([]SplitSpanCheckResult) {
+		require.Equal(t, OpMerge, result.OpType)
+		require.Len(t, result.MergeSpans, 2)
+	}
+}
+
 func TestSplitSpanChecker_ChooseMoveSpans_SimpleMove(t *testing.T) {
 	testutil.SetUpTestServices(t)
 	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)

--- a/maintainer/replica/split_span_checker_test.go
+++ b/maintainer/replica/split_span_checker_test.go
@@ -664,7 +664,7 @@ func TestSplitSpanChecker_CheckBalanceTraffic_Balance(t *testing.T) {
 	// Set region counts
 	for _, spanStatus := range []*splitSpanStatus{spanStatus1, spanStatus2, spanStatus3, spanStatus4} {
 		spanStatus.regionCount = 3
-		spanStatus.GetStatus().CheckpointTs = oracle.ComposeTS(int64(time.Now().Add(-10*time.Second).UnixMilli()), 0)
+		spanStatus.GetStatus().CheckpointTs = oracle.ComposeTS(time.Now().Add(-10*time.Second).UnixMilli(), 0)
 	}
 	checker.balanceCondition.statusUpdated = true
 
@@ -766,9 +766,9 @@ func TestSplitSpanChecker_CheckBalanceTraffic_SplitIfNoMove(t *testing.T) {
 
 	// Set region counts
 	spanStatus1.regionCount = 5
-	spanStatus1.GetStatus().CheckpointTs = oracle.ComposeTS(int64(time.Now().Add(-10*time.Second).UnixMilli()), 0)
+	spanStatus1.GetStatus().CheckpointTs = oracle.ComposeTS(time.Now().Add(-10*time.Second).UnixMilli(), 0)
 	spanStatus2.regionCount = 5
-	spanStatus2.GetStatus().CheckpointTs = oracle.ComposeTS(int64(time.Now().Add(-10*time.Second).UnixMilli()), 0)
+	spanStatus2.GetStatus().CheckpointTs = oracle.ComposeTS(time.Now().Add(-10*time.Second).UnixMilli(), 0)
 
 	checker.balanceCondition.statusUpdated = true
 
@@ -977,7 +977,7 @@ func TestSplitSpanChecker_ChooseMergedSpans_Continuous(t *testing.T) {
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 200,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		}
 		replica.UpdateStatus(status)
 	}
@@ -1034,7 +1034,7 @@ func TestSplitSpanChecker_ChooseMergedSpans_LimitsMergeResultsPerGroup(t *testin
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 200,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		})
 	}
 
@@ -1086,7 +1086,7 @@ func TestSplitSpanChecker_ChooseMergedSpans_RespectsBatchSizeBelowMergeLimit(t *
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 200,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		})
 	}
 
@@ -1096,6 +1096,40 @@ func TestSplitSpanChecker_ChooseMergedSpans_RespectsBatchSizeBelowMergeLimit(t *
 		require.Equal(t, OpMerge, result.OpType)
 		require.Len(t, result.MergeSpans, 2)
 	}
+}
+
+func TestSplitSpanChecker_ChooseMergedSpans_ZeroBatchReturnsNoResults(t *testing.T) {
+	testutil.SetUpTestServices(t)
+	cfID := common.NewChangeFeedIDWithName("test", common.DefaultKeyspaceName)
+
+	schedulerCfg := &config.ChangefeedSchedulerConfig{
+		WriteKeyThreshold:     util.AddressOf(1000),
+		RegionThreshold:       util.AddressOf(20),
+		BalanceScoreThreshold: util.AddressOf(1),
+		MinTrafficPercentage:  util.AddressOf(0.8),
+		MaxTrafficPercentage:  util.AddressOf(1.2),
+	}
+
+	nodeManager := appcontext.GetService[*watcher.NodeManager](watcher.NodeManagerName)
+	nodeManager.GetAliveNodes()["node1"] = node.NewInfo("node1", "127.0.0.1:8300")
+
+	replicas := createTestSplitSpanReplications(cfID, 100000, 2)
+	groupID := replicas[0].GetGroupID()
+	checker := newTestSplitChecker(t, cfID, groupID, schedulerCfg)
+
+	for _, replica := range replicas {
+		checker.AddReplica(replica)
+		replica.SetNodeID("node1")
+
+		spanStatus := checker.allTasks[replica.ID]
+		spanStatus.trafficScore = 0
+		spanStatus.regionCount = 3
+		spanStatus.lastThreeTraffic = []float64{200, 200, 200}
+	}
+
+	results, sortedSpans := checker.chooseMergedSpans(0)
+	require.Empty(t, results)
+	require.Len(t, sortedSpans, len(replicas))
 }
 
 func TestSplitSpanChecker_ChooseMoveSpans_SimpleMove(t *testing.T) {
@@ -1151,7 +1185,7 @@ func TestSplitSpanChecker_ChooseMoveSpans_SimpleMove(t *testing.T) {
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 200,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		}
 		replica.UpdateStatus(status)
 	}
@@ -1213,7 +1247,7 @@ func TestSplitSpanChecker_ChooseMoveSpans_ExchangeMove(t *testing.T) {
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 100,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		}
 		replica.UpdateStatus(status)
 	}
@@ -1291,7 +1325,7 @@ func TestSplitSpanChecker_Check_FullFlow(t *testing.T) {
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 200,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		}
 		replica.UpdateStatus(status)
 	}
@@ -1367,7 +1401,7 @@ func TestSplitSpanChecker_Check_FullFlow_WriteThresholdZero(t *testing.T) {
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 200,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		}
 		replica.UpdateStatus(status)
 	}
@@ -1443,7 +1477,7 @@ func TestSplitSpanChecker_Check_FullFlow_RegionThresholdZero(t *testing.T) {
 			ID:                 replica.ID.ToPB(),
 			ComponentStatus:    heartbeatpb.ComponentState_Working,
 			EventSizePerSecond: 0,
-			CheckpointTs:       oracle.ComposeTS(int64(currentTime.Add(-10*time.Second).UnixMilli()), 0),
+			CheckpointTs:       oracle.ComposeTS(currentTime.Add(-10*time.Second).UnixMilli(), 0),
 		}
 		replica.UpdateStatus(status)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5047

For split tables, a single split span checker run can produce many merge operators. Each merge operator creates a merged dispatcher and can trigger incremental scan work in TiCDC. Creating too many merge operators at once may start a large number of incremental scan tasks and saturate CPU.

### What is changed and how it works?

This PR limits local merge candidates produced by one split table group in one checker run to 8 merge operators.

The checker now derives a merge batch size from the scheduler batch and the new per-group cap:

- `min(batchSize, maxMergeOperatorsPerGroup)`

This preserves smaller scheduler batch limits while preventing a single group from emitting too many merge operators in one scheduling round. The limit applies only to `chooseMergedSpans`; whole-group merge still produces at most one merge operation, and move-for-merge behavior is unchanged.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This reduces merge scheduling concurrency for split table groups and keeps existing scheduler batch limits when they are lower than the new cap.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This is an internal scheduling guardrail and does not add a user-facing configuration.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Limit split table merge scheduling to at most 8 merge operators per group in one checker run to reduce incremental scan CPU spikes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cap the number of merge operations emitted per check to make merge behavior more predictable; now stops scanning once the per-check limit is reached and always flushes any pending merge group.
  * Minor logging and type-cleanup improvements.

* **Tests**
  * Added tests verifying per-check merge caps, respect for batch-size limits, and zero-batch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5048)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->