### PR TITLE
redo, event: preserve table route target names in redo log

### DIFF
--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -159,7 +159,7 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 		}
 		log.Info("redo sink send DDL event",
 			zap.String("keyspace", s.changefeedID.Keyspace()), zap.String("changefeed", s.changefeedID.Name()),
-			zap.Any("event", e.GetDDLQuery()), zap.Any("startTs", event.GetStartTs()), zap.Any("commitTs", event.GetCommitTs()),
+			zap.Any("query", e.GetDDLQuery()), zap.Any("startTs", event.GetStartTs()), zap.Any("commitTs", event.GetCommitTs()),
 			zap.String("schema", e.GetSchemaName()), zap.String("table", e.GetTableName()), zap.Int64("tableID", e.GetTableID()))
 	}
 	return nil
@@ -170,6 +170,11 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 	events := make([]*commonEvent.RedoRowEvent, 0, rowsCount)
 	rowCallback := helper.NewTxnPostFlushRowCallback(event, uint64(rowsCount))
 
+	var (
+		startTs         = event.GetStartTs()
+		commitTs        = event.GetCommitTs()
+		physicalTableID = event.GetTableID()
+	)
 	for {
 		row, ok := event.GetNextRow()
 		if !ok {
@@ -177,10 +182,10 @@ func (s *Sink) AddDMLEvent(event *commonEvent.DMLEvent) {
 			break
 		}
 		events = append(events, &commonEvent.RedoRowEvent{
-			StartTs:         event.StartTs,
-			CommitTs:        event.CommitTs,
+			StartTs:         startTs,
+			CommitTs:        commitTs,
 			Event:           row,
-			PhysicalTableID: event.PhysicalTableID,
+			PhysicalTableID: physicalTableID,
 			TableInfo:       event.TableInfo,
 			Callback:        rowCallback,
 		})

--- a/downstreamadapter/sink/redo/sink.go
+++ b/downstreamadapter/sink/redo/sink.go
@@ -159,7 +159,7 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 		}
 		log.Info("redo sink send DDL event",
 			zap.String("keyspace", s.changefeedID.Keyspace()), zap.String("changefeed", s.changefeedID.Name()),
-			zap.Any("query", e.GetDDLQuery()), zap.Any("startTs", event.GetStartTs()), zap.Any("commitTs", event.GetCommitTs()),
+			zap.String("query", e.GetDDLQuery()), zap.Any("startTs", event.GetStartTs()), zap.Any("commitTs", event.GetCommitTs()),
 			zap.String("schema", e.GetSchemaName()), zap.String("table", e.GetTableName()), zap.Int64("tableID", e.GetTableID()))
 	}
 	return nil

--- a/pkg/common/event/ddl_event.go
+++ b/pkg/common/event/ddl_event.go
@@ -354,10 +354,6 @@ func (e *DDLEvent) GetUpdatedSchemas() []SchemaIDChange {
 }
 
 func (e *DDLEvent) GetDDLQuery() string {
-	if e == nil {
-		log.Error("DDLEvent is nil, should not happened in production env", zap.Any("event", e))
-		return ""
-	}
 	return e.Query
 }
 

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -19,10 +19,10 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/util"
-	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	tiTypes "github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"go.uber.org/zap"
 )
