### PR TITLE
pulsar: support debezium protocol

### DIFF
--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -111,7 +111,7 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
-	pulsarComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, topic, true, false)
+	pulsarComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, topic, true, protocol == config.ProtocolAvro)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)
 	}

--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -88,7 +88,7 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 	if !config.IsPulsarSupportedProtocols(protocol) {
 		return pulsarComponent, protocol, errors.ErrSinkURIInvalid.
 			GenWithStackByArgs("unsupported protocol, " +
-				"pulsar sink currently only support these protocols: [canal-json]")
+				"pulsar sink currently only support these protocols: [canal-json, debezium]")
 	}
 
 	pulsarComponent.config, err = pulsar.NewPulsarConfig(sinkURI, sinkConfig.PulsarConfig)
@@ -111,7 +111,6 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
-	// pulsar only support canal-json, so we don't need to check the protocol
 	pulsarComponent.eventRouter, err = eventrouter.NewEventRouter(sinkConfig, topic, true, false)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)

--- a/pkg/config/sink_protocol.go
+++ b/pkg/config/sink_protocol.go
@@ -180,5 +180,5 @@ func GetScheme(url *url.URL) string {
 
 // IsPulsarSupportedProtocols returns whether the protocol is supported by pulsar.
 func IsPulsarSupportedProtocols(p Protocol) bool {
-	return p == ProtocolCanalJSON
+	return p == ProtocolCanalJSON || p == ProtocolDebezium
 }

--- a/pkg/config/sink_protocol_test.go
+++ b/pkg/config/sink_protocol_test.go
@@ -62,6 +62,14 @@ func TestParseSinkProtocolFromString(t *testing.T) {
 			protocol:             "open-protocol",
 			expectedProtocolEnum: ProtocolOpen,
 		},
+		{
+			protocol:             "debezium",
+			expectedProtocolEnum: ProtocolDebezium,
+		},
+		{
+			protocol:             "simple",
+			expectedProtocolEnum: ProtocolSimple,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -108,6 +116,14 @@ func TestString(t *testing.T) {
 		{
 			protocolEnum:     ProtocolOpen,
 			expectedProtocol: "open-protocol",
+		},
+		{
+			protocolEnum:     ProtocolDebezium,
+			expectedProtocol: "debezium",
+		},
+		{
+			protocolEnum:     ProtocolSimple,
+			expectedProtocol: "simple",
 		},
 	}
 

--- a/pkg/config/sink_protocol_test.go
+++ b/pkg/config/sink_protocol_test.go
@@ -116,6 +116,26 @@ func TestString(t *testing.T) {
 	}
 }
 
+func TestIsPulsarSupportedProtocols(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		protocol Protocol
+		expect   bool
+	}{
+		{ProtocolCanalJSON, true},
+		{ProtocolDebezium, true},
+		{ProtocolAvro, false},
+		{ProtocolOpen, false},
+		{ProtocolSimple, false},
+		{ProtocolCanal, false},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expect, IsPulsarSupportedProtocols(tc.protocol))
+	}
+}
+
 func TestIsBatchEncoder(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration_tests/debezium_basic/run.sh
+++ b/tests/integration_tests/debezium_basic/run.sh
@@ -8,9 +8,9 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
-# use kafka-consumer with debezium decoder to sync data from kafka to mysql
+# use the mq consumer with debezium decoder to sync data from kafka/pulsar to mysql
 function run() {
-	if [ "$SINK_TYPE" != "kafka" ]; then
+	if [ "$SINK_TYPE" != "kafka" ] && [ "$SINK_TYPE" != "pulsar" ]; then
 		return
 	fi
 
@@ -24,12 +24,25 @@ function run() {
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 
-	SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=debezium&enable-tidb-extension=true"
+	if [ "$SINK_TYPE" == "kafka" ]; then
+		SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=debezium&enable-tidb-extension=true"
+	fi
+
+	if [ "$SINK_TYPE" == "pulsar" ]; then
+		run_pulsar_cluster $WORK_DIR normal
+		SINK_URI="pulsar://127.0.0.1:6650/$TOPIC_NAME?protocol=debezium&enable-tidb-extension=true"
+	fi
 
 	cdc_cli_changefeed create --sink-uri="$SINK_URI" --config=$CUR/conf/changefeed.toml
 	sleep 5 # wait for changefeed to start
 	# determine the sink uri and run corresponding consumer
-	run_kafka_consumer $WORK_DIR $SINK_URI $CUR/conf/changefeed.toml
+	if [ "$SINK_TYPE" == "kafka" ]; then
+		run_kafka_consumer $WORK_DIR $SINK_URI $CUR/conf/changefeed.toml
+	fi
+
+	if [ "$SINK_TYPE" == "pulsar" ]; then
+		run_pulsar_consumer --upstream-uri $SINK_URI --config $CUR/conf/changefeed.toml
+	fi
 
 	run_sql_file $CUR/data/data.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE TABLE test.finish_mark1 (a int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5056 

The Pulsar sink currently only supports `canal-json`. Users who consume
TiCDC events via Pulsar with Debezium-compatible consumers (e.g. Flink CDC)
have no way to use the standard Debezium message format.

### What is changed and how it works?

- Extend `IsPulsarSupportedProtocols()` in `pkg/config/sink_protocol.go`
  to include `ProtocolDebezium`.
- Update the error message in `downstreamadapter/sink/pulsar/helper.go`
  to reflect the expanded protocol list.
- The Debezium codec is already fully implemented and shared with the Kafka
  sink via the common codec builder, so no additional encoding logic is needed.
- Add unit test `TestIsPulsarSupportedProtocols`.

### Check List

#### Tests

- [x] Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. Existing `canal-json` behavior is unchanged.

##### Do you need to update user documentation, design documentation or monitoring documentation?

The Pulsar sink docs should note that `debezium` is now a valid `protocol` value.

### Release note

```release-note
The Pulsar sink now supports the `debezium` protocol. Set `protocol=debezium`
in the Pulsar sink URI to produce Debezium-format change events.


## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pulsar sink now supports debezium protocol in addition to canal-json protocol.

* **Tests**
  * Added validation tests for Pulsar sink protocol compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5054)

<!-- review_stack_entry_end -->
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pulsar sink now supports Debezium protocol format in addition to Canal-JSON.

* **Tests**
  * Added unit tests for protocol parsing and Pulsar-supported protocol validation.
  * Updated Debezium integration test flow to run against both Kafka and Pulsar sink types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->