### PR TITLE
storage sink: integrate storage sink in to the table route

### DIFF
--- a/downstreamadapter/sink/cloudstorage/dml_writers.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers.go
@@ -158,10 +158,12 @@ func (d *dmlWriters) addTasks(ctx context.Context) error {
 }
 
 func (d *dmlWriters) addDMLEvent(event *commonEvent.DMLEvent) {
+	targetSchema := event.TableInfo.GetTargetSchemaName()
+	targetTable := event.TableInfo.GetTargetTableName()
 	table := cloudstorage.VersionedTableName{
 		TableNameWithPhysicTableID: commonType.TableName{
-			Schema:      event.TableInfo.GetSchemaName(),
-			Table:       event.TableInfo.GetTableName(),
+			Schema:      targetSchema,
+			Table:       targetTable,
 			TableID:     event.PhysicalTableID,
 			IsPartition: event.TableInfo.IsPartitionTable(),
 		},

--- a/downstreamadapter/sink/cloudstorage/dml_writers.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers.go
@@ -158,12 +158,10 @@ func (d *dmlWriters) addTasks(ctx context.Context) error {
 }
 
 func (d *dmlWriters) addDMLEvent(event *commonEvent.DMLEvent) {
-	targetSchema := event.TableInfo.GetTargetSchemaName()
-	targetTable := event.TableInfo.GetTargetTableName()
 	table := cloudstorage.VersionedTableName{
 		TableNameWithPhysicTableID: commonType.TableName{
-			Schema:      targetSchema,
-			Table:       targetTable,
+			Schema:      event.TableInfo.GetTargetSchemaName(),
+			Table:       event.TableInfo.GetTargetTableName(),
 			TableID:     event.PhysicalTableID,
 			IsPartition: event.TableInfo.IsPartitionTable(),
 		},

--- a/downstreamadapter/sink/cloudstorage/dml_writers.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers.go
@@ -21,7 +21,6 @@ import (
 	sinkmetrics "github.com/pingcap/ticdc/downstreamadapter/sink/metrics"
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
-	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/metrics"
 	"github.com/pingcap/ticdc/pkg/sink/cloudstorage"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
@@ -146,7 +145,7 @@ func (d *dmlWriters) addTasks(ctx context.Context) error {
 
 		task, ok, err := d.msgCh.GetWithContext(ctx)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if !ok {
 			return nil
@@ -158,12 +157,13 @@ func (d *dmlWriters) addTasks(ctx context.Context) error {
 }
 
 func (d *dmlWriters) addDMLEvent(event *commonEvent.DMLEvent) {
+	tableInfo := event.TableInfo
 	table := cloudstorage.VersionedTableName{
 		TableNameWithPhysicTableID: commonType.TableName{
-			Schema:      event.TableInfo.GetTargetSchemaName(),
-			Table:       event.TableInfo.GetTargetTableName(),
+			Schema:      tableInfo.GetTargetSchemaName(),
+			Table:       tableInfo.GetTargetTableName(),
 			TableID:     event.PhysicalTableID,
-			IsPartition: event.TableInfo.IsPartitionTable(),
+			IsPartition: tableInfo.IsPartitionTable(),
 		},
 		TableInfoVersion: event.TableInfoVersion,
 		DispatcherID:     event.GetDispatcherID(),

--- a/downstreamadapter/sink/cloudstorage/dml_writers_routing_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_routing_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudstorage
+
+import (
+	"context"
+	"testing"
+
+	commonType "github.com/pingcap/ticdc/pkg/common"
+	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/utils/chann"
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddDMLEventUsesTargetNames(t *testing.T) {
+	t.Parallel()
+
+	idFieldType := types.NewFieldType(mysql.TypeLong)
+	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
+	routedTableInfo := commonType.WrapTableInfo("source_db", &timodel.TableInfo{
+		ID:       20,
+		Name:     ast.NewCIStr("source_table"),
+		UpdateTS: 100,
+		Columns: []*timodel.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *idFieldType,
+				State:     timodel.StatePublic,
+			},
+		},
+	}).CloneWithRouting("target_db", "target_table")
+	dmlEvent := commonEvent.NewDMLEvent(
+		commonType.NewDispatcherID(),
+		routedTableInfo.TableName.TableID,
+		1,
+		2,
+		routedTableInfo,
+	)
+	dmlEvent.TableInfoVersion = routedTableInfo.GetUpdateTS()
+
+	writers := &dmlWriters{
+		msgCh: chann.NewUnlimitedChannelDefault[*task](),
+	}
+
+	writers.addDMLEvent(dmlEvent)
+
+	task, ok, err := writers.msgCh.GetWithContext(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, task)
+	require.Equal(t, "target_db", task.versionedTable.TableNameWithPhysicTableID.Schema)
+	require.Equal(t, "target_table", task.versionedTable.TableNameWithPhysicTableID.Table)
+	require.Equal(t, dmlEvent.PhysicalTableID, task.versionedTable.TableNameWithPhysicTableID.TableID)
+	require.Equal(t, routedTableInfo.IsPartitionTable(), task.versionedTable.TableNameWithPhysicTableID.IsPartition)
+}

--- a/downstreamadapter/sink/cloudstorage/dml_writers_routing_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_routing_test.go
@@ -17,10 +17,10 @@ import (
 	"context"
 	"testing"
 
-	commonType "github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/utils/chann"
-	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -32,21 +32,21 @@ func TestAddDMLEventUsesTargetNames(t *testing.T) {
 
 	idFieldType := types.NewFieldType(mysql.TypeLong)
 	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
-	routedTableInfo := commonType.WrapTableInfo("source_db", &timodel.TableInfo{
+	routedTableInfo := common.WrapTableInfo("source_db", &model.TableInfo{
 		ID:       20,
 		Name:     ast.NewCIStr("source_table"),
 		UpdateTS: 100,
-		Columns: []*timodel.ColumnInfo{
+		Columns: []*model.ColumnInfo{
 			{
 				ID:        1,
 				Name:      ast.NewCIStr("id"),
 				FieldType: *idFieldType,
-				State:     timodel.StatePublic,
+				State:     model.StatePublic,
 			},
 		},
 	}).CloneWithRouting("target_db", "target_table")
 	dmlEvent := commonEvent.NewDMLEvent(
-		commonType.NewDispatcherID(),
+		common.NewDispatcherID(),
 		routedTableInfo.TableName.TableID,
 		1,
 		2,

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -244,14 +244,26 @@ func (s *sink) writeDDLEvent(event *commonEvent.DDLEvent) error {
 		sourceTableInfo := event.MultipleTableInfos[1]
 
 		var def cloudstorage.TableDefinition
-		def.FromTableInfo(event.ExtraSchemaName, event.ExtraTableName, event.TableInfo, event.FinishedTs, s.cfg.OutputColumnID)
+		def.FromTableInfo(
+			event.GetTargetExtraSchemaName(),
+			event.GetTargetExtraTableName(),
+			event.TableInfo,
+			event.FinishedTs,
+			s.cfg.OutputColumnID,
+		)
 		def.Query = event.Query
 		def.Type = event.Type
 		if err := s.writeFile(event, def); err != nil {
 			return err
 		}
 		var sourceTableDef cloudstorage.TableDefinition
-		sourceTableDef.FromTableInfo(event.SchemaName, event.TableName, sourceTableInfo, event.FinishedTs, s.cfg.OutputColumnID)
+		sourceTableDef.FromTableInfo(
+			sourceTableInfo.GetTargetSchemaName(),
+			sourceTableInfo.GetTargetTableName(),
+			sourceTableInfo,
+			event.FinishedTs,
+			s.cfg.OutputColumnID,
+		)
 		sourceEvent := *event
 		sourceEvent.TableInfo = sourceTableInfo
 		if err := s.writeFile(&sourceEvent, sourceTableDef); err != nil {
@@ -269,8 +281,8 @@ func (s *sink) writeDDLEvent(event *commonEvent.DDLEvent) error {
 	log.Info("storage sink executed ddl event",
 		zap.String("keyspace", s.changefeedID.Keyspace()),
 		zap.String("changefeed", s.changefeedID.Name()),
-		zap.String("schema", event.GetSchemaName()),
-		zap.String("table", event.GetTableName()),
+		zap.String("schema", event.GetTargetSchemaName()),
+		zap.String("table", event.GetTargetTableName()),
 		zap.String("dispatcher", event.GetDispatcherID().String()),
 		zap.String("query", event.GetDDLQuery()),
 		zap.Uint64("finishedTs", event.GetCommitTs()),

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -99,6 +99,7 @@ func Verify(ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.
 	return nil
 }
 
+//nolint:revive // Keep the constructor shape consistent with other sink implementations.
 func New(
 	ctx context.Context, changefeedID common.ChangeFeedID, sinkURI *url.URL, sinkConfig *config.SinkConfig, enableTableAcrossNodes bool,
 	cleanupJobs []func(), /* only for test */

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -348,7 +348,7 @@ func (s *sink) sendCheckpointTs(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Trace(context.Cause(ctx))
+			return context.Cause(ctx)
 		case checkpoint = <-s.checkpointChan:
 		}
 
@@ -402,7 +402,7 @@ func (s *sink) initCron(
 	for _, job := range cleanupJobs {
 		err = s.cron.AddFunc(s.cfg.FileCleanupCronSpec, job)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.WrapError(errors.ErrStorageSinkInvalidConfig, err, "add cloud storage cleanup job")
 		}
 	}
 	return nil

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -258,8 +258,8 @@ func (s *sink) writeDDLEvent(event *commonEvent.DDLEvent) error {
 		}
 		var sourceTableDef cloudstorage.TableDefinition
 		sourceTableDef.FromTableInfo(
-			sourceTableInfo.GetTargetSchemaName(),
-			sourceTableInfo.GetTargetTableName(),
+			event.GetTargetSchemaName(),
+			event.GetTargetTableName(),
 			sourceTableInfo,
 			event.FinishedTs,
 			s.cfg.OutputColumnID,

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -451,7 +451,7 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 
 			checkpointTs := s.lastCheckpointTs.Load()
 			start := time.Now()
-			cnt, err := cloudstorage.RemoveEmptyDirs(ctx, s.changefeedID, uri.Path)
+			err := cloudstorage.RemoveEmptyDirs(ctx, s.changefeedID, uri.Path)
 			if err != nil {
 				log.Error("failed to remove empty dirs",
 					zap.String("keyspace", s.changefeedID.Keyspace()),
@@ -466,7 +466,6 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 				zap.String("keyspace", s.changefeedID.Keyspace()),
 				zap.String("changefeedID", s.changefeedID.Name()),
 				zap.Uint64("checkpointTs", checkpointTs),
-				zap.Uint64("count", cnt),
 				zap.Duration("cost", time.Since(start)))
 		})
 	}
@@ -483,7 +482,7 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 		defer isCleanupRunning.Store(false)
 		start := time.Now()
 		checkpointTs := s.lastCheckpointTs.Load()
-		cnt, err := cloudstorage.RemoveExpiredFiles(ctx, s.changefeedID, s.storage, s.cfg, checkpointTs)
+		err := cloudstorage.RemoveExpiredFiles(ctx, s.changefeedID, s.storage, s.cfg, checkpointTs)
 		if err != nil {
 			log.Error("failed to remove expired files",
 				zap.String("keyspace", s.changefeedID.Keyspace()),
@@ -498,7 +497,6 @@ func (s *sink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 			zap.String("keyspace", s.changefeedID.Keyspace()),
 			zap.String("changefeedID", s.changefeedID.Name()),
 			zap.Uint64("checkpointTs", checkpointTs),
-			zap.Uint64("count", cnt),
 			zap.Duration("cost", time.Since(start)))
 	})
 	return ret

--- a/downstreamadapter/sink/cloudstorage/sink.go
+++ b/downstreamadapter/sink/cloudstorage/sink.go
@@ -294,9 +294,6 @@ func (s *sink) writeDDLEvent(event *commonEvent.DDLEvent) error {
 func (s *sink) writeFile(v *commonEvent.DDLEvent, def cloudstorage.TableDefinition) error {
 	// skip write database-level event for 'use-table-id-as-path' mode
 	if s.cfg.UseTableIDAsPath && def.Table == "" {
-		log.Debug("skip database schema for table id path",
-			zap.String("schema", def.Schema),
-			zap.String("query", def.Query))
 		return nil
 	}
 	encodedDef, err := def.MarshalWithQuery()
@@ -308,8 +305,6 @@ func (s *sink) writeFile(v *commonEvent.DDLEvent, def cloudstorage.TableDefiniti
 	if err != nil {
 		return err
 	}
-	log.Debug("write ddl event to external storage",
-		zap.String("path", path), zap.Any("ddl", v))
 	return s.statistics.RecordDDLExecution(func() (string, error) {
 		err = s.storage.WriteFile(s.ctx, path, encodedDef)
 		if err != nil {

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -15,6 +15,7 @@ package cloudstorage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -499,6 +500,21 @@ func TestWriteDDLEventWithInvalidExchangePartitionEvent(t *testing.T) {
 	}
 }
 
+func readSchemaDefinitionForTest(t *testing.T, parentDir, schema, table string) pkgcloudstorage.TableDefinition {
+	t.Helper()
+
+	files, err := os.ReadDir(filepath.Join(parentDir, schema, table, "meta"))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	content, err := os.ReadFile(filepath.Join(parentDir, schema, table, "meta", files[0].Name()))
+	require.NoError(t, err)
+
+	var def pkgcloudstorage.TableDefinition
+	require.NoError(t, json.Unmarshal(content, &def))
+	return def
+}
+
 func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
 	parentDir := t.TempDir()
 	uri := fmt.Sprintf("file:///%s?protocol=csv", parentDir)
@@ -518,16 +534,38 @@ func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	tableInfo := common.WrapTableInfo("source_db", &timodel.TableInfo{
+	idColumn := &timodel.ColumnInfo{
+		ID:        1,
+		Name:      ast.NewCIStr("id"),
+		FieldType: *types.NewFieldType(mysql.TypeLong),
+		State:     timodel.StatePublic,
+	}
+	partitionedTableInfo := common.WrapTableInfo("source_db", &timodel.TableInfo{
 		ID:   20,
 		Name: ast.NewCIStr("partitioned"),
 		Columns: []*timodel.ColumnInfo{
+			idColumn,
 			{
-				Name:      ast.NewCIStr("id"),
-				FieldType: *types.NewFieldType(mysql.TypeLong),
+				ID:        2,
+				Name:      ast.NewCIStr("partition_value"),
+				FieldType: *types.NewFieldType(mysql.TypeVarchar),
+				State:     timodel.StatePublic,
 			},
 		},
 	}).CloneWithRouting("target_db", "partitioned_routed")
+	exchangeTableInfo := common.WrapTableInfo("source_db", &timodel.TableInfo{
+		ID:   21,
+		Name: ast.NewCIStr("exchange_table"),
+		Columns: []*timodel.ColumnInfo{
+			idColumn,
+			{
+				ID:        2,
+				Name:      ast.NewCIStr("exchange_value"),
+				FieldType: *types.NewFieldType(mysql.TypeVarchar),
+				State:     timodel.StatePublic,
+			},
+		},
+	}).CloneWithRouting("target_db", "exchange_table_routed")
 
 	baseEvent := &commonEvent.DDLEvent{
 		Query:           "alter table source_db.partitioned exchange partition p0 with table source_db.exchange_table",
@@ -537,7 +575,7 @@ func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
 		ExtraSchemaName: "source_db",
 		ExtraTableName:  "exchange_table",
 		FinishedTs:      100,
-		TableInfo:       tableInfo,
+		TableInfo:       partitionedTableInfo,
 	}
 	routedEvent := commonEvent.NewRoutedDDLEvent(
 		baseEvent,
@@ -546,18 +584,24 @@ func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
 		"partitioned_routed",
 		"target_db",
 		"exchange_table_routed",
-		tableInfo,
-		[]*common.TableInfo{tableInfo, tableInfo},
+		partitionedTableInfo,
+		[]*common.TableInfo{partitionedTableInfo, exchangeTableInfo},
 		nil,
 	)
 
 	err = cloudStorageSink.WriteBlockEvent(routedEvent)
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join(parentDir, "target_db", "exchange_table_routed", "meta"))
-	require.NoError(t, err)
-	_, err = os.Stat(filepath.Join(parentDir, "target_db", "partitioned_routed", "meta"))
-	require.NoError(t, err)
+	exchangeDef := readSchemaDefinitionForTest(t, parentDir, "target_db", "exchange_table_routed")
+	require.Equal(t, "target_db", exchangeDef.Schema)
+	require.Equal(t, "exchange_table_routed", exchangeDef.Table)
+	require.Equal(t, "partition_value", exchangeDef.Columns[1].Name)
+
+	partitionedDef := readSchemaDefinitionForTest(t, parentDir, "target_db", "partitioned_routed")
+	require.Equal(t, "target_db", partitionedDef.Schema)
+	require.Equal(t, "partitioned_routed", partitionedDef.Table)
+	require.Equal(t, "exchange_value", partitionedDef.Columns[1].Name)
+
 	_, err = os.Stat(filepath.Join(parentDir, "source_db"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -499,6 +499,69 @@ func TestWriteDDLEventWithInvalidExchangePartitionEvent(t *testing.T) {
 	}
 }
 
+func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
+	parentDir := t.TempDir()
+	uri := fmt.Sprintf("file:///%s?protocol=csv", parentDir)
+	sinkURI, err := url.Parse(uri)
+	require.NoError(t, err)
+
+	replicaConfig := config.GetDefaultReplicaConfig()
+	err = replicaConfig.ValidateAndAdjust(sinkURI)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockPDClock := pdutil.NewClock4Test()
+	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+
+	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
+	require.NoError(t, err)
+
+	tableInfo := common.WrapTableInfo("source_db", &timodel.TableInfo{
+		ID:   20,
+		Name: ast.NewCIStr("partitioned"),
+		Columns: []*timodel.ColumnInfo{
+			{
+				Name:      ast.NewCIStr("id"),
+				FieldType: *types.NewFieldType(mysql.TypeLong),
+			},
+		},
+	}).CloneWithRouting("target_db", "partitioned_routed")
+
+	baseEvent := &commonEvent.DDLEvent{
+		Query:           "alter table source_db.partitioned exchange partition p0 with table source_db.exchange_table",
+		Type:            byte(timodel.ActionExchangeTablePartition),
+		SchemaName:      "source_db",
+		TableName:       "partitioned",
+		ExtraSchemaName: "source_db",
+		ExtraTableName:  "exchange_table",
+		FinishedTs:      100,
+		TableInfo:       tableInfo,
+	}
+	routedEvent := commonEvent.NewRoutedDDLEvent(
+		baseEvent,
+		"alter table target_db.partitioned_routed exchange partition p0 with table target_db.exchange_table_routed",
+		"target_db",
+		"partitioned_routed",
+		"target_db",
+		"exchange_table_routed",
+		tableInfo,
+		[]*common.TableInfo{tableInfo, tableInfo},
+		nil,
+	)
+
+	err = cloudStorageSink.WriteBlockEvent(routedEvent)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(parentDir, "target_db", "exchange_table_routed", "meta"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(parentDir, "target_db", "partitioned_routed", "meta"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(parentDir, "source_db"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestWriteCheckpointEvent(t *testing.T) {
 	parentDir := t.TempDir()
 	uri := fmt.Sprintf("file:///%s?protocol=csv", parentDir)

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -504,8 +504,7 @@ func FetchIndexFromFileName(fileName string, extension string) (uint64, error) {
 	if len(fileName) < minFileNamePrefixLen+len(extension) ||
 		!strings.HasPrefix(fileName, "CDC") ||
 		!strings.HasSuffix(fileName, extension) {
-		return 0, errors.ErrStorageSinkInvalidFileName.GenWithStack(
-			"filename in storage sink is invalid: %q", fileName)
+		return 0, errors.ErrStorageSinkInvalidFileName.GenWithStack("filename in storage sink is invalid: %q", fileName)
 	}
 
 	// CDC[_{dispatcherID}_]{num}.fileExtension
@@ -516,8 +515,7 @@ func FetchIndexFromFileName(fileName string, extension string) (uint64, error) {
 
 	matches := pathRE.FindStringSubmatch(fileName)
 	if len(matches) != 3 {
-		return 0, errors.ErrStorageSinkInvalidFileName.GenWithStack(
-			"cannot match dml path pattern for %q", fileName)
+		return 0, errors.ErrStorageSinkInvalidFileName.GenWithStack("cannot match dml path pattern for %q", fileName)
 	}
 	return strconv.ParseUint(matches[2], 10, 64)
 }
@@ -531,9 +529,9 @@ func RemoveExpiredFiles(
 	storage storage.ExternalStorage,
 	cfg *Config,
 	checkpointTs uint64,
-) (uint64, error) {
+) error {
 	if cfg.DateSeparator != config.DateSeparatorDay.String() {
-		return 0, nil
+		return nil
 	}
 	if dateSeparatorDayRegexp == nil {
 		dateSeparatorDayRegexp = regexp.MustCompile(config.DateSeparatorDay.GetPattern())
@@ -544,18 +542,13 @@ func RemoveExpiredFiles(
 	// Note: `expiredDate` is formatted using local TZ.
 	expiredDate := currTime.Format("2006-01-02")
 
-	cnt := uint64(0)
 	err := util.RemoveFilesIf(ctx, storage, func(path string) bool {
 		// the path is like: <schema>/<table>/<tableVersion>/<partitionID>/<date>/CDC_{dispatcher}_{num}.extension
 		// or <schema>/<table>/<tableVersion>/<partitionID>/<date>/CDC{num}.extension
 		match := dateSeparatorDayRegexp.FindString(path)
-		if match != "" && match < expiredDate {
-			cnt++
-			return true
-		}
-		return false
+		return match != "" && match < expiredDate
 	}, nil)
-	return cnt, err
+	return err
 }
 
 // RemoveEmptyDirs removes empty directories from external storage.
@@ -563,8 +556,7 @@ func RemoveEmptyDirs(
 	ctx context.Context,
 	id commonType.ChangeFeedID,
 	target string,
-) (uint64, error) {
-	cnt := uint64(0)
+) error {
 	err := filepath.Walk(target, func(path string, info fs.FileInfo, err error) error {
 		if os.IsNotExist(err) || path == target || info == nil {
 			// if path not exists, we should return nil to continue.
@@ -573,21 +565,19 @@ func RemoveEmptyDirs(
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
-			files, err := os.ReadDir(path)
-			if err == nil && len(files) == 0 {
-				log.Debug("Deleting empty directory",
-					zap.String("keyspace", id.Keyspace()),
-					zap.String("changeFeedID", id.Name()),
-					zap.String("path", path))
-				// Keep best-effort cleanup semantics: ignore remove failures.
-				_ = os.Remove(path) // #nosec G122
-				cnt++
-				return filepath.SkipDir
-			}
+
+		if !info.IsDir() {
+			return nil
+		}
+
+		files, err := os.ReadDir(path)
+		if err == nil && len(files) == 0 {
+			// Keep best-effort cleanup semantics: ignore remove failures.
+			_ = os.Remove(path) // #nosec G122
+			return filepath.SkipDir
 		}
 		return nil
 	})
 
-	return cnt, err
+	return err
 }

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -230,7 +230,15 @@ func (f *FilePathGenerator) CheckOrWriteSchema(
 	changefeed := f.changefeedID.Name()
 
 	var def TableDefinition
-	def.FromTableInfo(tableInfo.GetSchemaName(), tableInfo.GetTableName(), tableInfo, table.TableInfoVersion, f.config.OutputColumnID)
+	targetSchema := tableInfo.GetTargetSchemaName()
+	targetTable := tableInfo.GetTargetTableName()
+	def.FromTableInfo(
+		targetSchema,
+		targetTable,
+		tableInfo,
+		table.TableInfoVersion,
+		f.config.OutputColumnID,
+	)
 	if !def.IsTableSchema() {
 		// only check schema for table
 		log.Error("invalid table schema",

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -230,11 +230,9 @@ func (f *FilePathGenerator) CheckOrWriteSchema(
 	changefeed := f.changefeedID.Name()
 
 	var def TableDefinition
-	targetSchema := tableInfo.GetTargetSchemaName()
-	targetTable := tableInfo.GetTargetTableName()
 	def.FromTableInfo(
-		targetSchema,
-		targetTable,
+		tableInfo.GetTargetSchemaName(),
+		tableInfo.GetTargetTableName(),
 		tableInfo,
 		table.TableInfoVersion,
 		f.config.OutputColumnID,

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -66,28 +66,30 @@ func IsSchemaFile(path string) bool {
 
 // mustParseSchemaName parses the version from the schema file name.
 func mustParseSchemaName(path string) (uint64, uint32) {
-	reportErr := func(err error) {
-		log.Panic("failed to parse schema file name",
+	reportErr := func(reason string, fields ...zap.Field) {
+		fields = append([]zap.Field{
 			zap.String("schemaPath", path),
-			zap.Any("error", err))
+			zap.String("reason", reason),
+		}, fields...)
+		log.Panic("failed to parse schema file name", fields...)
 	}
 
 	// For <schema>/<table>/meta/schema_{tableVersion}_{checksum}.json, the parts
 	// should be ["<schema>/<table>/meta/schema", "{tableVersion}", "{checksum}.json"].
 	parts := strings.Split(path, "_")
 	if len(parts) < 3 {
-		reportErr(errors.New("invalid path format"))
+		reportErr("invalid path format")
 	}
 
 	checksum := strings.TrimSuffix(parts[len(parts)-1], ".json")
 	tableChecksum, err := strconv.ParseUint(checksum, 10, 32)
 	if err != nil {
-		reportErr(err)
+		reportErr("invalid checksum", zap.Error(err))
 	}
 	version := parts[len(parts)-2]
 	tableVersion, err := strconv.ParseUint(version, 10, 64)
 	if err != nil {
-		reportErr(err)
+		reportErr("invalid table version", zap.Error(err))
 	}
 	return tableVersion, uint32(tableChecksum)
 }
@@ -96,9 +98,9 @@ func generateSchemaFilePath(
 	schema, table string, tableVersion uint64, checksum uint32, omitSchema bool,
 ) (string, error) {
 	if schema == "" || tableVersion == 0 {
-		return "", errors.ErrInternalCheckFailed.GenWithStackByArgs(
-			fmt.Sprintf("invalid schema or tableVersion, schema=%q table=%q tableVersion=%d",
-				schema, table, tableVersion),
+		return "", errors.ErrInternalCheckFailed.GenWithStack(
+			"invalid schema or tableVersion, schema=%q table=%q tableVersion=%d",
+			schema, table, tableVersion,
 		)
 	}
 
@@ -290,9 +292,9 @@ func (f *FilePathGenerator) CheckOrWriteSchema(
 				zap.String("keyspace", keyspace),
 				zap.String("changefeedID", changefeed),
 				zap.String("path", path), zap.Any("checksum", checksum))
-			errMsg := fmt.Sprintf("invalid schema filename in storage sink, "+
-				"expected checksum: %d, actual checksum: %d", checksum, parsedChecksum)
-			return errors.ErrInternalCheckFailed.GenWithStackByArgs(errMsg)
+			return errors.ErrInternalCheckFailed.GenWithStack(
+				"invalid schema filename in storage sink, expected checksum: %d, actual checksum: %d",
+				checksum, parsedChecksum)
 		}
 		if version > table.TableInfoVersion {
 			hasNewerSchemaVersion = true
@@ -502,8 +504,8 @@ func FetchIndexFromFileName(fileName string, extension string) (uint64, error) {
 	if len(fileName) < minFileNamePrefixLen+len(extension) ||
 		!strings.HasPrefix(fileName, "CDC") ||
 		!strings.HasSuffix(fileName, extension) {
-		return 0, errors.WrapError(errors.ErrStorageSinkInvalidFileName,
-			fmt.Errorf("'%s' is a invalid file name", fileName))
+		return 0, errors.ErrStorageSinkInvalidFileName.GenWithStack(
+			"filename in storage sink is invalid: %q", fileName)
 	}
 
 	// CDC[_{dispatcherID}_]{num}.fileExtension
@@ -514,7 +516,8 @@ func FetchIndexFromFileName(fileName string, extension string) (uint64, error) {
 
 	matches := pathRE.FindStringSubmatch(fileName)
 	if len(matches) != 3 {
-		return 0, fmt.Errorf("cannot match dml path pattern for %s", fileName)
+		return 0, errors.ErrStorageSinkInvalidFileName.GenWithStack(
+			"cannot match dml path pattern for %q", fileName)
 	}
 	return strconv.ParseUint(matches[2], 10, 64)
 }

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -54,7 +54,7 @@ const (
 	// <schema>/<table>/meta/schema_{tableVersion}_{checksum}.json
 	tableSchemaPrefix = "%s/%s/meta/"
 	// When use-table-id-as-path, schema is omitted: <table_id>/meta/...
-	tableIdPrefix = "%s/meta/"
+	tableIDPrefix = "%s/meta/"
 )
 
 var schemaRE = regexp.MustCompile(`meta/schema_\d+_\d{10}\.json$`)
@@ -80,7 +80,7 @@ func mustParseSchemaName(path string) (uint64, uint32) {
 	}
 
 	checksum := strings.TrimSuffix(parts[len(parts)-1], ".json")
-	tableChecksum, err := strconv.ParseUint(checksum, 10, 64)
+	tableChecksum, err := strconv.ParseUint(checksum, 10, 32)
 	if err != nil {
 		reportErr(err)
 	}
@@ -110,7 +110,7 @@ func generateSchemaFilePath(
 			)
 		}
 		// use-table-id-as-path: omit schema, path is <table_id>/meta/
-		dir = fmt.Sprintf(tableIdPrefix, table)
+		dir = fmt.Sprintf(tableIDPrefix, table)
 	} else {
 		if table == "" {
 			// Generate db schema file path.
@@ -270,7 +270,7 @@ func (f *FilePathGenerator) CheckOrWriteSchema(
 	}
 	var subDir string
 	if f.config.UseTableIDAsPath {
-		subDir = fmt.Sprintf(tableIdPrefix, tablePathPart)
+		subDir = fmt.Sprintf(tableIDPrefix, tablePathPart)
 	} else {
 		subDir = fmt.Sprintf(tableSchemaPrefix, def.Schema, tablePathPart)
 	}
@@ -577,7 +577,8 @@ func RemoveEmptyDirs(
 					zap.String("keyspace", id.Keyspace()),
 					zap.String("changeFeedID", id.Name()),
 					zap.String("path", path))
-				os.Remove(path)
+				// Keep best-effort cleanup semantics: ignore remove failures.
+				_ = os.Remove(path) // #nosec G122
 				cnt++
 				return filepath.SkipDir
 			}

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -405,6 +405,48 @@ func TestCheckOrWriteSchema(t *testing.T) {
 	require.Equal(t, 2, len(files))
 }
 
+func TestCheckOrWriteSchemaUsesRoutedTargetNames(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dir := t.TempDir()
+	f := testFilePathGenerator(ctx, t, dir)
+
+	tableInfo := commonType.WrapTableInfo("source_db", &timodel.TableInfo{
+		ID:   20,
+		Name: ast.NewCIStr("source_table"),
+		Columns: []*timodel.ColumnInfo{
+			{
+				Name:      ast.NewCIStr("id"),
+				FieldType: *types.NewFieldType(mysql.TypeLong),
+				State:     timodel.StatePublic,
+			},
+		},
+		Version: 100,
+	}).CloneWithRouting("target_db", "target_table")
+
+	table := VersionedTableName{
+		TableNameWithPhysicTableID: commonType.TableName{
+			Schema:  tableInfo.GetSchemaName(),
+			Table:   tableInfo.GetTableName(),
+			TableID: tableInfo.TableName.TableID,
+		},
+		TableInfoVersion: 100,
+	}
+
+	hasNewerSchemaVersion, err := f.CheckOrWriteSchema(ctx, table, tableInfo)
+	require.NoError(t, err)
+	require.False(t, hasNewerSchemaVersion)
+
+	files, err := os.ReadDir(filepath.Join(dir, "target_db", "target_table", "meta"))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	_, err = os.Stat(filepath.Join(dir, "source_db"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestRemoveExpiredFilesWithoutPartition(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -528,7 +528,6 @@ func TestRemoveExpiredFilesWithoutPartition(t *testing.T) {
 
 	currTime := time.Date(2021, 1, 3, 0, 0, 0, 0, time.Local)
 	checkpointTs := oracle.GoTimeToTS(currTime)
-	cnt, err := RemoveExpiredFiles(ctx, commonType.ChangeFeedID{}, storage, cfg, checkpointTs)
+	err = RemoveExpiredFiles(ctx, commonType.ChangeFeedID{}, storage, cfg, checkpointTs)
 	require.NoError(t, err)
-	require.Equal(t, uint64(16), cnt)
 }

--- a/pkg/sink/cloudstorage/table_definition.go
+++ b/pkg/sink/cloudstorage/table_definition.go
@@ -213,7 +213,7 @@ type tableDefWithoutQuery struct {
 
 // FromDDLEvent converts from DDLEvent to TableDefinition.
 func (t *TableDefinition) FromDDLEvent(event *commonEvent.DDLEvent, outputColumnID bool) {
-	t.FromTableInfo(event.SchemaName, event.TableName, event.TableInfo, event.FinishedTs, outputColumnID)
+	t.FromTableInfo(event.GetTargetSchemaName(), event.GetTargetTableName(), event.TableInfo, event.FinishedTs, outputColumnID)
 	t.Query = event.Query
 	t.Type = event.Type
 }

--- a/pkg/sink/cloudstorage/table_definition.go
+++ b/pkg/sink/cloudstorage/table_definition.go
@@ -23,7 +23,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/hash"
-	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -51,7 +51,7 @@ type TableCol struct {
 }
 
 // FromTiColumnInfo converts from TiDB ColumnInfo to TableCol.
-func (t *TableCol) FromTiColumnInfo(col *timodel.ColumnInfo, outputColumnID bool) {
+func (t *TableCol) FromTiColumnInfo(col *model.ColumnInfo, outputColumnID bool) {
 	defaultFlen, defaultDecimal := mysql.GetDefaultFieldLengthAndDecimal(col.GetType())
 	isDecimalNotDefault := col.GetDecimal() != defaultDecimal &&
 		col.GetDecimal() != 0 &&
@@ -106,14 +106,14 @@ func (t *TableCol) FromTiColumnInfo(col *timodel.ColumnInfo, outputColumnID bool
 }
 
 // ToTiColumnInfo converts from TableCol to TiDB ColumnInfo.
-func (t *TableCol) ToTiColumnInfo(colID int64) (*timodel.ColumnInfo, error) {
-	col := new(timodel.ColumnInfo)
+func (t *TableCol) ToTiColumnInfo(colID int64) (*model.ColumnInfo, error) {
+	col := new(model.ColumnInfo)
 
 	if t.ID != "" {
 		var err error
 		col.ID, err = strconv.ParseInt(t.ID, 10, 64)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.WrapError(errors.ErrInternalCheckFailed, err)
 		}
 	}
 
@@ -140,7 +140,7 @@ func (t *TableCol) ToTiColumnInfo(colID int64) (*timodel.ColumnInfo, error) {
 		if len(precision) > 0 {
 			flen, err := strconv.Atoi(precision)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.WrapError(errors.ErrInternalCheckFailed, err)
 			}
 			col.SetFlen(flen)
 		}
@@ -150,7 +150,7 @@ func (t *TableCol) ToTiColumnInfo(colID int64) (*timodel.ColumnInfo, error) {
 		if len(scale) > 0 {
 			decimal, err := strconv.Atoi(scale)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.WrapError(errors.ErrInternalCheckFailed, err)
 			}
 			col.SetDecimal(decimal)
 		}
@@ -160,23 +160,23 @@ func (t *TableCol) ToTiColumnInfo(colID int64) (*timodel.ColumnInfo, error) {
 	case mysql.TypeTimestamp, mysql.TypeDatetime, mysql.TypeDuration:
 		err := setDecimal(t.Scale)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	case mysql.TypeDouble, mysql.TypeFloat, mysql.TypeNewDecimal:
 		err := setFlen(t.Precision)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		err = setDecimal(t.Scale)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong,
 		mysql.TypeBit, mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob,
 		mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeYear:
 		err := setFlen(t.Precision)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	case mysql.TypeEnum, mysql.TypeSet:
 		col.SetElems(t.Elems)
@@ -257,7 +257,7 @@ func (t *TableDefinition) FromTableInfo(
 
 // ToTableInfo converts from TableDefinition to DDLEvent.
 func (t *TableDefinition) ToTableInfo() (*common.TableInfo, error) {
-	tidbTableInfo := &timodel.TableInfo{
+	tidbTableInfo := &model.TableInfo{
 		Name: ast.NewCIStr(t.Table),
 	}
 	nextMockID := int64(100) // 100 is an arbitrary number
@@ -350,14 +350,10 @@ func (t *TableDefinition) GenerateSchemaFilePath(useTableIDAsPath bool, tableID 
 	}
 	isTableSchema := t.TotalColumns != 0
 	if !isTableSchema && t.Table != "" {
-		return "", errors.ErrInternalCheckFailed.GenWithStackByArgs(
-			"invalid table definition",
-		)
+		return "", errors.ErrInternalCheckFailed.GenWithStackByArgs("invalid table definition")
 	}
 	if useTableIDAsPath && isTableSchema && tableID <= 0 {
-		return "", errors.ErrInternalCheckFailed.GenWithStackByArgs(
-			"invalid table id for table-id path",
-		)
+		return "", errors.ErrInternalCheckFailed.GenWithStackByArgs("invalid table id for table-id path")
 	}
 
 	table := t.Table

--- a/pkg/sink/cloudstorage/table_definition_test.go
+++ b/pkg/sink/cloudstorage/table_definition_test.go
@@ -77,6 +77,53 @@ func generateTableDef() (TableDefinition, *common.TableInfo) {
 	return def, tableInfo
 }
 
+func TestFromDDLEventUsesTargetNames(t *testing.T) {
+	t.Parallel()
+
+	idFieldType := types.NewFieldType(mysql.TypeLong)
+	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
+	routedTableInfo := common.WrapTableInfo("source_db", &timodel.TableInfo{
+		ID:       20,
+		Name:     ast.NewCIStr("source_table"),
+		UpdateTS: 100,
+		Columns: []*timodel.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *idFieldType,
+				State:     timodel.StatePublic,
+			},
+		},
+	}).CloneWithRouting("target_db", "target_table")
+	sourceDDL := &commonEvent.DDLEvent{
+		Version:    commonEvent.DDLEventVersion1,
+		Type:       byte(timodel.ActionCreateTable),
+		SchemaName: "source_db",
+		TableName:  "source_table",
+		Query:      "CREATE TABLE `source_db`.`source_table` (`id` INT PRIMARY KEY)",
+		TableInfo:  routedTableInfo,
+		FinishedTs: 100,
+	}
+
+	routedDDL := commonEvent.NewRoutedDDLEvent(
+		sourceDDL,
+		"CREATE TABLE `target_db`.`target_table` (`id` INT PRIMARY KEY)",
+		"target_db",
+		"target_table",
+		"",
+		"",
+		routedTableInfo,
+		nil,
+		nil,
+	)
+
+	var def TableDefinition
+	def.FromDDLEvent(routedDDL, false)
+	require.Equal(t, "target_db", def.Schema)
+	require.Equal(t, "target_table", def.Table)
+	require.Contains(t, def.Query, "`target_db`.`target_table`")
+}
+
 func TestTableCol(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sink/codec/canal/canal_json_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_encoder.go
@@ -146,6 +146,8 @@ func newJSONMessageForDML(
 		return nil, errors.ErrCanalEncodeFailed.GenWithStack("not found valid columns for the event")
 	}
 
+	targetSchema := e.TableInfo.GetTargetSchemaName()
+	targetTable := e.TableInfo.GetTargetTableName()
 	mysqlTypeMap := make(map[string]string, columnLen)
 	// TODO: use util.JsonWriter
 	out := &jwriter.Writer{}
@@ -158,12 +160,12 @@ func newJSONMessageForDML(
 	{
 		const prefix string = ",\"database\":"
 		out.RawString(prefix)
-		out.String(e.TableInfo.GetSchemaName())
+		out.String(targetSchema)
 	}
 	{
 		const prefix string = ",\"table\":"
 		out.RawString(prefix)
-		out.String(e.TableInfo.GetTableName())
+		out.String(targetTable)
 	}
 	{
 		const prefix string = ",\"pkNames\":"
@@ -385,10 +387,12 @@ func NewJSONRowEventEncoder(ctx context.Context, config *common.Config) (common.
 }
 
 func (c *JSONRowEventEncoder) newJSONMessageForDDL(e *commonEvent.DDLEvent) canalJSONMessageInterface {
+	targetSchema := e.GetTargetSchemaName()
+	targetTable := e.GetTargetTableName()
 	msg := &JSONMessage{
 		ID:            0, // ignored by both Canal Adapter and Flink
-		Schema:        e.GetSchemaName(),
-		Table:         e.GetTableName(),
+		Schema:        targetSchema,
+		Table:         targetTable,
 		IsDDL:         true,
 		EventType:     convertDdlEventType(e.Type).String(),
 		ExecutionTime: convertToCanalTs(e.GetCommitTs()),
@@ -449,6 +453,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 	_ string,
 	e *commonEvent.RowEvent,
 ) error {
+	targetTable := e.TableInfo.GetTargetTableName()
 	value, err := newJSONMessageForDML(e, c.config, false, "")
 	if err != nil {
 		return errors.Trace(err)
@@ -473,7 +478,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 				zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
 				zap.Int("length", originLength),
 				zap.Any("table", e.TableInfo.TableName))
-			return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), originLength, c.config.MaxMessageBytes)
+			return errors.ErrMessageTooLarge.GenWithStackByArgs(targetTable, originLength, c.config.MaxMessageBytes)
 		}
 
 		if c.config.LargeMessageHandle.HandleKeyOnly() {
@@ -496,7 +501,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 					zap.Int("originLength", originLength),
 					zap.Int("length", length),
 					zap.Any("table", e.TableInfo.TableName))
-				return errors.ErrMessageTooLarge.GenWithStackByArgs(e.TableInfo.GetTableName(), length, c.config.MaxMessageBytes)
+				return errors.ErrMessageTooLarge.GenWithStackByArgs(targetTable, length, c.config.MaxMessageBytes)
 			}
 			log.Warn("Single message is too large for canal-json, only encode handle-key columns",
 				zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
@@ -525,6 +530,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 func (c *JSONRowEventEncoder) newClaimCheckLocationMessage(
 	event *commonEvent.RowEvent, fileName string,
 ) (*common.Message, error) {
+	targetTable := event.TableInfo.GetTargetTableName()
 	claimCheckLocation := c.claimCheck.FileNameWithPrefix(fileName)
 	value, err := newJSONMessageForDML(event, c.config, true, claimCheckLocation)
 	if err != nil {
@@ -548,7 +554,7 @@ func (c *JSONRowEventEncoder) newClaimCheckLocationMessage(
 			zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
 			zap.Int("length", length),
 			zap.Any("table", event.TableInfo.TableName))
-		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), length, c.config.MaxMessageBytes)
+		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(targetTable, length, c.config.MaxMessageBytes)
 	}
 	return result, nil
 }

--- a/pkg/sink/codec/canal/canal_json_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_encoder.go
@@ -139,7 +139,7 @@ func newJSONMessageForDML(
 	columnLen := 0
 	for _, col := range e.TableInfo.GetColumns() {
 		if col != nil && !col.IsVirtualGenerated() && e.ColumnSelector.Select(col) {
-			columnLen += 1
+			columnLen++
 		}
 	}
 	if columnLen == 0 {
@@ -258,7 +258,7 @@ func newJSONMessageForDML(
 	{
 		const prefix string = ",\"mysqlType\":"
 		out.RawString(prefix)
-		if mysqlTypeMap == nil {
+		if len(mysqlTypeMap) == 0 {
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')

--- a/pkg/sink/codec/canal/canal_json_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_encoder.go
@@ -146,8 +146,6 @@ func newJSONMessageForDML(
 		return nil, errors.ErrCanalEncodeFailed.GenWithStack("not found valid columns for the event")
 	}
 
-	targetSchema := e.TableInfo.GetTargetSchemaName()
-	targetTable := e.TableInfo.GetTargetTableName()
 	mysqlTypeMap := make(map[string]string, columnLen)
 	// TODO: use util.JsonWriter
 	out := &jwriter.Writer{}
@@ -160,12 +158,12 @@ func newJSONMessageForDML(
 	{
 		const prefix string = ",\"database\":"
 		out.RawString(prefix)
-		out.String(targetSchema)
+		out.String(e.TableInfo.GetTargetSchemaName())
 	}
 	{
 		const prefix string = ",\"table\":"
 		out.RawString(prefix)
-		out.String(targetTable)
+		out.String(e.TableInfo.GetTargetTableName())
 	}
 	{
 		const prefix string = ",\"pkNames\":"
@@ -387,12 +385,10 @@ func NewJSONRowEventEncoder(ctx context.Context, config *common.Config) (common.
 }
 
 func (c *JSONRowEventEncoder) newJSONMessageForDDL(e *commonEvent.DDLEvent) canalJSONMessageInterface {
-	targetSchema := e.GetTargetSchemaName()
-	targetTable := e.GetTargetTableName()
 	msg := &JSONMessage{
 		ID:            0, // ignored by both Canal Adapter and Flink
-		Schema:        targetSchema,
-		Table:         targetTable,
+		Schema:        e.GetTargetSchemaName(),
+		Table:         e.GetTargetTableName(),
 		IsDDL:         true,
 		EventType:     convertDdlEventType(e.Type).String(),
 		ExecutionTime: convertToCanalTs(e.GetCommitTs()),
@@ -453,7 +449,6 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 	_ string,
 	e *commonEvent.RowEvent,
 ) error {
-	targetTable := e.TableInfo.GetTargetTableName()
 	value, err := newJSONMessageForDML(e, c.config, false, "")
 	if err != nil {
 		return errors.Trace(err)
@@ -470,6 +465,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 	m.Callback = e.Callback
 	m.IncRowsCount()
 
+	targetTable := e.TableInfo.GetTargetTableName()
 	originLength := m.Length()
 	if m.Length() > c.config.MaxMessageBytes {
 		// for single message that is longer than max-message-bytes, do not send it.
@@ -530,7 +526,6 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 func (c *JSONRowEventEncoder) newClaimCheckLocationMessage(
 	event *commonEvent.RowEvent, fileName string,
 ) (*common.Message, error) {
-	targetTable := event.TableInfo.GetTargetTableName()
 	claimCheckLocation := c.claimCheck.FileNameWithPrefix(fileName)
 	value, err := newJSONMessageForDML(event, c.config, true, claimCheckLocation)
 	if err != nil {
@@ -554,7 +549,7 @@ func (c *JSONRowEventEncoder) newClaimCheckLocationMessage(
 			zap.Int("maxMessageBytes", c.config.MaxMessageBytes),
 			zap.Int("length", length),
 			zap.Any("table", event.TableInfo.TableName))
-		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(targetTable, length, c.config.MaxMessageBytes)
+		return nil, errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTargetTableName(), length, c.config.MaxMessageBytes)
 	}
 	return result, nil
 }

--- a/pkg/sink/codec/canal/canal_json_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_encoder.go
@@ -129,6 +129,9 @@ func newJSONMessageForDML(
 	messageTooLarge bool,
 	claimCheckFileName string,
 ) ([]byte, error) {
+	tableInfo := e.TableInfo
+	columns := tableInfo.GetColumns()
+	columnSelector := e.ColumnSelector
 	isDelete := e.IsDelete()
 
 	onlyHandleKey := messageTooLarge
@@ -137,8 +140,8 @@ func newJSONMessageForDML(
 	}
 
 	columnLen := 0
-	for _, col := range e.TableInfo.GetColumns() {
-		if col != nil && !col.IsVirtualGenerated() && e.ColumnSelector.Select(col) {
+	for _, col := range columns {
+		if col != nil && !col.IsVirtualGenerated() && columnSelector.Select(col) {
 			columnLen++
 		}
 	}
@@ -158,12 +161,12 @@ func newJSONMessageForDML(
 	{
 		const prefix string = ",\"database\":"
 		out.RawString(prefix)
-		out.String(e.TableInfo.GetTargetSchemaName())
+		out.String(tableInfo.GetTargetSchemaName())
 	}
 	{
 		const prefix string = ",\"table\":"
 		out.RawString(prefix)
-		out.String(e.TableInfo.GetTargetTableName())
+		out.String(tableInfo.GetTargetTableName())
 	}
 	{
 		const prefix string = ",\"pkNames\":"
@@ -212,11 +215,11 @@ func newJSONMessageForDML(
 	javaTypeMap := make(map[int64]common.JavaSQLType, columnLen) // colId -> javaType
 
 	row := e.GetRows()
-	if e.IsDelete() {
+	if isDelete {
 		row = e.GetPreRows()
 	}
-	for idx, col := range e.TableInfo.GetColumns() {
-		if col == nil || col.IsVirtualGenerated() || !e.ColumnSelector.Select(col) {
+	for idx, col := range columns {
+		if col == nil || col.IsVirtualGenerated() || !columnSelector.Select(col) {
 			continue
 		}
 		value, javaType := formatColumnValue(row, idx, col)
@@ -227,10 +230,8 @@ func newJSONMessageForDML(
 		const prefix string = ",\"sqlType\":"
 		out.RawString(prefix)
 		emptyColumn := true
-		tableInfo := e.TableInfo
-		columnInfos := tableInfo.GetColumns()
-		for _, col := range columnInfos {
-			if col != nil && !col.IsVirtualGenerated() && e.ColumnSelector.Select(col) {
+		for _, col := range columns {
+			if col != nil && !col.IsVirtualGenerated() && columnSelector.Select(col) {
 				colID := col.ID
 				colName := col.Name.O
 				if onlyHandleKey && !tableInfo.IsHandleKey(colID) {
@@ -277,37 +278,37 @@ func newJSONMessageForDML(
 		}
 	}
 
-	if e.IsDelete() {
+	if isDelete {
 		out.RawString(",\"old\":null")
 		out.RawString(",\"data\":")
-		if err := fillColumns(valueMap, e.TableInfo, onlyHandleKey, out, e.ColumnSelector); err != nil {
+		if err := fillColumns(valueMap, tableInfo, onlyHandleKey, out, columnSelector); err != nil {
 			return nil, err
 		}
 	} else if e.IsInsert() {
 		out.RawString(",\"old\":null")
 		out.RawString(",\"data\":")
-		if err := fillColumns(valueMap, e.TableInfo, onlyHandleKey, out, e.ColumnSelector); err != nil {
+		if err := fillColumns(valueMap, tableInfo, onlyHandleKey, out, columnSelector); err != nil {
 			return nil, err
 		}
 	} else if e.IsUpdate() {
 		out.RawString(",\"old\":")
 
-		oldValueMap := make(map[int64]optionalString, 0) // colId -> value
+		oldValueMap := make(map[int64]optionalString, columnLen) // colId -> value
 		preRow := e.GetPreRows()
-		for idx, col := range e.TableInfo.GetColumns() {
-			if col == nil || col.IsVirtualGenerated() || !e.ColumnSelector.Select(col) {
+		for idx, col := range columns {
+			if col == nil || col.IsVirtualGenerated() || !columnSelector.Select(col) {
 				continue
 			}
 			value, _ := formatColumnValue(preRow, idx, col)
 			oldValueMap[col.ID] = value
 		}
 
-		if err := fillUpdateColumns(valueMap, oldValueMap, e.TableInfo, onlyHandleKey,
-			config.OnlyOutputUpdatedColumns, out, e.ColumnSelector); err != nil {
+		if err := fillUpdateColumns(valueMap, oldValueMap, tableInfo, onlyHandleKey,
+			config.OnlyOutputUpdatedColumns, out, columnSelector); err != nil {
 			return nil, err
 		}
 		out.RawString(",\"data\":")
-		if err := fillColumns(valueMap, e.TableInfo, onlyHandleKey, out, e.ColumnSelector); err != nil {
+		if err := fillColumns(valueMap, tableInfo, onlyHandleKey, out, columnSelector); err != nil {
 			return nil, err
 		}
 	} else {
@@ -375,7 +376,7 @@ type JSONRowEventEncoder struct {
 func NewJSONRowEventEncoder(ctx context.Context, config *common.Config) (common.EventEncoder, error) {
 	claimCheck, err := claimcheck.New(ctx, config.LargeMessageHandle, config.ChangefeedID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &JSONRowEventEncoder{
 		messages:   make([]*common.Message, 0, 1),
@@ -437,7 +438,7 @@ func (c *JSONRowEventEncoder) EncodeCheckpointEvent(ts uint64) (*common.Message,
 		c.config.ChangefeedID, c.config.LargeMessageHandle.LargeMessageHandleCompression, value,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.WrapError(errors.ErrCanalEncodeFailed, err)
 	}
 
 	return common.NewMsg(nil, value), nil
@@ -451,14 +452,14 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 ) error {
 	value, err := newJSONMessageForDML(e, c.config, false, "")
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	value, err = common.Compress(
 		c.config.ChangefeedID, c.config.LargeMessageHandle.LargeMessageHandleCompression, value,
 	)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.WrapError(errors.ErrCanalEncodeFailed, err)
 	}
 
 	m := common.NewMsg(nil, value)
@@ -480,13 +481,13 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 		if c.config.LargeMessageHandle.HandleKeyOnly() {
 			value, err = newJSONMessageForDML(e, c.config, true, "")
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			value, err = common.Compress(
 				c.config.ChangefeedID, c.config.LargeMessageHandle.LargeMessageHandleCompression, value,
 			)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.WrapError(errors.ErrCanalEncodeFailed, err)
 			}
 
 			m.Value = value
@@ -509,12 +510,12 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 		if c.config.LargeMessageHandle.EnableClaimCheck() {
 			claimCheckFileName := claimcheck.NewFileName()
 			if err = c.claimCheck.WriteMessage(ctx, m.Key, m.Value, claimCheckFileName); err != nil {
-				return errors.Trace(err)
+				return err
 			}
 
 			m, err = c.newClaimCheckLocationMessage(e, claimCheckFileName)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		}
 	}
@@ -536,7 +537,7 @@ func (c *JSONRowEventEncoder) newClaimCheckLocationMessage(
 		c.config.ChangefeedID, c.config.LargeMessageHandle.LargeMessageHandleCompression, value,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.WrapError(errors.ErrCanalEncodeFailed, err)
 	}
 
 	result := common.NewMsg(nil, value)
@@ -576,7 +577,7 @@ func (c *JSONRowEventEncoder) EncodeDDLEvent(e *commonEvent.DDLEvent) (*common.M
 		c.config.ChangefeedID, c.config.LargeMessageHandle.LargeMessageHandleCompression, value,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.WrapError(errors.ErrCanalEncodeFailed, err)
 	}
 
 	return common.NewMsg(nil, value), nil

--- a/pkg/sink/codec/canal/canal_json_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_encoder_test.go
@@ -20,13 +20,91 @@ import (
 	"testing"
 
 	"github.com/pingcap/ticdc/downstreamadapter/sink/columnselector"
+	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/compression"
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
+
+func newRoutedCanalTableInfo() *commonType.TableInfo {
+	idFieldType := types.NewFieldType(mysql.TypeLong)
+	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
+	nameFieldType := types.NewFieldType(mysql.TypeVarchar)
+	nameFieldType.SetFlen(32)
+
+	return commonType.WrapTableInfo("source_db", &timodel.TableInfo{
+		ID:       20,
+		Name:     ast.NewCIStr("source_table"),
+		UpdateTS: 100,
+		Columns: []*timodel.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *idFieldType,
+				State:     timodel.StatePublic,
+				Offset:    0,
+			},
+			{
+				ID:        2,
+				Name:      ast.NewCIStr("name"),
+				FieldType: *nameFieldType,
+				State:     timodel.StatePublic,
+				Offset:    1,
+			},
+		},
+	}).CloneWithRouting("target_db", "target_table")
+}
+
+func newRoutedCanalDMLEvent() *commonEvent.DMLEvent {
+	tableInfo := newRoutedCanalTableInfo()
+	event := commonEvent.NewDMLEvent(
+		commonType.NewDispatcherID(),
+		tableInfo.TableName.TableID,
+		1,
+		2,
+		tableInfo,
+	)
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
+	rows.AppendRow(chunk.MutRowFromValues(int64(1), "alice").ToRow())
+	event.SetRows(rows)
+	event.RowTypes = append(event.RowTypes, commonType.RowTypeInsert)
+	event.RowKeys = append(event.RowKeys, []byte("row-key"))
+	event.Length = 1
+	event.TableInfoVersion = tableInfo.GetUpdateTS()
+	return event
+}
+
+func newRoutedCanalDDLEvent() *commonEvent.DDLEvent {
+	tableInfo := newRoutedCanalTableInfo()
+	sourceDDL := &commonEvent.DDLEvent{
+		Version:    commonEvent.DDLEventVersion1,
+		Type:       byte(timodel.ActionCreateTable),
+		SchemaName: "source_db",
+		TableName:  "source_table",
+		Query:      "CREATE TABLE `source_db`.`source_table` (`id` INT PRIMARY KEY)",
+		TableInfo:  tableInfo,
+		FinishedTs: 100,
+	}
+	return commonEvent.NewRoutedDDLEvent(
+		sourceDDL,
+		"CREATE TABLE `target_db`.`target_table` (`id` INT PRIMARY KEY)",
+		"target_db",
+		"target_table",
+		"",
+		"",
+		tableInfo,
+		nil,
+		nil,
+	)
+}
 
 func dml2rowEvent(t *testing.T, dml *commonEvent.DMLEvent) *commonEvent.RowEvent {
 	row, ok := dml.GetNextRow()
@@ -198,6 +276,68 @@ func TestCanalJSONCompressionE2E(t *testing.T) {
 
 	decodedWatermark := decoder.NextResolvedEvent()
 	require.Equal(t, decodedWatermark, waterMark)
+}
+
+func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
+	t.Parallel()
+
+	dmlEvent := newRoutedCanalDMLEvent()
+	row, ok := dmlEvent.GetNextRow()
+	require.True(t, ok)
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolCanalJSON)
+
+	encIface, err := NewJSONRowEventEncoder(ctx, codecConfig)
+	require.NoError(t, err)
+	encoder := encIface.(*JSONRowEventEncoder)
+
+	require.NoError(t, encoder.AppendRowChangedEvent(ctx, "", &commonEvent.RowEvent{
+		TableInfo:      dmlEvent.TableInfo,
+		CommitTs:       dmlEvent.CommitTs,
+		Event:          row,
+		ColumnSelector: columnselector.NewDefaultColumnSelector(),
+	}))
+
+	message := encoder.Build()[0]
+
+	decoder, err := NewDecoder(ctx, codecConfig, nil)
+	require.NoError(t, err)
+	decoder.AddKeyValue(message.Key, message.Value)
+
+	messageType, hasNext := decoder.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeRow, messageType)
+
+	decoded := dml2rowEvent(t, decoder.NextDMLEvent())
+	require.Equal(t, "target_db", decoded.TableInfo.GetSchemaName())
+	require.Equal(t, "target_table", decoded.TableInfo.GetTableName())
+}
+
+func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolCanalJSON)
+	encIface, err := NewJSONRowEventEncoder(ctx, codecConfig)
+	require.NoError(t, err)
+	encoder := encIface.(*JSONRowEventEncoder)
+
+	message, err := encoder.EncodeDDLEvent(newRoutedCanalDDLEvent())
+	require.NoError(t, err)
+
+	decoder, err := NewDecoder(ctx, codecConfig, nil)
+	require.NoError(t, err)
+	decoder.AddKeyValue(message.Key, message.Value)
+
+	messageType, hasNext := decoder.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeDDL, messageType)
+
+	decoded := decoder.NextDDLEvent()
+	require.Equal(t, "target_db", decoded.SchemaName)
+	require.Equal(t, "target_table", decoded.TableName)
+	require.Contains(t, decoded.Query, "`target_db`.`target_table`")
 }
 
 func TestCanalJSONClaimCheckE2E(t *testing.T) {

--- a/pkg/sink/codec/canal/canal_json_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_encoder_test.go
@@ -24,7 +24,7 @@ import (
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/compression"
 	"github.com/pingcap/ticdc/pkg/config"
-	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -761,7 +761,7 @@ func TestMaxMessageBytes(t *testing.T) {
 		Event:          rc,
 		ColumnSelector: columnselector.NewDefaultColumnSelector(),
 	})
-	require.Error(t, err, cerror.ErrMessageTooLarge)
+	require.Error(t, err, errors.ErrMessageTooLarge)
 }
 
 func TestCanalJSONContentCompatibleE2E(t *testing.T) {

--- a/pkg/sink/codec/canal/canal_json_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_encoder_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
-	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -40,23 +40,23 @@ func newRoutedCanalTableInfo() *commonType.TableInfo {
 	nameFieldType := types.NewFieldType(mysql.TypeVarchar)
 	nameFieldType.SetFlen(32)
 
-	return commonType.WrapTableInfo("source_db", &timodel.TableInfo{
+	return commonType.WrapTableInfo("source_db", &model.TableInfo{
 		ID:       20,
 		Name:     ast.NewCIStr("source_table"),
 		UpdateTS: 100,
-		Columns: []*timodel.ColumnInfo{
+		Columns: []*model.ColumnInfo{
 			{
 				ID:        1,
 				Name:      ast.NewCIStr("id"),
 				FieldType: *idFieldType,
-				State:     timodel.StatePublic,
+				State:     model.StatePublic,
 				Offset:    0,
 			},
 			{
 				ID:        2,
 				Name:      ast.NewCIStr("name"),
 				FieldType: *nameFieldType,
-				State:     timodel.StatePublic,
+				State:     model.StatePublic,
 				Offset:    1,
 			},
 		},
@@ -86,7 +86,7 @@ func newRoutedCanalDDLEvent() *commonEvent.DDLEvent {
 	tableInfo := newRoutedCanalTableInfo()
 	sourceDDL := &commonEvent.DDLEvent{
 		Version:    commonEvent.DDLEventVersion1,
-		Type:       byte(timodel.ActionCreateTable),
+		Type:       byte(model.ActionCreateTable),
 		SchemaName: "source_db",
 		TableName:  "source_table",
 		Query:      "CREATE TABLE `source_db`.`source_table` (`id` INT PRIMARY KEY)",

--- a/pkg/sink/codec/canal/canal_json_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_encoder_test.go
@@ -279,8 +279,6 @@ func TestCanalJSONCompressionE2E(t *testing.T) {
 }
 
 func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
-	t.Parallel()
-
 	dmlEvent := newRoutedCanalDMLEvent()
 	row, ok := dmlEvent.GetNextRow()
 	require.True(t, ok)
@@ -315,8 +313,6 @@ func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
 }
 
 func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	codecConfig := common.NewConfig(config.ProtocolCanalJSON)
 	encIface, err := NewJSONRowEventEncoder(ctx, codecConfig)

--- a/pkg/sink/codec/canal/canal_json_txn_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder.go
@@ -54,6 +54,7 @@ func NewJSONTxnEventEncoder(config *common.Config) common.TxnEventEncoder {
 
 // AppendTxnEvent appends a txn event to the encoder.
 func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error {
+	targetTable := event.TableInfo.GetTargetTableName()
 	for {
 		row, ok := event.GetNextRow()
 		if !ok {
@@ -76,7 +77,7 @@ func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error 
 				zap.Int("maxMessageBytes", j.config.MaxMessageBytes),
 				zap.Int("length", length),
 				zap.Any("table", event.TableInfo.TableName))
-			return errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTableName(), length, j.config.MaxMessageBytes)
+			return errors.ErrMessageTooLarge.GenWithStackByArgs(targetTable, length, j.config.MaxMessageBytes)
 		}
 		j.valueBuf.Write(value)
 		j.valueBuf.Write(j.terminator)
@@ -84,8 +85,10 @@ func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error 
 	}
 	j.callback = event.PostFlush
 	j.txnCommitTs = event.CommitTs
-	j.txnSchema = event.TableInfo.GetSchemaNamePtr()
-	j.txnTable = event.TableInfo.GetTableNamePtr()
+	txnSchema := event.TableInfo.GetTargetSchemaName()
+	txnTable := targetTable
+	j.txnSchema = &txnSchema
+	j.txnTable = &txnTable
 	return nil
 }
 

--- a/pkg/sink/codec/canal/canal_json_txn_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder.go
@@ -34,11 +34,6 @@ type JSONTxnEventEncoder struct {
 	batchSize  int
 	callback   func()
 
-	// Store some fields of the txn event.
-	txnCommitTs uint64
-	txnSchema   *string
-	txnTable    *string
-
 	columnSelector commonEvent.Selector
 }
 
@@ -84,11 +79,6 @@ func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error 
 		j.batchSize++
 	}
 	j.callback = event.PostFlush
-	j.txnCommitTs = event.CommitTs
-	txnSchema := event.TableInfo.GetTargetSchemaName()
-	txnTable := targetTable
-	j.txnSchema = &txnSchema
-	j.txnTable = &txnTable
 	return nil
 }
 
@@ -108,9 +98,6 @@ func (j *JSONTxnEventEncoder) Build() []*common.Message {
 	}
 	j.callback = nil
 	j.batchSize = 0
-	j.txnCommitTs = 0
-	j.txnSchema = nil
-	j.txnTable = nil
 
 	return []*common.Message{ret}
 }

--- a/pkg/sink/codec/canal/canal_json_txn_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder.go
@@ -49,7 +49,6 @@ func NewJSONTxnEventEncoder(config *common.Config) common.TxnEventEncoder {
 
 // AppendTxnEvent appends a txn event to the encoder.
 func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error {
-	targetTable := event.TableInfo.GetTargetTableName()
 	for {
 		row, ok := event.GetNextRow()
 		if !ok {
@@ -72,7 +71,7 @@ func (j *JSONTxnEventEncoder) AppendTxnEvent(event *commonEvent.DMLEvent) error 
 				zap.Int("maxMessageBytes", j.config.MaxMessageBytes),
 				zap.Int("length", length),
 				zap.Any("table", event.TableInfo.TableName))
-			return errors.ErrMessageTooLarge.GenWithStackByArgs(targetTable, length, j.config.MaxMessageBytes)
+			return errors.ErrMessageTooLarge.GenWithStackByArgs(event.TableInfo.GetTargetTableName(), length, j.config.MaxMessageBytes)
 		}
 		j.valueBuf.Write(value)
 		j.valueBuf.Write(j.terminator)

--- a/pkg/sink/codec/canal/canal_json_txn_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder_test.go
@@ -52,6 +52,18 @@ func TestCanalJSONTxnEventEncoderMaxMessageBytes(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestCanalJSONTxnEventEncoderUsesTargetNames(t *testing.T) {
+	t.Parallel()
+
+	encoder := NewJSONTxnEventEncoder(common.NewConfig(config.ProtocolCanalJSON))
+	require.NoError(t, encoder.AppendTxnEvent(newRoutedCanalDMLEvent()))
+
+	messages := encoder.Build()
+	require.Len(t, messages, 1)
+	require.Contains(t, string(messages[0].Value), `"database":"target_db"`)
+	require.Contains(t, string(messages[0].Value), `"table":"target_table"`)
+}
+
 func TestCanalJSONAppendTxnEventEncoderWithCallback(t *testing.T) {
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()

--- a/pkg/sink/codec/canal/canal_json_txn_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder_test.go
@@ -96,8 +96,6 @@ func TestCanalJSONAppendTxnEventEncoderWithCallback(t *testing.T) {
 	msgs[0].Callback()
 	require.Equal(t, 1, count, "expected one callback be called")
 	// Assert the build reset all the internal states.
-	require.Nil(t, encoder.(*JSONTxnEventEncoder).txnSchema)
-	require.Nil(t, encoder.(*JSONTxnEventEncoder).txnTable)
 	require.Nil(t, encoder.(*JSONTxnEventEncoder).callback)
 	require.Equal(t, 0, encoder.(*JSONTxnEventEncoder).batchSize)
 	require.Equal(t, 0, encoder.(*JSONTxnEventEncoder).valueBuf.Len())

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -335,11 +335,13 @@ func fromColValToCsvVal(csvConfig *common.Config, row *chunk.Row, idx int, colIn
 // rowChangedEvent2CSVMsg converts a RowChangedEvent to a csv record.
 func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *event.RowEvent) (*csvMessage, error) {
 	var err error
+	targetSchema := e.TableInfo.GetTargetSchemaName()
+	targetTable := e.TableInfo.GetTargetTableName()
 
 	csvMsg := &csvMessage{
 		config:     csvConfig,
-		tableName:  e.TableInfo.GetTableName(),
-		schemaName: e.TableInfo.GetSchemaName(),
+		tableName:  targetTable,
+		schemaName: targetSchema,
 		commitTs:   e.CommitTs,
 		newRecord:  true,
 	}

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -334,14 +334,10 @@ func fromColValToCsvVal(csvConfig *common.Config, row *chunk.Row, idx int, colIn
 
 // rowChangedEvent2CSVMsg converts a RowChangedEvent to a csv record.
 func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *event.RowEvent) (*csvMessage, error) {
-	var err error
-	targetSchema := e.TableInfo.GetTargetSchemaName()
-	targetTable := e.TableInfo.GetTargetTableName()
-
 	csvMsg := &csvMessage{
 		config:     csvConfig,
-		tableName:  targetTable,
-		schemaName: targetSchema,
+		tableName:  e.TableInfo.GetTargetTableName(),
+		schemaName: e.TableInfo.GetTargetSchemaName(),
 		commitTs:   e.CommitTs,
 		newRecord:  true,
 	}
@@ -351,6 +347,7 @@ func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *event.RowEvent) (*csvMe
 		// csvMsg.HandleKey = e.HandleKey
 	}
 
+	var err error
 	if e.IsDelete() {
 		csvMsg.opType = operationDelete
 		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetPreRows(), e.TableInfo)

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -67,8 +67,9 @@ func (o *operation) FromString(op string) error {
 	case "U":
 		*o = operationUpdate
 	default:
+		return errors.ErrCSVDecodeFailed.GenWithStack("invalid operation type %s", op)
 	}
-	return errors.ErrCSVDecodeFailed.GenWithStack("invalid operation type %s", op)
+	return nil
 }
 
 type csvMessage struct {

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -67,10 +67,8 @@ func (o *operation) FromString(op string) error {
 	case "U":
 		*o = operationUpdate
 	default:
-		return fmt.Errorf("invalid operation type %s", op)
 	}
-
-	return nil
+	return errors.ErrCSVDecodeFailed.GenWithStack("invalid operation type %s", op)
 }
 
 type csvMessage struct {
@@ -152,13 +150,12 @@ func (c *csvMessage) encodeColumns(columns []any, b *strings.Builder) {
 func (c *csvMessage) decode(datums []types.Datum) error {
 	var dataColIdx int
 	if len(datums) < minimumColsCnt {
-		return errors.WrapError(errors.ErrCSVDecodeFailed,
-			errors.New("the csv row should have at least four columns"+
-				"(operation-type, table-name, schema-name, commit-ts)"))
+		return errors.ErrCSVDecodeFailed.GenWithStack(
+			"the csv row should have at least four columns(operation-type, table-name, schema-name, commit-ts)")
 	}
 
 	if err := c.opType.FromString(datums[0].GetString()); err != nil {
-		return errors.WrapError(errors.ErrCSVDecodeFailed, err)
+		return err
 	}
 	dataColIdx++
 	c.tableName = datums[1].GetString()
@@ -168,8 +165,8 @@ func (c *csvMessage) decode(datums []types.Datum) error {
 	if c.config.IncludeCommitTs {
 		commitTs, err := strconv.ParseUint(datums[3].GetString(), 10, 64)
 		if err != nil {
-			return errors.WrapError(errors.ErrCSVDecodeFailed,
-				fmt.Errorf("the 4th column(%s) of csv row should be a valid commit-ts", datums[3].GetString()))
+			return errors.ErrCSVDecodeFailed.Wrap(err).GenWithStack(
+				"the 4th column(%s) of csv row should be a valid commit-ts", datums[3].GetString())
 		}
 		c.commitTs = commitTs
 		dataColIdx++
@@ -291,9 +288,8 @@ func fromColValToCsvVal(csvConfig *common.Config, row *chunk.Row, idx int, colIn
 			case config.BinaryEncodingHex:
 				return hex.EncodeToString(v), nil
 			default:
-				return nil, errors.WrapError(errors.ErrCSVEncodeFailed,
-					errors.Errorf("unsupported binary encoding method %s",
-						csvConfig.BinaryEncodingMethod))
+				return nil, errors.ErrCSVEncodeFailed.GenWithStack(
+					"unsupported binary encoding method %s", csvConfig.BinaryEncodingMethod)
 			}
 		}
 		return row.GetString(idx), nil
@@ -334,10 +330,11 @@ func fromColValToCsvVal(csvConfig *common.Config, row *chunk.Row, idx int, colIn
 
 // rowChangedEvent2CSVMsg converts a RowChangedEvent to a csv record.
 func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *event.RowEvent) (*csvMessage, error) {
+	tableInfo := e.TableInfo
 	csvMsg := &csvMessage{
 		config:     csvConfig,
-		tableName:  e.TableInfo.GetTargetTableName(),
-		schemaName: e.TableInfo.GetTargetSchemaName(),
+		tableName:  tableInfo.GetTargetTableName(),
+		schemaName: tableInfo.GetTargetSchemaName(),
 		commitTs:   e.CommitTs,
 		newRecord:  true,
 	}
@@ -350,14 +347,14 @@ func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *event.RowEvent) (*csvMe
 	var err error
 	if e.IsDelete() {
 		csvMsg.opType = operationDelete
-		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetPreRows(), e.TableInfo)
+		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetPreRows(), tableInfo)
 		if err != nil {
 			return nil, err
 		}
 	} else if e.IsInsert() {
 		// This is a insert operation.
 		csvMsg.opType = operationInsert
-		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetRows(), e.TableInfo)
+		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetRows(), tableInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -366,16 +363,16 @@ func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *event.RowEvent) (*csvMe
 		csvMsg.opType = operationUpdate
 		if csvConfig.OutputOldValue {
 			if e.GetPreRows().Len() != e.GetRows().Len() {
-				return nil, errors.WrapError(errors.ErrCSVDecodeFailed,
-					fmt.Errorf("the column length of preColumns %d doesn't equal to that of columns %d",
-						e.GetPreRows().Len(), e.GetRows().Len()))
+				return nil, errors.ErrCSVDecodeFailed.GenWithStack(
+					"the column length of preColumns %d doesn't equal to that of columns %d",
+					e.GetPreRows().Len(), e.GetRows().Len())
 			}
-			csvMsg.preColumns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetPreRows(), e.TableInfo)
+			csvMsg.preColumns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetPreRows(), tableInfo)
 			if err != nil {
 				return nil, err
 			}
 		}
-		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetRows(), e.TableInfo)
+		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.GetRows(), tableInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -396,7 +393,7 @@ func rowChangeColumns2CSVColumns(csvConfig *common.Config, row *chunk.Row, table
 		flag := col.GetFlag()
 		converted, err := fromColValToCsvVal(csvConfig, row, i, col, flag)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		csvColumns = append(csvColumns, converted)
 	}

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -957,6 +957,38 @@ func TestRowChangeEventConversion(t *testing.T) {
 	}
 }
 
+func TestRowChangedEvent2CSVMsgUsesTargetNames(t *testing.T) {
+	t.Parallel()
+
+	tableInfo := commonType.WrapTableInfo("source_db", &model.TableInfo{
+		ID:   20,
+		Name: ast.NewCIStr("source_table"),
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *types.NewFieldType(mysql.TypeLong),
+			},
+		},
+	}).CloneWithRouting("target_db", "target_table")
+
+	csvMsg, err := rowChangedEvent2CSVMsg(&common.Config{
+		Delimiter:  ",",
+		Quote:      "\"",
+		Terminator: "\n",
+		NullString: "\\N",
+	}, &commonEvent.RowEvent{
+		TableInfo: tableInfo,
+		Event: commonEvent.RowChange{
+			Row: chunk.MutRowFromValues(int64(1)).ToRow(),
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "target_db", csvMsg.schemaName)
+	require.Equal(t, "target_table", csvMsg.tableName)
+	require.Contains(t, string(csvMsg.encode()), `"target_table","target_db"`)
+}
+
 func TestCSVMessageDecode(t *testing.T) {
 	// datums := make([][]types.Datum, 0, 4)
 	testCases := []struct {

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -175,7 +175,7 @@ storage_groups=(
 	# G13
 	'cli_with_auth fail_over_ddl_N maintainer_failover_when_operator'
 	# G14
-	'csv_storage_partition_table csv_storage_multi_tables_ddl fail_over_ddl_O update_changefeed_check_config'
+	'csv_storage_partition_table csv_storage_multi_tables_ddl table_route fail_over_ddl_O update_changefeed_check_config'
 	# G15
 	'split_region autorandom gc_safepoint'
 )

--- a/tests/integration_tests/table_route/run.sh
+++ b/tests/integration_tests/table_route/run.sh
@@ -8,24 +8,11 @@ WORK_DIR="$OUT_DIR/$TEST_NAME"
 CDC_BINARY=cdc.test
 SINK_TYPE="$1"
 
-function run() {
-	if [ "$SINK_TYPE" != "mysql" ]; then
-		return
-	fi
-
-	rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
-
-	start_tidb_cluster --workdir "$WORK_DIR"
-
-	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
-
-	SINK_URI="mysql://normal:123456@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/"
-	cdc_cli_changefeed create --sink-uri="$SINK_URI" --config="$CUR/conf/changefeed.toml"
-
-	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+function verify_table_route_result() {
+	local work_dir=$1
 
 	check_table_exists target_db.finish_mark_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
-	check_sync_diff "$WORK_DIR" "$CUR/conf/diff_config.toml" 120
+	check_sync_diff "$work_dir" "$CUR/conf/diff_config.toml" 120
 
 	check_table_not_exists source_db.users "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_table_not_exists source_db.orders "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
@@ -52,13 +39,86 @@ function run() {
 	check_contains 'target_db`.`orders_routed`.`id'
 	check_contains 'FROM `target_db`.`orders_routed`'
 	check_table_not_exists target_db.transient_view_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+}
 
+function verify_table_route_drop_database() {
 	run_sql "DROP DATABASE source_extra_db" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
 	run_sql "DROP DATABASE source_db" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
 	check_db_not_exists target_extra_db "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
 	check_db_not_exists target_db "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
+}
+
+function check_storage_files_use_target_names() {
+	local storage_dir=$1
+
+	ensure 60 test -d "$storage_dir/target_db/users_routed/meta"
+	ensure 60 test -d "$storage_dir/target_extra_db/external_users_routed/meta"
+
+	if [ -e "$storage_dir/source_db" ] || [ -e "$storage_dir/source_extra_db" ]; then
+		echo "storage table route wrote source table directories:"
+		find "$storage_dir" -maxdepth 2 -type d | sort
+		exit 1
+	fi
+}
+
+function run_mysql() {
+	rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
+
+	start_tidb_cluster --workdir "$WORK_DIR"
+
+	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+
+	SINK_URI="mysql://normal:123456@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/"
+	cdc_cli_changefeed create --sink-uri="$SINK_URI" --config="$CUR/conf/changefeed.toml"
+
+	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+
+	verify_table_route_result "$WORK_DIR"
+	verify_table_route_drop_database
 
 	cleanup_process "$CDC_BINARY"
+}
+
+function run_storage_case() {
+	local protocol=$1
+	local work_dir="$WORK_DIR/$protocol"
+	local storage_dir="$work_dir/storage_test"
+	local sink_uri="file://$storage_dir?flush-interval=5s&protocol=$protocol"
+	if [ "$protocol" = "canal-json" ]; then
+		sink_uri="$sink_uri&enable-tidb-extension=true"
+	fi
+
+	rm -rf "$work_dir" && mkdir -p "$work_dir"
+
+	start_tidb_cluster --workdir "$work_dir"
+
+	run_cdc_server --workdir "$work_dir" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+
+	cdc_cli_changefeed create --sink-uri="$sink_uri" --config="$CUR/conf/changefeed.toml"
+
+	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+
+	run_storage_consumer "$work_dir" "$sink_uri" "$CUR/conf/changefeed.toml" "$protocol"
+
+	verify_table_route_result "$work_dir"
+	check_storage_files_use_target_names "$storage_dir"
+	verify_table_route_drop_database
+
+	stop_test "$work_dir"
+	check_logs "$work_dir"
+}
+
+function run_storage() {
+	run_storage_case canal-json
+	run_storage_case csv
+}
+
+function run() {
+	case "$SINK_TYPE" in
+	mysql) run_mysql ;;
+	storage) run_storage ;;
+	*) return ;;
+	esac
 }
 
 trap 'stop_test "$WORK_DIR"' EXIT

--- a/tests/integration_tests/table_route/run.sh
+++ b/tests/integration_tests/table_route/run.sh
@@ -77,6 +77,7 @@ function run_mysql() {
 	verify_table_route_drop_database
 
 	cleanup_process "$CDC_BINARY"
+	check_logs "$WORK_DIR"
 }
 
 function run_storage_case() {
@@ -123,5 +124,4 @@ function run() {
 
 trap 'stop_test "$WORK_DIR"' EXIT
 run "$@"
-check_logs "$WORK_DIR"
 echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4821

### What is changed and how it works?

This PR integrates table route support into the storage sink for the `canal-json` and `csv` protocols.

- Storage sink DML file routing now uses the target schema/table names from table route.
- Storage sink DDL/schema file generation now writes table definitions under routed target paths, including exchange partition DDL handling.
- `canal-json` row, DDL, and txn encoders now emit routed target database/table names. This also applies to Kafka and Pulsar sinks when they use `canal-json`.
- `csv` message generation now uses routed target schema/table names.
- The existing `table_route` integration test is reused for storage sink and runs both `canal-json` and `csv` storage cases.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Manual validation commands run:

```bash
go test ./downstreamadapter/sink/cloudstorage -run 'Test(AddDMLEventUsesTargetNames|WriteExchangePartitionDDLEventUsesTargetNames)'
go test ./pkg/sink/cloudstorage -run 'Test(CheckOrWriteSchemaUsesRoutedTargetNames|FromDDLEventUsesTargetNames)'
go test ./pkg/sink/codec/canal -run 'TestEncodeRouted|TestCanalJSONTxnEventEncoderUsesTargetNames'
go test --tags=intest ./pkg/sink/codec/canal -run TestCanalJSONAppendTxnEventEncoderWithCallback
go test ./pkg/sink/codec/csv -run TestRowChangedEvent2CSVMsgUsesTargetNames
bash -n tests/integration_tests/table_route/run.sh
make fmt
make local-static-check
git diff --check
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No expected performance regression. The change only switches schema/table name selection to existing routed target names when table route is configured. Without table route, target-name getters fall back to the original schema/table names.

For compatibility, `canal-json` output now consistently carries target database/table names under table route. This affects storage, Kafka, and Pulsar sinks that use `canal-json`, and is the intended behavior for table route.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This PR wires existing table route behavior into storage sink paths and the affected encoders. It does not add new config fields, metrics, protocol fields, or user-facing options.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Support table route for storage sink with canal-json and csv protocols.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table routing now consistently applies target schema and table names across DML/DDL event processing, cloud storage paths, and all codec formats (Canal JSON, CSV).
  * Schema definitions and storage outputs now correctly reflect routed target identities instead of source identities.

* **Tests**
  * Added comprehensive test coverage for table routing behavior across DML events, DDL events, codec encoders, and storage sinks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->