@@ -133,13 +133,11 @@ func (r *RedoRowEvent) PostFlush() {
 }
 
 func (r *RedoRowEvent) ToRedoLog() *RedoLog {
-	startTs := r.StartTs
-	commitTs := r.CommitTs
 	redoLog := &RedoLog{
 		RedoRow: &RedoDMLEvent{
 			Row: &DMLEventInRedoLog{
-				StartTs:      startTs,
-				CommitTs:     commitTs,
+				StartTs:      r.StartTs,
+				CommitTs:     r.CommitTs,
 				Table:        nil,
 				Columns:      nil,
 				PreColumns:   nil,
@@ -245,24 +243,8 @@ func (d *DDLEvent) ToRedoLog() *RedoLog {
 		redoLog.RedoDDL.TableName.IsPartition = d.TableInfo.TableName.IsPartition
 	}
 
-	schemaName := d.GetTargetSchemaName()
-	tableName := d.GetTargetTableName()
-	if d.TableInfo != nil {
-		if targetSchema := d.TableInfo.GetTargetSchemaName(); targetSchema != "" {
-			schemaName = targetSchema
-		}
-		if targetTable := d.TableInfo.GetTargetTableName(); targetTable != "" {
-			tableName = targetTable
-		}
-	}
-	if schemaName != "" || tableName != "" {
-		redoLog.RedoDDL.TableName = common.TableName{
-			Schema:      schemaName,
-			Table:       tableName,
-			TableID:     redoLog.RedoDDL.TableName.TableID,
-			IsPartition: redoLog.RedoDDL.TableName.IsPartition,
-		}
-	}
+	redoLog.RedoDDL.TableName.Schema = d.GetTargetSchemaName()
+	redoLog.RedoDDL.TableName.Table = d.GetTargetTableName()
 
 	return redoLog
 }
@@ -302,7 +284,7 @@ func (r *RedoDMLEvent) ToDMLEvent() *DMLEvent {
 			zap.Any("columns", r.Row.Columns), zap.Any("columnsValue", r.Columns),
 		)
 	}
-	tidbTableInfo := &timodel.TableInfo{
+	tidbTableInfo := &model.TableInfo{
 		ID:   r.Row.Table.TableID,
 		Name: ast.NewCIStr(r.Row.Table.Table),
 	}
@@ -313,10 +295,10 @@ func (r *RedoDMLEvent) ToDMLEvent() *DMLEvent {
 		rawColsValue = r.PreColumns
 	}
 	for idx, col := range rawCols {
-		colInfo := &timodel.ColumnInfo{
+		colInfo := &model.ColumnInfo{
 			ID:    int64(idx),
 			Name:  ast.NewCIStr(col.Name),
-			State: timodel.StatePublic,
+			State: model.StatePublic,
 		}
 		colInfo.SetType(col.Type)
 		colInfo.SetCharset(col.Charset)
@@ -346,9 +328,9 @@ func (r *RedoDMLEvent) ToDMLEvent() *DMLEvent {
 		tidbTableInfo.Columns = append(tidbTableInfo.Columns, colInfo)
 	}
 	for i, index := range r.Row.IndexColumns {
-		indexInfo := &timodel.IndexInfo{
+		indexInfo := &model.IndexInfo{
 			Name:  ast.NewCIStr(fmt.Sprintf("index_%d", i)),
-			State: timodel.StatePublic,
+			State: model.StatePublic,
 		}
 		firstCol := tidbTableInfo.Columns[index[0]]
 		if mysql.HasPriKeyFlag(firstCol.GetFlag()) || mysql.HasUniKeyFlag(firstCol.GetFlag()) {
@@ -361,7 +343,7 @@ func (r *RedoDMLEvent) ToDMLEvent() *DMLEvent {
 			if col == nil || !mysql.HasPriKeyFlag(firstCol.GetFlag()) {
 				isPrimary = false
 			}
-			indexInfo.Columns = append(indexInfo.Columns, &timodel.IndexColumn{
+			indexInfo.Columns = append(indexInfo.Columns, &model.IndexColumn{
 				Name:   ast.NewCIStr(rawCols[id].Name),
 				Offset: id,
 			})
@@ -409,11 +391,11 @@ func (r *RedoDDLEvent) ToDDLEvent() *DDLEvent {
 		blockedTables = &InfluencedTables{InfluenceType: InfluenceTypeNormal}
 		blockedTableNames = []SchemaTableName{{SchemaName: schemaName, TableName: tableName}}
 	}
-	columns := make([]*timodel.ColumnInfo, 0, len(r.DDL.Columns))
+	columns := make([]*model.ColumnInfo, 0, len(r.DDL.Columns))
 	for _, col := range r.DDL.Columns {
-		colInfo := &timodel.ColumnInfo{
+		colInfo := &model.ColumnInfo{
 			Name:    ast.NewCIStr(col.Name),
-			State:   timodel.StatePublic,
+			State:   model.StatePublic,
 			Version: col.Version,
 		}
 		colInfo.SetType(col.Type)
@@ -425,7 +407,7 @@ func (r *RedoDDLEvent) ToDDLEvent() *DDLEvent {
 		}
 		columns = append(columns, colInfo)
 	}
-	tableInfo := common.WrapTableInfo(schemaName, &timodel.TableInfo{
+	tableInfo := common.WrapTableInfo(schemaName, &model.TableInfo{
 		ID:      r.TableName.TableID,
 		Name:    ast.NewCIStr(tableName),
 		Columns: columns,
@@ -452,7 +434,7 @@ func (r *RedoDDLEvent) SetTableSchemaStore(tableSchemaStore *TableSchemaStore) {
 	}
 }
 
-func parseColumnValue(row *chunk.Row, colInfo *timodel.ColumnInfo, i int, isHandleKey bool) RedoColumnValue {
+func parseColumnValue(row *chunk.Row, colInfo *model.ColumnInfo, i int, isHandleKey bool) RedoColumnValue {
 	v := common.ExtractColVal(row, colInfo, i)
 	switch colInfo.GetType() {
 	case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar,
@@ -472,7 +454,7 @@ func parseColumnValue(row *chunk.Row, colInfo *timodel.ColumnInfo, i int, isHand
 }
 
 // For compatibility
-func convertFlag(colInfo *timodel.ColumnInfo, isHandleKey bool) uint64 {
+func convertFlag(colInfo *model.ColumnInfo, isHandleKey bool) uint64 {
 	var flag common.ColumnFlagType
 	if isHandleKey {
 		flag.SetIsHandleKey()
@@ -515,13 +497,13 @@ func getIndexColumns(tableInfo *common.TableInfo) [][]int {
 	return indexColumns
 }
 
-func collectAllColumnsValue(data []RedoColumnValue, columns []*timodel.ColumnInfo, chk *chunk.Chunk) {
+func collectAllColumnsValue(data []RedoColumnValue, columns []*model.ColumnInfo, chk *chunk.Chunk) {
 	for idx := range data {
 		appendCol2Chunk(idx, data[idx].Value, columns[idx].FieldType, chk)
 	}
 }
 
-func appendCol2Chunk(idx int, raw any, ft tiTypes.FieldType, chk *chunk.Chunk) {
+func appendCol2Chunk(idx int, raw any, ft types.FieldType, chk *chunk.Chunk) {
 	if raw == nil {
 		chk.AppendNull(idx)
 		return
@@ -552,35 +534,35 @@ func appendCol2Chunk(idx int, raw any, ft tiTypes.FieldType, chk *chunk.Chunk) {
 		mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
 		chk.AppendBytes(idx, raw.([]byte))
 	case mysql.TypeNewDecimal:
-		chk.AppendMyDecimal(idx, tiTypes.NewDecFromStringForTest(raw.(string)))
+		chk.AppendMyDecimal(idx, types.NewDecFromStringForTest(raw.(string)))
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
-		val, err := tiTypes.ParseTime(tiTypes.DefaultStmtNoWarningContext, raw.(string), ft.GetType(), tiTypes.MaxFsp)
+		val, err := types.ParseTime(types.DefaultStmtNoWarningContext, raw.(string), ft.GetType(), types.MaxFsp)
 		if err != nil {
 			log.Panic("invalid column value for data time", zap.String("raw", util.RedactAny(raw)), zap.Error(err))
 		}
 		chk.AppendTime(idx, val)
 	case mysql.TypeDuration:
-		val, _, err := tiTypes.ParseDuration(tiTypes.DefaultStmtNoWarningContext, raw.(string), tiTypes.MaxFsp)
+		val, _, err := types.ParseDuration(types.DefaultStmtNoWarningContext, raw.(string), types.MaxFsp)
 		if err != nil {
 			log.Panic("invalid column value for duration", zap.String("raw", util.RedactAny(raw)), zap.Error(err))
 		}
 		chk.AppendDuration(idx, val)
 	case mysql.TypeEnum:
-		chk.AppendEnum(idx, tiTypes.Enum{Value: val})
+		chk.AppendEnum(idx, types.Enum{Value: val})
 	case mysql.TypeSet:
 
-		chk.AppendSet(idx, tiTypes.Set{Value: val})
+		chk.AppendSet(idx, types.Set{Value: val})
 	case mysql.TypeBit:
-		value := tiTypes.NewBinaryLiteralFromUint(val, -1)
+		value := types.NewBinaryLiteralFromUint(val, -1)
 		chk.AppendBytes(idx, value)
 	case mysql.TypeJSON:
-		result, err := tiTypes.ParseBinaryJSONFromString(raw.(string))
+		result, err := types.ParseBinaryJSONFromString(raw.(string))
 		if err != nil {
 			log.Panic("invalid column value for json", zap.String("raw", util.RedactAny(raw)), zap.Error(err))
 		}
 		chk.AppendJSON(idx, result)
 	case mysql.TypeTiDBVectorFloat32:
-		result, err := tiTypes.ParseVectorFloat32(raw.(string))
+		result, err := types.ParseVectorFloat32(raw.(string))
 		if err != nil {
 			log.Panic("cannot parse vector32 value from string", zap.String("raw", util.RedactAny(raw)), zap.Error(err))
 		}

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -241,11 +241,26 @@ func (d *DDLEvent) ToRedoLog() *RedoLog {
 		Type: RedoLogTypeDDL,
 	}
 	if d.TableInfo != nil {
+		redoLog.RedoDDL.TableName.TableID = d.TableInfo.TableName.TableID
+		redoLog.RedoDDL.TableName.IsPartition = d.TableInfo.TableName.IsPartition
+	}
+
+	schemaName := d.GetTargetSchemaName()
+	tableName := d.GetTargetTableName()
+	if d.TableInfo != nil {
+		if targetSchema := d.TableInfo.GetTargetSchemaName(); targetSchema != "" {
+			schemaName = targetSchema
+		}
+		if targetTable := d.TableInfo.GetTargetTableName(); targetTable != "" {
+			tableName = targetTable
+		}
+	}
+	if schemaName != "" || tableName != "" {
 		redoLog.RedoDDL.TableName = common.TableName{
-			Schema:      d.TableInfo.GetTargetSchemaName(),
-			Table:       d.TableInfo.GetTargetTableName(),
-			TableID:     d.TableInfo.TableName.TableID,
-			IsPartition: d.TableInfo.TableName.IsPartition,
+			Schema:      schemaName,
+			Table:       tableName,
+			TableID:     redoLog.RedoDDL.TableName.TableID,
+			IsPartition: redoLog.RedoDDL.TableName.IsPartition,
 		}
 	}
 

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -77,15 +77,15 @@ type DDLEventInRedoLog struct {
 	StartTs           uint64            `msg:"start-ts"`
 	CommitTs          uint64            `msg:"commit-ts"`
 	Query             string            `msg:"query"`
-	Columns           []*ColumnInfo     `msg:"columns"`
+	Columns           []*columnInfo     `msg:"columns"`
 	BlockedTables     *InfluencedTables `msg:"blocked-tables"`
 	BlockedTableNames []SchemaTableName `msg:"blocked-table-names"`
 	NeedDroppedTables *InfluencedTables `msg:"need-dropped-tables"`
 	NeedAddedTables   []Table           `msg:"need_added_tables"`
 }
 
-// ColumnInfo is for column meta in DDL event
-type ColumnInfo struct {
+// columnInfo is for column meta in DDL event
+type columnInfo struct {
 	Name               string `msg:"name"`
 	OriginDefaultValue any    `msg:"origin_default"`
 	Type               byte   `msg:"type"`
@@ -210,11 +210,11 @@ func (r *RedoRowEvent) ToRedoLog() *RedoLog {
 
 // ToRedoLog converts ddl event to redo log
 func (d *DDLEvent) ToRedoLog() *RedoLog {
-	var columns []*ColumnInfo
+	var columns []*columnInfo
 	if d.TableInfo != nil {
-		columns = make([]*ColumnInfo, 0, len(d.TableInfo.GetColumns()))
+		columns = make([]*columnInfo, 0, len(d.TableInfo.GetColumns()))
 		for _, col := range d.TableInfo.GetColumns() {
-			columns = append(columns, &ColumnInfo{
+			columns = append(columns, &columnInfo{
 				Name:               col.Name.String(),
 				OriginDefaultValue: col.GetOriginDefaultValue(),
 				Type:               col.GetType(),
@@ -227,12 +227,12 @@ func (d *DDLEvent) ToRedoLog() *RedoLog {
 			DDL: &DDLEventInRedoLog{
 				StartTs:           d.GetStartTs(),
 				CommitTs:          d.GetCommitTs(),
-				Query:             d.Query,
+				Query:             d.GetDDLQuery(),
 				Columns:           columns,
-				BlockedTables:     d.BlockedTables,
-				BlockedTableNames: d.BlockedTableNames,
-				NeedDroppedTables: d.NeedDroppedTables,
-				NeedAddedTables:   d.NeedAddedTables,
+				BlockedTables:     d.GetBlockedTables(),
+				BlockedTableNames: d.GetBlockedTableNames(),
+				NeedDroppedTables: d.GetNeedDroppedTables(),
+				NeedAddedTables:   d.GetNeedAddedTables(),
 			},
 			Type: d.Type,
 		},

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -388,7 +388,9 @@ func (r *RedoDDLEvent) ToDDLEvent() *DDLEvent {
 	tableName := r.TableName.GetTable()
 	if blockedTables == nil {
 		blockedTables = &InfluencedTables{InfluenceType: InfluenceTypeNormal}
-		blockedTableNames = []SchemaTableName{{SchemaName: schemaName, TableName: tableName}}
+		if len(blockedTableNames) == 0 {
+			blockedTableNames = []SchemaTableName{{SchemaName: schemaName, TableName: tableName}}
+		}
 	}
 	columns := make([]*model.ColumnInfo, 0, len(r.DDL.Columns))
 	for _, col := range r.DDL.Columns {

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -77,15 +77,15 @@ type DDLEventInRedoLog struct {
 	StartTs           uint64            `msg:"start-ts"`
 	CommitTs          uint64            `msg:"commit-ts"`
 	Query             string            `msg:"query"`
-	Columns           []*columnInfo     `msg:"columns"`
+	Columns           []*ColumnInfo     `msg:"columns"`
 	BlockedTables     *InfluencedTables `msg:"blocked-tables"`
 	BlockedTableNames []SchemaTableName `msg:"blocked-table-names"`
 	NeedDroppedTables *InfluencedTables `msg:"need-dropped-tables"`
 	NeedAddedTables   []Table           `msg:"need_added_tables"`
 }
 
-// columnInfo is for column meta in DDL event
-type columnInfo struct {
+// ColumnInfo is for column meta in DDL event
+type ColumnInfo struct {
 	Name               string `msg:"name"`
 	OriginDefaultValue any    `msg:"origin_default"`
 	Type               byte   `msg:"type"`
@@ -210,11 +210,11 @@ func (r *RedoRowEvent) ToRedoLog() *RedoLog {
 
 // ToRedoLog converts ddl event to redo log
 func (d *DDLEvent) ToRedoLog() *RedoLog {
-	var columns []*columnInfo
+	var columns []*ColumnInfo
 	if d.TableInfo != nil {
-		columns = make([]*columnInfo, 0, len(d.TableInfo.GetColumns()))
+		columns = make([]*ColumnInfo, 0, len(d.TableInfo.GetColumns()))
 		for _, col := range d.TableInfo.GetColumns() {
-			columns = append(columns, &columnInfo{
+			columns = append(columns, &ColumnInfo{
 				Name:               col.Name.String(),
 				OriginDefaultValue: col.GetOriginDefaultValue(),
 				Type:               col.GetType(),
@@ -222,31 +222,34 @@ func (d *DDLEvent) ToRedoLog() *RedoLog {
 			})
 		}
 	}
-	redoLog := &RedoLog{
-		RedoDDL: &RedoDDLEvent{
-			DDL: &DDLEventInRedoLog{
-				StartTs:           d.GetStartTs(),
-				CommitTs:          d.GetCommitTs(),
-				Query:             d.GetDDLQuery(),
-				Columns:           columns,
-				BlockedTables:     d.GetBlockedTables(),
-				BlockedTableNames: d.GetBlockedTableNames(),
-				NeedDroppedTables: d.GetNeedDroppedTables(),
-				NeedAddedTables:   d.GetNeedAddedTables(),
-			},
-			Type: d.Type,
-		},
-		Type: RedoLogTypeDDL,
+
+	body := &DDLEventInRedoLog{
+		StartTs:           d.GetStartTs(),
+		CommitTs:          d.GetCommitTs(),
+		Query:             d.GetDDLQuery(),
+		Columns:           columns,
+		BlockedTables:     d.GetBlockedTables(),
+		BlockedTableNames: d.GetBlockedTableNames(),
+		NeedDroppedTables: d.GetNeedDroppedTables(),
+		NeedAddedTables:   d.GetNeedAddedTables(),
 	}
+
+	redoDDL := &RedoDDLEvent{
+		DDL:  body,
+		Type: d.Type,
+	}
+
 	if d.TableInfo != nil {
-		redoLog.RedoDDL.TableName.TableID = d.TableInfo.TableName.TableID
-		redoLog.RedoDDL.TableName.IsPartition = d.TableInfo.TableName.IsPartition
+		redoDDL.TableName.TableID = d.TableInfo.TableName.TableID
+		redoDDL.TableName.IsPartition = d.TableInfo.TableName.IsPartition
 	}
+	redoDDL.TableName.Schema = d.GetTargetSchemaName()
+	redoDDL.TableName.Table = d.GetTargetTableName()
 
-	redoLog.RedoDDL.TableName.Schema = d.GetTargetSchemaName()
-	redoLog.RedoDDL.TableName.Table = d.GetTargetTableName()
-
-	return redoLog
+	return &RedoLog{
+		RedoDDL: redoDDL,
+		Type:    RedoLogTypeDDL,
+	}
 }
 
 // GetCommitTs returns commit timestamp of the log event.

--- a/pkg/common/event/redo.go
+++ b/pkg/common/event/redo.go
@@ -133,79 +133,75 @@ func (r *RedoRowEvent) PostFlush() {
 }
 
 func (r *RedoRowEvent) ToRedoLog() *RedoLog {
-	redoLog := &RedoLog{
-		RedoRow: &RedoDMLEvent{
-			Row: &DMLEventInRedoLog{
-				StartTs:      r.StartTs,
-				CommitTs:     r.CommitTs,
-				Table:        nil,
-				Columns:      nil,
-				PreColumns:   nil,
-				IndexColumns: nil,
-			},
-			PreColumns: nil,
-			Columns:    nil,
+	redoRow := &RedoDMLEvent{
+		Row: &DMLEventInRedoLog{
+			StartTs:  r.StartTs,
+			CommitTs: r.CommitTs,
 		},
-		Type: RedoLogTypeRow,
 	}
-	if r.TableInfo != nil {
-		redoLog.RedoRow.Row.Table = &common.TableName{
-			Schema:      r.TableInfo.GetTargetSchemaName(),
-			Table:       r.TableInfo.GetTargetTableName(),
-			TableID:     r.PhysicalTableID,
-			IsPartition: r.TableInfo.TableName.IsPartition,
-		}
-		redoLog.RedoRow.Row.IndexColumns = getIndexColumns(r.TableInfo)
 
-		columnCount := len(r.TableInfo.GetColumns())
-		columns := make([]*RedoColumn, 0, columnCount)
+	if r.TableInfo == nil {
+		return &RedoLog{RedoRow: redoRow, Type: RedoLogTypeRow}
+	}
+
+	row := redoRow.Row
+	row.Table = &common.TableName{
+		Schema:      r.TableInfo.GetTargetSchemaName(),
+		Table:       r.TableInfo.GetTargetTableName(),
+		TableID:     r.PhysicalTableID,
+		IsPartition: r.TableInfo.TableName.IsPartition,
+	}
+	row.IndexColumns = getIndexColumns(r.TableInfo)
+
+	columnCount := len(r.TableInfo.GetColumns())
+	var columnsVal, preColumnsVal []RedoColumnValue
+	switch r.Event.RowType {
+	case common.RowTypeInsert:
+		columnsVal = make([]RedoColumnValue, 0, columnCount)
+	case common.RowTypeDelete:
+		preColumnsVal = make([]RedoColumnValue, 0, columnCount)
+	case common.RowTypeUpdate:
+		columnsVal = make([]RedoColumnValue, 0, columnCount)
+		preColumnsVal = make([]RedoColumnValue, 0, columnCount)
+	}
+
+	columns := make([]*RedoColumn, 0, columnCount)
+	for i, column := range r.TableInfo.GetColumns() {
+		if !common.IsColCDCVisible(column) {
+			continue
+		}
+		columns = append(columns, &RedoColumn{
+			Name:      column.Name.String(),
+			Type:      column.GetType(),
+			Charset:   column.GetCharset(),
+			Collation: column.GetCollate(),
+		})
+		isHandleKey := r.TableInfo.IsHandleKey(column.ID)
 		switch r.Event.RowType {
 		case common.RowTypeInsert:
-			redoLog.RedoRow.Columns = make([]RedoColumnValue, 0, columnCount)
+			columnsVal = append(columnsVal, parseColumnValue(&r.Event.Row, column, i, isHandleKey))
 		case common.RowTypeDelete:
-			redoLog.RedoRow.PreColumns = make([]RedoColumnValue, 0, columnCount)
+			preColumnsVal = append(preColumnsVal, parseColumnValue(&r.Event.PreRow, column, i, isHandleKey))
 		case common.RowTypeUpdate:
-			redoLog.RedoRow.Columns = make([]RedoColumnValue, 0, columnCount)
-			redoLog.RedoRow.PreColumns = make([]RedoColumnValue, 0, columnCount)
-		default:
-		}
-
-		for i, column := range r.TableInfo.GetColumns() {
-			if common.IsColCDCVisible(column) {
-				columns = append(columns, &RedoColumn{
-					Name:      column.Name.String(),
-					Type:      column.GetType(),
-					Charset:   column.GetCharset(),
-					Collation: column.GetCollate(),
-				})
-				isHandleKey := r.TableInfo.IsHandleKey(column.ID)
-				switch r.Event.RowType {
-				case common.RowTypeInsert:
-					v := parseColumnValue(&r.Event.Row, column, i, isHandleKey)
-					redoLog.RedoRow.Columns = append(redoLog.RedoRow.Columns, v)
-				case common.RowTypeDelete:
-					v := parseColumnValue(&r.Event.PreRow, column, i, isHandleKey)
-					redoLog.RedoRow.PreColumns = append(redoLog.RedoRow.PreColumns, v)
-				case common.RowTypeUpdate:
-					v := parseColumnValue(&r.Event.Row, column, i, isHandleKey)
-					redoLog.RedoRow.Columns = append(redoLog.RedoRow.Columns, v)
-					v = parseColumnValue(&r.Event.PreRow, column, i, isHandleKey)
-					redoLog.RedoRow.PreColumns = append(redoLog.RedoRow.PreColumns, v)
-				default:
-				}
-			}
-		}
-		switch r.Event.RowType {
-		case common.RowTypeInsert:
-			redoLog.RedoRow.Row.Columns = columns
-		case common.RowTypeDelete:
-			redoLog.RedoRow.Row.PreColumns = columns
-		case common.RowTypeUpdate:
-			redoLog.RedoRow.Row.Columns = columns
-			redoLog.RedoRow.Row.PreColumns = columns
+			columnsVal = append(columnsVal, parseColumnValue(&r.Event.Row, column, i, isHandleKey))
+			preColumnsVal = append(preColumnsVal, parseColumnValue(&r.Event.PreRow, column, i, isHandleKey))
 		}
 	}
-	return redoLog
+
+	switch r.Event.RowType {
+	case common.RowTypeInsert:
+		row.Columns = columns
+	case common.RowTypeDelete:
+		row.PreColumns = columns
+	case common.RowTypeUpdate:
+		row.Columns = columns
+		row.PreColumns = columns
+	}
+
+	redoRow.Columns = columnsVal
+	redoRow.PreColumns = preColumnsVal
+
+	return &RedoLog{RedoRow: redoRow, Type: RedoLogTypeRow}
 }
 
 // ToRedoLog converts ddl event to redo log

--- a/pkg/common/event/redo_test.go
+++ b/pkg/common/event/redo_test.go
@@ -147,10 +147,12 @@ func TestRedoDDLEventRoundTripPreservesColumnMetadata(t *testing.T) {
 
 func TestDDLEventToRedoLogHandlesNilTableInfo(t *testing.T) {
 	ddlEvent := &DDLEvent{
-		Type:       byte(timodel.ActionCreateSchema),
-		Query:      "create database test_redo",
-		StartTs:    33,
-		FinishedTs: 44,
+		Type:             byte(timodel.ActionCreateSchema),
+		SchemaName:       "source_db",
+		targetSchemaName: "target_db",
+		Query:            "create database target_db",
+		StartTs:          33,
+		FinishedTs:       44,
 	}
 
 	require.NotPanics(t, func() {
@@ -159,6 +161,16 @@ func TestDDLEventToRedoLogHandlesNilTableInfo(t *testing.T) {
 		require.Equal(t, ddlEvent.StartTs, redoLog.RedoDDL.DDL.StartTs)
 		require.Equal(t, ddlEvent.FinishedTs, redoLog.RedoDDL.DDL.CommitTs)
 		require.Nil(t, redoLog.RedoDDL.DDL.Columns)
+		require.Equal(t, "target_db", redoLog.RedoDDL.TableName.Schema)
+		require.Empty(t, redoLog.RedoDDL.TableName.Table)
+
+		roundTrip := redoLog.RedoDDL.ToDDLEvent()
+		require.Equal(t, "target_db", roundTrip.SchemaName)
+		require.Equal(t, "target_db", roundTrip.GetTargetSchemaName())
+		require.Equal(t, []SchemaTableName{{
+			SchemaName: "target_db",
+			TableName:  "",
+		}}, roundTrip.BlockedTableNames)
 	})
 }
 

--- a/pkg/common/event/redo_test.go
+++ b/pkg/common/event/redo_test.go
@@ -97,7 +97,6 @@ func TestRedoUsesRoutedTableNames(t *testing.T) {
 	require.Equal(t, "target_table", decoded.TableInfo.GetTargetTableName())
 }
 
-
 // TestRedoDDLEventToRedoLogWithoutRouting verifies that a DDL event with a
 // non-routed TableInfo writes the source schema/table names into the redo log.
 func TestRedoDDLEventToRedoLogWithoutRouting(t *testing.T) {

--- a/pkg/common/event/redo_test.go
+++ b/pkg/common/event/redo_test.go
@@ -293,6 +293,7 @@ func TestRedoRowEventToRedoLogWithoutRouting(t *testing.T) {
 	require.Equal(t, "test", decoded.TableInfo.GetTargetSchemaName())
 	require.Equal(t, "t", decoded.TableInfo.GetTargetTableName())
 }
+
 func newRedoDDLTestColumn(
 	t *testing.T,
 	id int64,

--- a/pkg/common/event/redo_test.go
+++ b/pkg/common/event/redo_test.go
@@ -37,13 +37,15 @@ func TestRedoUsesRoutedTableNames(t *testing.T) {
 	routedTableInfo := sourceTableInfo.CloneWithRouting("target_db", "target_table")
 
 	redoDDLEvent := (&DDLEvent{
-		Query:      "ALTER TABLE `target_db`.`target_table` ADD COLUMN age INT",
-		Type:       byte(model.ActionAddColumn),
-		SchemaName: "test",
-		TableName:  "t",
-		TableInfo:  routedTableInfo,
-		FinishedTs: 200,
-		StartTs:    100,
+		Query:            "ALTER TABLE `target_db`.`target_table` ADD COLUMN age INT",
+		Type:             byte(model.ActionAddColumn),
+		SchemaName:       "test",
+		TableName:        "t",
+		targetSchemaName: "target_db",
+		targetTableName:  "target_table",
+		TableInfo:        routedTableInfo,
+		FinishedTs:       200,
+		StartTs:          100,
 	}).ToRedoLog().RedoDDL
 
 	require.Equal(t, "target_db", redoDDLEvent.TableName.Schema)
@@ -95,6 +97,41 @@ func TestRedoUsesRoutedTableNames(t *testing.T) {
 	require.Equal(t, "target_table", decoded.TableInfo.GetTargetTableName())
 }
 
+
+// TestRedoDDLEventToRedoLogWithoutRouting verifies that a DDL event with a
+// non-routed TableInfo writes the source schema/table names into the redo log.
+func TestRedoDDLEventToRedoLogWithoutRouting(t *testing.T) {
+	helper := NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job(`create table test.t(id int primary key, name varchar(32))`)
+	require.NotNil(t, job)
+	sourceTableInfo := helper.GetTableInfo(job)
+
+	redoDDL := (&DDLEvent{
+		Query:      "ALTER TABLE `test`.`t` ADD COLUMN age INT",
+		Type:       byte(model.ActionAddColumn),
+		SchemaName: "test",
+		TableName:  "t",
+		TableInfo:  sourceTableInfo,
+		FinishedTs: 200,
+		StartTs:    100,
+	}).ToRedoLog().RedoDDL
+
+	require.Equal(t, "test", redoDDL.TableName.Schema)
+	require.Equal(t, "t", redoDDL.TableName.Table)
+	require.Equal(t, sourceTableInfo.TableName.TableID, redoDDL.TableName.TableID)
+	require.False(t, redoDDL.TableName.IsPartition)
+
+	// Round-trip through ToDDLEvent must preserve the names.
+	roundTrip := redoDDL.ToDDLEvent()
+	require.Equal(t, "test", roundTrip.SchemaName)
+	require.Equal(t, "t", roundTrip.TableName)
+	require.Equal(t, "test", roundTrip.GetTargetSchemaName())
+	require.Equal(t, "t", roundTrip.GetTargetTableName())
+}
+
 func TestRedoDDLEventRoundTripPreservesColumnMetadata(t *testing.T) {
 	originalTableInfo := commonType.NewTableInfo4Decoder("test", &timodel.TableInfo{
 		ID:   1001,
@@ -111,6 +148,8 @@ func TestRedoDDLEventRoundTripPreservesColumnMetadata(t *testing.T) {
 	ddlEvent := &DDLEvent{
 		Type:              byte(timodel.ActionCreateTable),
 		Query:             "create table test.t_redo(id bigint, status varchar(16) default 'ready')",
+		SchemaName:        "test",
+		TableName:         "t_redo",
 		TableInfo:         originalTableInfo,
 		StartTs:           11,
 		FinishedTs:        22,
@@ -188,8 +227,73 @@ func TestDDLEventToRedoLogHandlesUninitializedTableInfo(t *testing.T) {
 	require.Equal(t, ddlEvent.StartTs, redoLog.RedoDDL.DDL.StartTs)
 	require.Equal(t, ddlEvent.FinishedTs, redoLog.RedoDDL.DDL.CommitTs)
 	require.Empty(t, redoLog.RedoDDL.DDL.Columns)
+	// TableName falls back to event SchemaName/TableName via GetTargetSchemaName/GetTargetTableName,
+	// both of which are empty for an uninitialized TableInfo without explicit names.
+	require.Empty(t, redoLog.RedoDDL.TableName.Schema)
+	require.Empty(t, redoLog.RedoDDL.TableName.Table)
+	require.Equal(t, int64(0), redoLog.RedoDDL.TableName.TableID)
+	require.False(t, redoLog.RedoDDL.TableName.IsPartition)
 }
 
+// TestRedoRowEventToRedoLogHandlesNilTableInfo verifies that a DML redo event
+// with nil TableInfo does not panic and produces a minimal redo log.
+func TestRedoRowEventToRedoLogHandlesNilTableInfo(t *testing.T) {
+	redoRow := (&RedoRowEvent{
+		StartTs:  100,
+		CommitTs: 200,
+	}).ToRedoLog().RedoRow
+
+	require.NotNil(t, redoRow)
+	require.NotNil(t, redoRow.Row)
+	require.Equal(t, uint64(100), redoRow.Row.StartTs)
+	require.Equal(t, uint64(200), redoRow.Row.CommitTs)
+	require.Nil(t, redoRow.Row.Table)
+	require.Nil(t, redoRow.Row.Columns)
+	require.Nil(t, redoRow.Row.PreColumns)
+	require.Nil(t, redoRow.Row.IndexColumns)
+	require.Nil(t, redoRow.Columns)
+	require.Nil(t, redoRow.PreColumns)
+}
+
+// TestRedoRowEventToRedoLogWithoutRouting verifies that a DML event with a
+// non-routed TableInfo writes the source schema/table names into the redo log.
+func TestRedoRowEventToRedoLogWithoutRouting(t *testing.T) {
+	helper := NewEventTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job(`create table test.t(id int primary key, name varchar(32), age int)`)
+	require.NotNil(t, job)
+	sourceTableInfo := helper.GetTableInfo(job)
+
+	dmlEvent := helper.DML2Event("test", "t", `insert into test.t values (1, 'alice', 25)`)
+	dmlEvent.TableInfo = sourceTableInfo
+
+	row, ok := dmlEvent.GetNextRow()
+	require.True(t, ok)
+
+	redoRow := (&RedoRowEvent{
+		StartTs:         dmlEvent.StartTs,
+		CommitTs:        dmlEvent.CommitTs,
+		PhysicalTableID: dmlEvent.PhysicalTableID,
+		TableInfo:       sourceTableInfo,
+		Event:           row,
+	}).ToRedoLog().RedoRow
+
+	require.Equal(t, "test", redoRow.Row.Table.Schema)
+	require.Equal(t, "t", redoRow.Row.Table.Table)
+	require.Equal(t, sourceTableInfo.TableName.TableID, redoRow.Row.Table.TableID)
+	require.False(t, redoRow.Row.Table.IsPartition)
+	require.Empty(t, redoRow.Row.Table.TargetSchema)
+	require.Empty(t, redoRow.Row.Table.TargetTable)
+
+	// Round-trip through ToDMLEvent must preserve the names.
+	decoded := redoRow.ToDMLEvent()
+	require.Equal(t, "test", decoded.TableInfo.GetSchemaName())
+	require.Equal(t, "t", decoded.TableInfo.GetTableName())
+	require.Equal(t, "test", decoded.TableInfo.GetTargetSchemaName())
+	require.Equal(t, "t", decoded.TableInfo.GetTargetTableName())
+}
 func newRedoDDLTestColumn(
 	t *testing.T,
 	id int64,

--- a/tests/integration_tests/api_v2/model.go
+++ b/tests/integration_tests/api_v2/model.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/pingcap/errors"
+	"github.com/pingcap/ticdc/pkg/errors"
 )
 
 const timeFormat = `"2006-01-02 15:04:05.000"`

--- a/tests/integration_tests/redo_apply_table_route/conf/changefeed.toml
+++ b/tests/integration_tests/redo_apply_table_route/conf/changefeed.toml
@@ -1,0 +1,21 @@
+# Changefeed config with redo log enabled for table route test.
+
+[consistent]
+level = "eventual"
+storage = "file:///tmp/tidb_cdc_test/redo_apply_table_route/redo"
+flush-interval = 2000
+meta-flush-interval = 200
+
+[filter]
+rules = ['source_db.*', 'source_extra_db.*']
+
+[sink]
+[[sink.dispatchers]]
+matcher = ['source_db.*']
+target-schema = 'target_db'
+target-table = '{table}_routed'
+
+[[sink.dispatchers]]
+matcher = ['source_extra_db.*']
+target-schema = 'target_extra_db'
+target-table = '{table}_routed'

--- a/tests/integration_tests/redo_apply_table_route/data/test.sql
+++ b/tests/integration_tests/redo_apply_table_route/data/test.sql
@@ -1,0 +1,156 @@
+-- Test mixed DDL and DML operations for redo apply with table route.
+DROP DATABASE IF EXISTS source_db;
+DROP DATABASE IF EXISTS source_extra_db;
+CREATE DATABASE source_db;
+CREATE DATABASE source_extra_db;
+USE source_db;
+
+-- ============================================
+-- DDL: CREATE TABLE with initial DML
+-- ============================================
+CREATE TABLE users (
+    id INT PRIMARY KEY,
+    name VARCHAR(100),
+    email VARCHAR(100)
+);
+
+CREATE TABLE orders (
+    id INT PRIMARY KEY,
+    user_id INT,
+    amount DECIMAL(10, 2)
+);
+
+INSERT INTO users VALUES (1, 'Alice', 'alice@example.com');
+INSERT INTO users VALUES (2, 'Bob', 'bob@example.com');
+
+INSERT INTO orders VALUES (1, 1, 100.00);
+INSERT INTO orders VALUES (2, 2, 200.00);
+
+-- ============================================
+-- DML: INSERT, UPDATE and DELETE
+-- ============================================
+INSERT INTO users VALUES (3, 'Charlie', 'charlie@example.com');
+INSERT INTO orders VALUES (3, 3, 300.00);
+UPDATE users SET email = 'alice_updated@example.com' WHERE id = 1;
+UPDATE orders SET amount = 150.00 WHERE id = 1;
+DELETE FROM orders WHERE id = 2;
+
+-- ============================================
+-- DDL: ALTER TABLE and CREATE TABLE LIKE
+-- ============================================
+ALTER TABLE users ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+CREATE TABLE products (
+    id INT PRIMARY KEY,
+    name VARCHAR(100),
+    price DECIMAL(10, 2)
+);
+
+INSERT INTO products VALUES (1, 'Widget', 29.99);
+INSERT INTO products VALUES (2, 'Gadget', 19.99);
+
+CREATE TABLE products_backup LIKE products;
+INSERT INTO products_backup VALUES (1, 'Widget', 29.99);
+
+ALTER TABLE users DROP COLUMN created_at;
+ALTER TABLE orders ADD INDEX idx_user_id (user_id);
+
+-- ============================================
+-- DDL: CROSS DATABASE
+-- ============================================
+CREATE TABLE `source_extra_db`.`external_users` LIKE `source_db`.`users`;
+INSERT INTO `source_extra_db`.`external_users`
+    SELECT `id`, `name`, `email` FROM `source_db`.`users` WHERE `id` <= 2;
+UPDATE `source_extra_db`.`external_users` SET `email` = 'external_alice@example.com' WHERE `id` = 1;
+
+CREATE TABLE `source_extra_db`.`external_users_from_default` LIKE `users`;
+INSERT INTO `source_extra_db`.`external_users_from_default`
+    SELECT `id`, `name`, `email` FROM `source_db`.`users` WHERE `id` IN (1, 3);
+UPDATE `source_extra_db`.`external_users_from_default` SET `email` = 'default_charlie@example.com' WHERE `id` = 3;
+
+CREATE TABLE `source_db`.`cross_move_source` (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+INSERT INTO `source_db`.`cross_move_source` VALUES (1, 'move_source');
+RENAME TABLE `source_db`.`cross_move_source` TO `source_extra_db`.`cross_move_target`;
+INSERT INTO `source_extra_db`.`cross_move_target` VALUES (2, 'move_target');
+
+-- ============================================
+-- DDL: RENAME TABLE
+-- ============================================
+CREATE TABLE temp_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+INSERT INTO temp_table VALUES (1, 'test');
+
+RENAME TABLE temp_table TO renamed_table;
+INSERT INTO renamed_table VALUES (2, 'test2');
+UPDATE renamed_table SET value = 'updated' WHERE id = 1;
+
+-- ============================================
+-- DDL: RENAME TABLE with multiple table pairs
+-- ============================================
+CREATE TABLE multi_rename_a (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+CREATE TABLE multi_rename_b (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+INSERT INTO multi_rename_a VALUES (1, 'a');
+INSERT INTO multi_rename_b VALUES (1, 'b');
+
+RENAME TABLE multi_rename_a TO multi_rename_a_new, multi_rename_b TO multi_rename_b_new;
+INSERT INTO multi_rename_a_new VALUES (2, 'a2');
+UPDATE multi_rename_b_new SET value = 'b2' WHERE id = 1;
+
+-- ============================================
+-- DDL: CREATE VIEW and DROP VIEW
+-- ============================================
+CREATE VIEW `source_db`.`user_order_view` AS
+    SELECT `u`.`id`, `u`.`name`, `o`.`amount`
+    FROM `source_db`.`users` AS `u`
+    JOIN `source_db`.`orders` AS `o` ON `u`.`id` = `o`.`user_id`;
+
+CREATE VIEW `source_db`.`transient_view` AS
+    SELECT `id`, `name` FROM `source_db`.`users`;
+
+DROP VIEW `source_db`.`transient_view`;
+
+-- ============================================
+-- DDL: TRUNCATE TABLE and DROP TABLE
+-- ============================================
+CREATE TABLE truncate_test (
+    id INT PRIMARY KEY,
+    data VARCHAR(100)
+);
+INSERT INTO truncate_test VALUES (1, 'will be truncated');
+INSERT INTO truncate_test VALUES (2, 'also truncated');
+
+TRUNCATE TABLE truncate_test;
+INSERT INTO truncate_test VALUES (10, 'after truncate');
+
+CREATE TABLE to_be_dropped (
+    id INT PRIMARY KEY
+);
+INSERT INTO to_be_dropped VALUES (1);
+DROP TABLE to_be_dropped;
+
+-- ============================================
+-- Mixed operations on existing tables
+-- ============================================
+INSERT INTO users VALUES (4, 'Diana', 'diana@example.com');
+INSERT INTO users VALUES (5, 'Eve', 'eve@example.com');
+UPDATE users SET name = CONCAT(name, '_v2') WHERE id IN (3, 4);
+DELETE FROM users WHERE id = 5;
+UPDATE products SET name = 'Super Widget', price = 12.99 WHERE id = 1;
+DELETE FROM products WHERE price < 15.00;
+
+-- ============================================
+-- Create finish marker table
+-- ============================================
+CREATE TABLE finish_mark (id INT PRIMARY KEY);
+INSERT INTO finish_mark VALUES (1);

--- a/tests/integration_tests/redo_apply_table_route/run.sh
+++ b/tests/integration_tests/redo_apply_table_route/run.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+# [DESCRIPTION]:
+#   This test verifies that redo log replay preserves table route target names.
+#   It first runs a table_route-style SQL workload through normal replication,
+#   then blocks MySQL DML writes, writes more source DML, and applies redo logs
+#   to confirm the replayed rows still land in routed downstream tables.
+
+set -euo pipefail
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$CUR/../_utils/test_prepare"
+
+WORK_DIR="$OUT_DIR/$TEST_NAME"
+CDC_BINARY=cdc.test
+SINK_TYPE="$1"
+
+REDO_DIR="/tmp/tidb_cdc_test/redo_apply_table_route/redo"
+SQL_RES_FILE="$OUT_DIR/$TEST_NAME/sql_res.$TEST_NAME.log"
+
+function cleanup_redo_dir() {
+	rm -rf "$REDO_DIR"
+	mkdir -p "$REDO_DIR"
+}
+
+function get_sql_count() {
+	grep -oE 'cnt:[[:space:]]*[0-9]+' "$SQL_RES_FILE" | grep -oE '[0-9]+' || echo "0"
+}
+
+function query_count() {
+	local sql="$1"
+	local host="$2"
+	local port="$3"
+
+	run_sql "$sql" "$host" "$port" >/dev/null
+	get_sql_count
+}
+
+function require_equal() {
+	local actual="$1"
+	local expected="$2"
+	local message="$3"
+
+	if [ "$actual" != "$expected" ]; then
+		echo "ERROR: $message, expected $expected, got $actual"
+		exit 1
+	fi
+}
+
+function verify_normal_table_route() {
+	check_table_exists target_db.finish_mark_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
+
+	local source_users_count
+	local target_users_count
+	local source_extra_count
+	local target_extra_count
+	source_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_db.users;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+	target_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+	source_extra_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_extra_db.external_users;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+	target_extra_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_extra_db.external_users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+
+	require_equal "$target_users_count" "$source_users_count" "normal table route users count mismatch"
+	require_equal "$target_extra_count" "$source_extra_count" "normal table route external_users count mismatch"
+
+	check_table_not_exists source_db.users "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists source_extra_db.external_users "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists target_db.temp_table_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists target_db.to_be_dropped_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+
+	run_sql "SHOW CREATE VIEW target_db.user_order_view_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "user_order_view_routed"
+	check_contains "users_routed"
+	check_contains "orders_routed"
+}
+
+function write_redo_only_dml() {
+	run_sql "INSERT INTO source_db.users VALUES (100, 'redo_user', 'redo_user@example.com');" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "UPDATE source_db.users SET email = 'redo_alice@example.com' WHERE id = 1;" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "INSERT INTO source_db.orders VALUES (100, 100, 1000.00);" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "INSERT INTO source_extra_db.external_users VALUES (100, 'redo_external', 'redo_external@example.com');" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "UPDATE source_extra_db.external_users SET email = 'redo_external_alice@example.com' WHERE id = 1;" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "INSERT INTO source_db.finish_mark VALUES (2);" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+}
+
+function verify_redo_apply_route() {
+	local source_users_count
+	local target_users_count
+	local source_orders_count
+	local target_orders_count
+	local source_extra_count
+	local target_extra_count
+	local source_finish_count
+	local target_finish_count
+
+	source_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_db.users;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+	target_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+	source_orders_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_db.orders;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+	target_orders_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.orders_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+	source_extra_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_extra_db.external_users;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+	target_extra_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_extra_db.external_users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+	source_finish_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_db.finish_mark;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+	target_finish_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.finish_mark_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+
+	require_equal "$target_users_count" "$source_users_count" "redo apply users count mismatch"
+	require_equal "$target_orders_count" "$source_orders_count" "redo apply orders count mismatch"
+	require_equal "$target_extra_count" "$source_extra_count" "redo apply external_users count mismatch"
+	require_equal "$target_finish_count" "$source_finish_count" "redo apply finish_mark count mismatch"
+
+	run_sql "SELECT email AS routed_email FROM target_db.users_routed WHERE id = 1;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "redo_alice@example.com"
+	run_sql "SELECT name AS routed_name FROM target_db.users_routed WHERE id = 100;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "redo_user"
+	run_sql "SELECT email AS routed_email FROM target_extra_db.external_users_routed WHERE id = 1;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "redo_external_alice@example.com"
+	run_sql "SELECT name AS routed_name FROM target_extra_db.external_users_routed WHERE id = 100;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "redo_external"
+
+	check_table_not_exists source_db.users "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists source_extra_db.external_users "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+}
+
+function run() {
+	if [ "$SINK_TYPE" != "mysql" ]; then
+		echo "skip redo apply table route test for non-mysql sink"
+		return
+	fi
+
+	rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
+	cleanup_redo_dir
+
+	start_tidb_cluster --workdir "$WORK_DIR"
+
+	start_ts=$(run_cdc_cli_tso_query "$UP_PD_HOST_1" "$UP_PD_PORT_1")
+	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+
+	local sink_uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/"
+	local changefeed_id="redo-table-route-test"
+	cdc_cli_changefeed create \
+		--start-ts="$start_ts" \
+		--sink-uri="$sink_uri" \
+		--changefeed-id="$changefeed_id" \
+		--config="$CUR/conf/changefeed.toml"
+
+	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	verify_normal_table_route
+
+	local pre_redo_users_count
+	pre_redo_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+
+	cleanup_process "$CDC_BINARY"
+	export GO_FAILPOINTS='github.com/pingcap/ticdc/pkg/sink/mysql/MySQLSinkHangLongTime=return(true)'
+	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+
+	write_redo_only_dml
+	sleep 20
+
+	local storage_path="file://$REDO_DIR"
+	local tmp_download_path="$WORK_DIR/cdc_data/redo/$changefeed_id"
+	local current_tso
+	current_tso=$(run_cdc_cli_tso_query "$UP_PD_HOST_1" "$UP_PD_PORT_1")
+	ensure 50 check_redo_resolved_ts "$changefeed_id" "$current_tso" "$storage_path" "$tmp_download_path/meta"
+
+	cleanup_process "$CDC_BINARY"
+	export GO_FAILPOINTS=''
+
+	local target_users_before_redo
+	target_users_before_redo=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
+	require_equal "$target_users_before_redo" "$pre_redo_users_count" "failpoint did not block MySQL DML before redo apply"
+
+	"$CDC_BINARY" redo apply \
+		--tmp-dir="$tmp_download_path/apply" \
+		--storage="$storage_path" \
+		--sink-uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/?safe-mode=true" \
+		2>&1 | tee "$WORK_DIR/redo_apply.log" || {
+		echo "Redo apply failed"
+		cat "$WORK_DIR/redo_apply.log"
+		exit 1
+	}
+
+	verify_redo_apply_route
+
+	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+	run_sql "INSERT INTO source_db.users VALUES (101, 'after_redo', 'after_redo@example.com');" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	check_table_exists target_db.finish_mark_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 30
+	sleep 10
+	run_sql "SELECT name AS routed_name FROM target_db.users_routed WHERE id = 101;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "after_redo"
+
+	cleanup_process "$CDC_BINARY"
+}
+
+trap 'stop_test "$WORK_DIR"' EXIT
+run "$@"
+check_logs "$WORK_DIR"
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/tests/integration_tests/redo_apply_table_route/run.sh
+++ b/tests/integration_tests/redo_apply_table_route/run.sh
@@ -36,6 +36,27 @@ function query_count() {
 	get_sql_count
 }
 
+function wait_query_count() {
+	local sql="$1"
+	local host="$2"
+	local port="$3"
+	local expected="$4"
+	local retries="${5:-30}"
+
+	while [ "$retries" -gt 0 ]; do
+		local actual
+		actual=$(query_count "$sql" "$host" "$port")
+		if [ "$actual" = "$expected" ]; then
+			return 0
+		fi
+		retries=$((retries - 1))
+		sleep 1
+	done
+
+	echo "ERROR: timeout waiting for expected count ($expected) for query: $sql"
+	return 1
+}
+
 function require_equal() {
 	local actual="$1"
 	local expected="$2"
@@ -152,7 +173,6 @@ function run() {
 	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
 
 	write_redo_only_dml
-	sleep 20
 
 	local storage_path="file://$REDO_DIR"
 	local tmp_download_path="$WORK_DIR/cdc_data/redo/$changefeed_id"
@@ -181,10 +201,8 @@ function run() {
 
 	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
 	run_sql "INSERT INTO source_db.users VALUES (101, 'after_redo', 'after_redo@example.com');" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
-	check_table_exists target_db.finish_mark_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 30
-	sleep 10
-	run_sql "SELECT name AS routed_name FROM target_db.users_routed WHERE id = 101;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	check_contains "after_redo"
+
+	wait_query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed WHERE id = 101 AND name = 'after_redo';" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" "1" 30
 
 	cleanup_process "$CDC_BINARY"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4819

When table route is configured and redo log is enabled, DDL events without a `TableInfo` (e.g., `CREATE DATABASE`) lose their routing target names in the redo log. During redo apply, the replayed DDL cannot be routed to the correct downstream target schema. DML and DDL events with `TableInfo` also relied on `TableInfo.GetTargetSchemaName()` but were inconsistent with how the event-level target names were set by the dispatcher.

### What is changed and how it works?

**Core fix** (`pkg/common/event/redo.go`):

- `DDLEvent.ToRedoLog()`: Now uses `d.GetTargetSchemaName()` / `d.GetTargetTableName()` to populate the redo log's `TableName`. These methods return the event-level target names set by the table route dispatcher (via `NewRoutedDDLEvent`), which works correctly even when `TableInfo` is nil. Previously the code only read from `TableInfo`, missing schema-level DDL events entirely.

- `RedoRowEvent.ToRedoLog()`: Uses `r.TableInfo.GetTargetSchemaName()` / `GetTargetTableName()`, which correctly return routed names when `TableInfo` has `TargetSchema`/`TargetTable` set.

- Both methods refactored for readability: intermediate variables replace deeply nested struct initialization, and `nil` TableInfo cases return early.

**Other changes**:

- `pkg/common/event/ddl_event.go`: Removed unnecessary nil-check in `GetDDLQuery()`.
- `downstreamadapter/sink/redo/sink.go`: Minor cleanup.
- `pkg/common/event/redo_test.go`: Added unit tests covering DDL/DML without routing, DML with nil TableInfo, and enhanced existing test assertions.

**Integration test** (`tests/integration_tests/redo_apply_table_route/`):

Validates end-to-end correctness: creates a changefeed with table route config, runs a complex DDL/DML workload, stops the sink writer with a failpoint to accumulate redo logs, applies redo, and verifies all replayed data lands in the correct routed downstream tables.

### Check List

#### Tests

- Unit test
- Integration test

#### Questions

##### Will it cause performance regression or break compatibility?

No. The refactoring preserves identical logic. Redo log format is unchanged — only the values written to existing fields differ when routing is active.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Integrate  the redo into the table route
```