### PR TITLE
pulsar: make max-message-bytes configurable

### DIFF
--- a/downstreamadapter/sink/pulsar/helper.go
+++ b/downstreamadapter/sink/pulsar/helper.go
@@ -122,7 +122,11 @@ func newPulsarSinkComponentWithFactory(ctx context.Context,
 		return pulsarComponent, protocol, errors.Trace(err)
 	}
 
-	encoderConfig, err := helper.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, config.DefaultMaxMessageBytes)
+	maxMessageBytes := config.DefaultMaxMessageBytes
+	if pulsarComponent.config.MaxMessageBytes != nil {
+		maxMessageBytes = *pulsarComponent.config.MaxMessageBytes
+	}
+	encoderConfig, err := helper.GetEncoderConfig(changefeedID, sinkURI, protocol, sinkConfig, maxMessageBytes)
 	if err != nil {
 		return pulsarComponent, protocol, errors.Trace(err)
 	}

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -643,6 +643,10 @@ type PulsarConfig struct {
 	// and 'type' always use 'client_credentials'
 	OAuth2 *OAuth2 `toml:"oauth2" json:"oauth2,omitempty"`
 
+	// MaxMessageBytes is the maximum size in bytes of a single message sent to Pulsar.
+	// Default: 10MB (same as the Kafka sink default).
+	MaxMessageBytes *int `toml:"max-message-bytes" json:"max-message-bytes,omitempty"`
+
 	// OutputRawChangeEvent controls whether to split the update pk/uk events.
 	OutputRawChangeEvent *bool `toml:"output-raw-change-event" json:"output-raw-change-event,omitempty"`
 

--- a/pkg/sink/pulsar/config.go
+++ b/pkg/sink/pulsar/config.go
@@ -16,6 +16,7 @@ package pulsar
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/pkg/config"
@@ -53,12 +54,25 @@ func checkSinkURI(sinkURI *url.URL) error {
 // NewPulsarConfig new pulsar config
 // TODO(dongmen): make this method more concise.
 func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*config.PulsarConfig, error) {
+	defaultMaxMessageBytes := config.DefaultMaxMessageBytes
 	c := &config.PulsarConfig{
 		ConnectionTimeout:       toSec(defaultConnectionTimeout),
 		OperationTimeout:        toSec(defaultOperationTimeout),
 		BatchingMaxMessages:     toUint(defaultBatchingMaxSize),
 		BatchingMaxPublishDelay: toMill(defaultBatchingMaxPublishDelay),
 		SendTimeout:             toSec(defaultSendTimeout),
+		MaxMessageBytes:         &defaultMaxMessageBytes,
+	}
+
+	if s := sinkURI.Query().Get("max-message-bytes"); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid max-message-bytes %s: %w", s, err)
+		}
+		if v <= 0 {
+			return nil, fmt.Errorf("max-message-bytes must be positive, got %d", v)
+		}
+		c.MaxMessageBytes = &v
 	}
 	err := checkSinkURI(sinkURI)
 	if err != nil {
@@ -106,6 +120,9 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 	}
 	if pulsarConfig.SendTimeout == nil {
 		pulsarConfig.SendTimeout = c.SendTimeout
+	}
+	if pulsarConfig.MaxMessageBytes == nil {
+		pulsarConfig.MaxMessageBytes = c.MaxMessageBytes
 	}
 
 	log.Debug("new pulsar config success", zap.Any("config", pulsarConfig))

--- a/pkg/sink/pulsar/config.go
+++ b/pkg/sink/pulsar/config.go
@@ -54,16 +54,8 @@ func checkSinkURI(sinkURI *url.URL) error {
 // NewPulsarConfig new pulsar config
 // TODO(dongmen): make this method more concise.
 func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*config.PulsarConfig, error) {
-	defaultMaxMessageBytes := config.DefaultMaxMessageBytes
-	c := &config.PulsarConfig{
-		ConnectionTimeout:       toSec(defaultConnectionTimeout),
-		OperationTimeout:        toSec(defaultOperationTimeout),
-		BatchingMaxMessages:     toUint(defaultBatchingMaxSize),
-		BatchingMaxPublishDelay: toMill(defaultBatchingMaxPublishDelay),
-		SendTimeout:             toSec(defaultSendTimeout),
-		MaxMessageBytes:         &defaultMaxMessageBytes,
-	}
-
+	// Parse max-message-bytes from the URI first so it can take precedence over TOML.
+	var uriMaxMessageBytes *int
 	if s := sinkURI.Query().Get("max-message-bytes"); s != "" {
 		v, err := strconv.Atoi(s)
 		if err != nil {
@@ -72,8 +64,24 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 		if v <= 0 {
 			return nil, fmt.Errorf("max-message-bytes must be positive, got %d", v)
 		}
-		c.MaxMessageBytes = &v
+		uriMaxMessageBytes = &v
 	}
+
+	defaultMaxMessageBytes := config.DefaultMaxMessageBytes
+	effectiveMaxMessageBytes := &defaultMaxMessageBytes
+	if uriMaxMessageBytes != nil {
+		effectiveMaxMessageBytes = uriMaxMessageBytes
+	}
+
+	c := &config.PulsarConfig{
+		ConnectionTimeout:       toSec(defaultConnectionTimeout),
+		OperationTimeout:        toSec(defaultOperationTimeout),
+		BatchingMaxMessages:     toUint(defaultBatchingMaxSize),
+		BatchingMaxPublishDelay: toMill(defaultBatchingMaxPublishDelay),
+		SendTimeout:             toSec(defaultSendTimeout),
+		MaxMessageBytes:         effectiveMaxMessageBytes,
+	}
+
 	err := checkSinkURI(sinkURI)
 	if err != nil {
 		return nil, err
@@ -121,7 +129,10 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 	if pulsarConfig.SendTimeout == nil {
 		pulsarConfig.SendTimeout = c.SendTimeout
 	}
-	if pulsarConfig.MaxMessageBytes == nil {
+	// URI parameter takes precedence over TOML; fall back to TOML, then default.
+	if uriMaxMessageBytes != nil {
+		pulsarConfig.MaxMessageBytes = uriMaxMessageBytes
+	} else if pulsarConfig.MaxMessageBytes == nil {
 		pulsarConfig.MaxMessageBytes = c.MaxMessageBytes
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5058

The Pulsar sink hardcodes `max-message-bytes` to `DefaultMaxMessageBytes`
(10MB), while the Kafka sink allows this to be tuned via the sink URI.
Users with different Pulsar broker configurations have no way to adjust
the message size limit.

### What is changed and how it works?

- Add `MaxMessageBytes *int` field to `PulsarConfig` in `pkg/config/sink.go`.
- Parse `max-message-bytes` from the sink URI in `pkg/sink/pulsar/config.go`,
  defaulting to 10MB when not set.
- Pass the configured value to `GetEncoderConfig` in
  `downstreamadapter/sink/pulsar/helper.go` instead of the hardcoded constant.

Usage: `pulsar://host/topic?max-message-bytes=5242880`

### Check List

#### Tests

- [x] Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No. The default value is unchanged (10MB). This only adds a new optional
URI parameter.

##### Do you need to update user documentation, design documentation or monitoring documentation?

The Pulsar sink URI parameter documentation should list `max-message-bytes`.

### Release note

```release-note
The Pulsar sink now supports the `max-message-bytes` URI parameter to
configure the maximum message size (default: 10MB), matching the existing
Kafka sink behavior.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum message size for Pulsar sinks. Users can now set `max-message-bytes` via TOML, JSON, or URI parameters with a default of 10MB, providing consistent behavior with Kafka sink configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->