### PR TITLE
sink,tests: support table route in Kafka sink

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
     - revive
     # unconvert: finds unnecessary type conversions.
     - unconvert
+    - modernize
 
   settings:
     depguard:
@@ -44,7 +45,7 @@ linters:
         no-direct-errors:
           files:
             - $all
-            - '!pkg/errors/**'
+            - "!pkg/errors/**"
           deny:
             - pkg: errors$
               desc: use github.com/pingcap/ticdc/pkg/errors outside pkg/errors

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -535,8 +535,11 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 }
 
 func (w *writer) onDDL(ddl *commonEvent.DDLEvent) {
+	if ddl.Query == "" {
+		return
+	}
 	switch w.protocol {
-	case config.ProtocolCanalJSON, config.ProtocolOpen, config.ProtocolAvro:
+	case config.ProtocolCanalJSON, config.ProtocolOpen, config.ProtocolAvro, config.ProtocolSimple, config.ProtocolDebezium:
 	default:
 		return
 	}

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -26,13 +26,13 @@ import (
 	"github.com/pingcap/ticdc/downstreamadapter/sink"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter"
 	commonType "github.com/pingcap/ticdc/pkg/common"
-	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/sink/codec/simple"
-	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"go.uber.org/atomic"
@@ -75,7 +75,7 @@ func (p *partitionProgress) updateWatermark(newWatermark uint64, offset kafka.Of
 
 type writer struct {
 	progresses         []*partitionProgress
-	ddlList            []*commonEvent.DDLEvent
+	ddlList            []*event.DDLEvent
 	ddlWithMaxCommitTs map[int64]uint64
 
 	// this should be used by the canal-json, avro and open protocol
@@ -96,7 +96,7 @@ func newWriter(ctx context.Context, o *option) *writer {
 		maxBatchSize:           o.maxBatchSize,
 		progresses:             make([]*partitionProgress, o.partitionNum),
 		partitionTableAccessor: common.NewPartitionTableAccessor(),
-		ddlList:                make([]*commonEvent.DDLEvent, 0),
+		ddlList:                make([]*event.DDLEvent, 0),
 		ddlWithMaxCommitTs:     make(map[int64]uint64),
 		enableTableAcrossNodes: o.enableTableAcrossNodes,
 	}
@@ -146,7 +146,7 @@ func (w *writer) run(ctx context.Context) error {
 	return w.mysqlSink.Run(ctx)
 }
 
-func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) error {
+func (w *writer) flushDDLEvent(ctx context.Context, ddl *event.DDLEvent) error {
 	var (
 		done = make(chan struct{}, 1)
 
@@ -156,7 +156,7 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 
 	tableIDs := w.getBlockTableIDs(ddl)
 	commitTs := ddl.GetCommitTs()
-	resolvedEvents := make([]*commonEvent.DMLEvent, 0)
+	resolvedEvents := make([]*event.DMLEvent, 0)
 	// resolvedGroups records which EventsGroup has flushed events so we can
 	// advance its AppliedWatermark after the flush is fully finished.
 	resolvedGroups := make([]struct {
@@ -225,20 +225,20 @@ func (w *writer) flushDDLEvent(ctx context.Context, ddl *commonEvent.DDLEvent) e
 	}
 }
 
-func (w *writer) getBlockTableIDs(ddl *commonEvent.DDLEvent) map[int64]struct{} {
+func (w *writer) getBlockTableIDs(ddl *event.DDLEvent) map[int64]struct{} {
 	// The DDL event is delivered after all messages belongs to the tables which are blocked by the DDL event
 	// so we can make assumption that the all DMLs received before the DDL event.
 	// since one table's events may be produced to the different partitions, so we have to flush all partitions.
 	// if block the whole database, flush all tables, otherwise flush the blocked tables.
 	tableIDs := make(map[int64]struct{})
 	switch ddl.GetBlockedTables().InfluenceType {
-	case commonEvent.InfluenceTypeDB, commonEvent.InfluenceTypeAll:
+	case event.InfluenceTypeDB, event.InfluenceTypeAll:
 		for _, progress := range w.progresses {
 			for tableID := range progress.eventsGroup {
 				tableIDs[tableID] = struct{}{}
 			}
 		}
-	case commonEvent.InfluenceTypeNormal:
+	case event.InfluenceTypeNormal:
 		for _, item := range ddl.GetBlockedTables().TableIDs {
 			tableIDs[item] = struct{}{}
 		}
@@ -253,7 +253,7 @@ func (w *writer) getBlockTableIDs(ddl *commonEvent.DDLEvent) map[int64]struct{} 
 // DDLs may be received out of commit-ts order (e.g. due to MQ delivery or buffering), so Write() sorts
 // ddlList by commit-ts before executing. ddlWithMaxCommitTs is a guard against per-table commit-ts
 // regressions: executing an older DDL after a newer one may corrupt downstream schema/DML ordering.
-func (w *writer) appendDDL(ddl *commonEvent.DDLEvent) {
+func (w *writer) appendDDL(ddl *event.DDLEvent) {
 	// If commitTs goes backwards for a blocked table, ignore this DDL instead of applying it out of order.
 	tableIDs := w.getBlockTableIDs(ddl)
 	for tableID := range tableIDs {
@@ -292,7 +292,7 @@ func (w *writer) flushDMLEventsByWatermark(ctx context.Context) error {
 	)
 
 	watermark := w.globalWatermark()
-	resolvedEvents := make([]*commonEvent.DMLEvent, 0)
+	resolvedEvents := make([]*event.DMLEvent, 0)
 	// resolvedGroups records which EventsGroup has flushed events so we can
 	// advance its AppliedWatermark after the flush is fully finished.
 	resolvedGroups := make([]struct {
@@ -475,7 +475,7 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 	}
 
 	watermark := w.globalWatermark()
-	ddlList := make([]*commonEvent.DDLEvent, 0)
+	ddlList := make([]*event.DDLEvent, 0)
 	for i, todoDDL := range w.ddlList {
 		// DDL ordering must follow commitTs (see appendDDL). Traditionally we wait until the global
 		// resolved-ts (watermark) has reached the DDL commitTs, which guarantees all partitions have
@@ -492,15 +492,15 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 		// populating BlockedTableNames and/or adding referenced table IDs (or partition IDs) into
 		// BlockedTables.TableIDs. We only bypass watermark for CREATE TABLE when the DDL only blocks the
 		// special DDL span and has no referenced blocked table names.
-		action := timodel.ActionType(todoDDL.Type)
+		action := model.ActionType(todoDDL.Type)
 		bypassWatermark := false
 		switch action {
-		case timodel.ActionCreateSchema:
+		case model.ActionCreateSchema:
 			bypassWatermark = true
-		case timodel.ActionCreateTable:
+		case model.ActionCreateTable:
 			blockedTables := todoDDL.GetBlockedTables()
 			bypassWatermark = blockedTables != nil &&
-				blockedTables.InfluenceType == commonEvent.InfluenceTypeNormal &&
+				blockedTables.InfluenceType == event.InfluenceTypeNormal &&
 				len(blockedTables.TableIDs) == 1 &&
 				blockedTables.TableIDs[0] == commonType.DDLSpanTableID &&
 				len(todoDDL.GetBlockedTableNames()) == 0
@@ -534,7 +534,7 @@ func (w *writer) Write(ctx context.Context, messageType common.MessageType) bool
 	return true
 }
 
-func (w *writer) onDDL(ddl *commonEvent.DDLEvent) {
+func (w *writer) onDDL(ddl *event.DDLEvent) {
 	if ddl.Query == "" {
 		return
 	}
@@ -545,8 +545,8 @@ func (w *writer) onDDL(ddl *commonEvent.DDLEvent) {
 	}
 	// TODO: support more corner cases
 	// e.g. create partition table + drop table(rename table) + create normal table: the partitionTableAccessor should drop the table when the table become normal.
-	switch timodel.ActionType(ddl.Type) {
-	case timodel.ActionCreateTable:
+	switch model.ActionType(ddl.Type) {
+	case model.ActionCreateTable:
 		stmt, err := parser.New().ParseOneStmt(ddl.Query, "", "")
 		if err != nil {
 			log.Panic("parse ddl query failed", zap.String("query", ddl.Query), zap.Error(err))
@@ -554,14 +554,14 @@ func (w *writer) onDDL(ddl *commonEvent.DDLEvent) {
 		if v, ok := stmt.(*ast.CreateTableStmt); ok && v.Partition != nil {
 			w.partitionTableAccessor.Add(ddl.GetSchemaName(), ddl.GetTableName())
 		}
-	case timodel.ActionRenameTable:
+	case model.ActionRenameTable:
 		if w.partitionTableAccessor.IsPartitionTable(ddl.ExtraSchemaName, ddl.ExtraTableName) {
 			w.partitionTableAccessor.Add(ddl.GetSchemaName(), ddl.GetTableName())
 		}
 	}
 }
 
-func (w *writer) checkPartition(row *commonEvent.DMLEvent, partition int32, offset kafka.Offset) {
+func (w *writer) checkPartition(row *event.DMLEvent, partition int32, offset kafka.Offset) {
 	var (
 		partitioner  = w.eventRouter.GetPartitionGenerator(row.TableInfo.GetSchemaName(), row.TableInfo.GetTableName())
 		partitionNum = int32(len(w.progresses))
@@ -588,7 +588,7 @@ func (w *writer) checkPartition(row *commonEvent.DMLEvent, partition int32, offs
 	}
 }
 
-func (w *writer) appendRow2Group(dml *commonEvent.DMLEvent, progress *partitionProgress, offset kafka.Offset) {
+func (w *writer) appendRow2Group(dml *event.DMLEvent, progress *partitionProgress, offset kafka.Offset) {
 	w.checkPartition(dml, progress.partition, offset)
 	// if the kafka cluster is normal, this should not hit.
 	// else if the cluster is abnormal, the consumer may consume old message, then cause the watermark fallback.

--- a/downstreamadapter/sink/blackhole/sink.go
+++ b/downstreamadapter/sink/blackhole/sink.go
@@ -28,6 +28,7 @@ type sink struct {
 	eventCh chan *commonEvent.DMLEvent
 }
 
+//nolint:revive // Keep the constructor shape consistent with other sink implementations.
 func New() (*sink, error) {
 	return &sink{
 		eventCh: make(chan *commonEvent.DMLEvent, 4096),

--- a/pkg/sink/codec/avro/arvo.go
+++ b/pkg/sink/codec/avro/arvo.go
@@ -131,7 +131,7 @@ func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *event.R
 			return nil, nil
 		}
 		buf := new(bytes.Buffer)
-		data := []interface{}{deleteByte, e.CommitTs}
+		data := []any{deleteByte, e.CommitTs}
 		for _, v := range data {
 			if err := binary.Write(buf, binary.BigEndian, v); err != nil {
 				return nil, errors.WrapError(errors.ErrAvroToEnvelopeError, err)
@@ -144,7 +144,7 @@ func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *event.R
 		return nil, nil
 	}
 	index := make([]int, length)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		index[i] = i
 	}
 	input := &avroEncodeInput{

--- a/pkg/sink/codec/avro/arvo.go
+++ b/pkg/sink/codec/avro/arvo.go
@@ -27,11 +27,11 @@ import (
 	"github.com/linkedin/goavro/v2"
 	"github.com/pingcap/log"
 	commonType "github.com/pingcap/ticdc/pkg/common"
-	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/util"
-	timodel "github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -79,7 +79,7 @@ func (a *BatchEncoder) getKeySchemaCodec(
 	return avroCodec, header, nil
 }
 
-func (a *BatchEncoder) encodeKey(ctx context.Context, topic string, e *commonEvent.RowEvent) ([]byte, error) {
+func (a *BatchEncoder) encodeKey(ctx context.Context, topic string, e *event.RowEvent) ([]byte, error) {
 	index, colInfos := e.PrimaryKeyColumn()
 	// result may be nil if the event has no handle key columns, this may happen in the force replicate mode.
 	// todo: disallow force replicate mode if using the avro.
@@ -125,7 +125,7 @@ func (a *BatchEncoder) encodeKey(ctx context.Context, topic string, e *commonEve
 	return data, nil
 }
 
-func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *commonEvent.RowEvent) ([]byte, error) {
+func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *event.RowEvent) ([]byte, error) {
 	if e.IsDelete() {
 		return nil, nil
 	}
@@ -176,7 +176,7 @@ func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *commonE
 
 func (a *BatchEncoder) nativeValueWithExtension(
 	native map[string]any,
-	e *commonEvent.RowEvent,
+	e *event.RowEvent,
 ) map[string]any {
 	native[tidbOp] = getOperation(e)
 	native[tidbCommitTs] = int64(e.CommitTs)
@@ -240,7 +240,7 @@ func (a *BatchEncoder) schemaWithExtension(
 	return top
 }
 
-func (a *BatchEncoder) getDefaultValue(col *timodel.ColumnInfo) (any, error) {
+func (a *BatchEncoder) getDefaultValue(col *model.ColumnInfo) (any, error) {
 	defaultVal := col.GetDefaultValue()
 	if defaultVal == nil {
 		return nil, nil
@@ -465,7 +465,7 @@ func (a *BatchEncoder) columns2AvroData(
 	return ret, nil
 }
 
-func (a *BatchEncoder) columnToAvroSchema(col *timodel.ColumnInfo) (any, error) {
+func (a *BatchEncoder) columnToAvroSchema(col *model.ColumnInfo) (any, error) {
 	tt := getTiDBTypeFromColumn(col)
 	switch col.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24:
@@ -602,7 +602,7 @@ func (a *BatchEncoder) columnToAvroSchema(col *timodel.ColumnInfo) (any, error) 
 func (a *BatchEncoder) columnToAvroData(
 	row *chunk.Row,
 	idx int,
-	col *timodel.ColumnInfo,
+	col *model.ColumnInfo,
 ) (any, string, error) {
 	if row.IsNull(idx) {
 		return nil, "null", nil

--- a/pkg/sink/codec/avro/arvo.go
+++ b/pkg/sink/codec/avro/arvo.go
@@ -127,7 +127,17 @@ func (a *BatchEncoder) encodeKey(ctx context.Context, topic string, e *event.Row
 
 func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *event.RowEvent) ([]byte, error) {
 	if e.IsDelete() {
-		return nil, nil
+		if !a.config.EnableTiDBExtension || !a.config.AvroEnableWatermark {
+			return nil, nil
+		}
+		buf := new(bytes.Buffer)
+		data := []interface{}{deleteByte, e.CommitTs}
+		for _, v := range data {
+			if err := binary.Write(buf, binary.BigEndian, v); err != nil {
+				return nil, errors.WrapError(errors.ErrAvroToEnvelopeError, err)
+			}
+		}
+		return buf.Bytes(), nil
 	}
 	length := e.GetRows().Len()
 	if length == 0 {

--- a/pkg/sink/codec/avro/arvo.go
+++ b/pkg/sink/codec/avro/arvo.go
@@ -86,8 +86,12 @@ func (a *BatchEncoder) encodeKey(ctx context.Context, topic string, e *commonEve
 	if len(index) == 0 {
 		return nil, nil
 	}
+	row := e.GetRows()
+	if e.IsDelete() {
+		row = e.GetPreRows()
+	}
 	keyColumns := &avroEncodeInput{
-		row:            e.GetRows(),
+		row:            row,
 		index:          index,
 		colInfos:       colInfos,
 		columnselector: e.ColumnSelector,
@@ -171,9 +175,9 @@ func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *commonE
 }
 
 func (a *BatchEncoder) nativeValueWithExtension(
-	native map[string]interface{},
+	native map[string]any,
 	e *commonEvent.RowEvent,
-) map[string]interface{} {
+) map[string]any {
 	native[tidbOp] = getOperation(e)
 	native[tidbCommitTs] = int64(e.CommitTs)
 	native[tidbPhysicalTime] = oracle.ExtractPhysical(e.CommitTs)
@@ -197,17 +201,17 @@ func (a *BatchEncoder) schemaWithExtension(
 	top *avroSchemaTop,
 ) *avroSchemaTop {
 	top.Fields = append(top.Fields,
-		map[string]interface{}{
+		map[string]any{
 			"name":    tidbOp,
 			"type":    "string",
 			"default": "",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":    tidbCommitTs,
 			"type":    "long",
 			"default": 0,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":    tidbPhysicalTime,
 			"type":    "long",
 			"default": 0,
@@ -216,17 +220,17 @@ func (a *BatchEncoder) schemaWithExtension(
 
 	if a.config.EnableRowChecksum {
 		top.Fields = append(top.Fields,
-			map[string]interface{}{
+			map[string]any{
 				"name":    tidbRowLevelChecksum,
 				"type":    "string",
 				"default": "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":    tidbCorrupted,
 				"type":    "boolean",
 				"default": false,
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":    tidbChecksumVersion,
 				"type":    "int",
 				"default": 0,
@@ -236,7 +240,7 @@ func (a *BatchEncoder) schemaWithExtension(
 	return top
 }
 
-func (a *BatchEncoder) getDefaultValue(col *timodel.ColumnInfo) (interface{}, error) {
+func (a *BatchEncoder) getDefaultValue(col *timodel.ColumnInfo) (any, error) {
 	defaultVal := col.GetDefaultValue()
 	if defaultVal == nil {
 		return nil, nil
@@ -353,7 +357,7 @@ func (a *BatchEncoder) columns2AvroSchema(
 		if err != nil {
 			return nil, err
 		}
-		field := make(map[string]interface{})
+		field := make(map[string]any)
 		field["name"] = common.SanitizeName(info.Name.O)
 
 		defaultValue, err := a.getDefaultValue(info)
@@ -365,7 +369,7 @@ func (a *BatchEncoder) columns2AvroSchema(
 		// https://github.com/linkedin/goavro/issues/202
 		if _, ok := avroType.(avroLogicalTypeSchema); ok {
 			if !mysql.HasNotNullFlag(info.GetFlag()) {
-				field["type"] = []interface{}{"null", avroType}
+				field["type"] = []any{"null", avroType}
 				field["default"] = nil
 			} else {
 				field["type"] = avroType
@@ -374,9 +378,9 @@ func (a *BatchEncoder) columns2AvroSchema(
 			if !mysql.HasNotNullFlag(info.GetFlag()) {
 				// https://stackoverflow.com/questions/22938124/avro-field-default-values
 				if defaultValue == nil {
-					field["type"] = []interface{}{"null", avroType}
+					field["type"] = []any{"null", avroType}
 				} else {
-					field["type"] = []interface{}{avroType, "null"}
+					field["type"] = []any{avroType, "null"}
 				}
 				field["default"] = defaultValue
 			} else {
@@ -438,8 +442,8 @@ func (a *BatchEncoder) key2AvroSchema(
 
 func (a *BatchEncoder) columns2AvroData(
 	input *avroEncodeInput,
-) (map[string]interface{}, error) {
-	ret := make(map[string]interface{}, len(input.colInfos))
+) (map[string]any, error) {
+	ret := make(map[string]any, len(input.colInfos))
 	for i, col := range input.colInfos {
 		if col == nil || !input.columnselector.Select(col) {
 			continue
@@ -461,7 +465,7 @@ func (a *BatchEncoder) columns2AvroData(
 	return ret, nil
 }
 
-func (a *BatchEncoder) columnToAvroSchema(col *timodel.ColumnInfo) (interface{}, error) {
+func (a *BatchEncoder) columnToAvroSchema(col *timodel.ColumnInfo) (any, error) {
 	tt := getTiDBTypeFromColumn(col)
 	switch col.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24:
@@ -599,7 +603,7 @@ func (a *BatchEncoder) columnToAvroData(
 	row *chunk.Row,
 	idx int,
 	col *timodel.ColumnInfo,
-) (interface{}, string, error) {
+) (any, string, error) {
 	if row.IsNull(idx) {
 		return nil, "null", nil
 	}
@@ -696,7 +700,7 @@ type avroEncodeResult struct {
 
 func (r *avroEncodeResult) toEnvelope() ([]byte, error) {
 	buf := new(bytes.Buffer)
-	data := []interface{}{r.header, r.data}
+	data := []any{r.header, r.data}
 	for _, v := range data {
 		err := binary.Write(buf, binary.BigEndian, v)
 		if err != nil {

--- a/pkg/sink/codec/avro/arvo.go
+++ b/pkg/sink/codec/avro/arvo.go
@@ -92,7 +92,8 @@ func (a *BatchEncoder) encodeKey(ctx context.Context, topic string, e *commonEve
 		colInfos:       colInfos,
 		columnselector: e.ColumnSelector,
 	}
-	avroCodec, header, err := a.getKeySchemaCodec(ctx, topic, &e.TableInfo.TableName, e.TableInfo.GetUpdateTS(), keyColumns)
+	targetTableName := routedTableName(e.TableInfo)
+	avroCodec, header, err := a.getKeySchemaCodec(ctx, topic, &targetTableName, e.TableInfo.GetUpdateTS(), keyColumns)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -138,7 +139,8 @@ func (a *BatchEncoder) encodeValue(ctx context.Context, topic string, e *commonE
 		index:          index,
 		columnselector: e.ColumnSelector,
 	}
-	avroCodec, header, err := a.getValueSchemaCodec(ctx, topic, &e.TableInfo.TableName, e.TableInfo.GetUpdateTS(), input)
+	targetTableName := routedTableName(e.TableInfo)
+	avroCodec, header, err := a.getValueSchemaCodec(ctx, topic, &targetTableName, e.TableInfo.GetUpdateTS(), input)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -182,6 +184,13 @@ func (a *BatchEncoder) nativeValueWithExtension(
 		native[tidbChecksumVersion] = e.Checksum.Version
 	}
 	return native
+}
+
+func routedTableName(tableInfo *commonType.TableInfo) commonType.TableName {
+	tableName := tableInfo.TableName
+	tableName.Schema = tableInfo.GetTargetSchemaName()
+	tableName.Table = tableInfo.GetTargetTableName()
+	return tableName
 }
 
 func (a *BatchEncoder) schemaWithExtension(

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -128,8 +128,7 @@ func TestAvroEncodeDeleteEventUsesPreRowForKey(t *testing.T) {
 	codecConfig := common.NewConfig(config.ProtocolAvro)
 	codecConfig.EnableTiDBExtension = true
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	encoder, err := SetupEncoderAndSchemaRegistry4Testing(ctx, codecConfig)
 	defer TeardownEncoderAndSchemaRegistry4Testing()
@@ -156,7 +155,7 @@ func TestAvroEncodeDeleteEventUsesPreRowForKey(t *testing.T) {
 	res, _, err := avroKeyCodec.NativeFromBinary(data)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.Equal(t, int32(127), res.(map[string]interface{})["tu1"])
+	require.Equal(t, int32(127), res.(map[string]any)["tu1"])
 }
 
 func TestAvroEncodeDeleteEventWithWatermarkCarriesCommitTs(t *testing.T) {
@@ -164,8 +163,7 @@ func TestAvroEncodeDeleteEventWithWatermarkCarriesCommitTs(t *testing.T) {
 	codecConfig.EnableTiDBExtension = true
 	codecConfig.AvroEnableWatermark = true
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	encoder, err := SetupEncoderAndSchemaRegistry4Testing(ctx, codecConfig)
 	defer TeardownEncoderAndSchemaRegistry4Testing()

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/linkedin/goavro/v2"
+	commonType "github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/pingcap/ticdc/pkg/uuid"
@@ -156,6 +157,46 @@ func TestAvroEncodeDeleteEventUsesPreRowForKey(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, int32(127), res.(map[string]interface{})["tu1"])
+}
+
+func TestAvroEncodeDeleteEventWithWatermarkCarriesCommitTs(t *testing.T) {
+	codecConfig := common.NewConfig(config.ProtocolAvro)
+	codecConfig.EnableTiDBExtension = true
+	codecConfig.AvroEnableWatermark = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	encoder, err := SetupEncoderAndSchemaRegistry4Testing(ctx, codecConfig)
+	defer TeardownEncoderAndSchemaRegistry4Testing()
+	require.NoError(t, err)
+	require.NotNil(t, encoder)
+
+	_, _, _, event := common.NewLargeEvent4Test(t)
+	topic := "avro-delete-with-watermark-test-topic"
+	require.NoError(t, encoder.AppendRowChangedEvent(ctx, topic, event))
+
+	messages := encoder.Build()
+	require.Len(t, messages, 1)
+	require.NotEmpty(t, messages[0].Key)
+	require.NotEmpty(t, messages[0].Value)
+	require.Equal(t, deleteByte, messages[0].Value[0])
+
+	decoder := NewDecoder(codecConfig, 0, encoder.schemaM, topic, nil)
+	decoder.AddKeyValue(messages[0].Key, messages[0].Value)
+
+	messageType, exists := decoder.HasNext()
+	require.True(t, exists)
+	require.Equal(t, common.MessageTypeRow, messageType)
+
+	decoded := decoder.NextDMLEvent()
+	require.NotNil(t, decoded)
+	require.Equal(t, event.CommitTs, decoded.GetCommitTs())
+	require.Len(t, decoded.RowTypes, 1)
+	require.Equal(t, commonType.RowTypeDelete, decoded.RowTypes[0])
+
+	_, exists = decoder.HasNext()
+	require.False(t, exists)
 }
 
 func TestAvroEnvelope(t *testing.T) {

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -123,6 +123,41 @@ func TestAvroEncode(t *testing.T) {
 	}
 }
 
+func TestAvroEncodeDeleteEventUsesPreRowForKey(t *testing.T) {
+	codecConfig := common.NewConfig(config.ProtocolAvro)
+	codecConfig.EnableTiDBExtension = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	encoder, err := SetupEncoderAndSchemaRegistry4Testing(ctx, codecConfig)
+	defer TeardownEncoderAndSchemaRegistry4Testing()
+	require.NoError(t, err)
+	require.NotNil(t, encoder)
+
+	_, _, _, event := common.NewLargeEvent4Test(t)
+	topic := "avro-delete-test-topic"
+	require.NoError(t, encoder.AppendRowChangedEvent(ctx, topic, event))
+
+	messages := encoder.Build()
+	require.Len(t, messages, 1)
+	require.NotEmpty(t, messages[0].Key)
+	require.Nil(t, messages[0].Value)
+
+	cid, data, err := extractConfluentSchemaIDAndBinaryData(messages[0].Key)
+	require.NoError(t, err)
+
+	avroKeyCodec, err := encoder.schemaM.Lookup(ctx,
+		topicName2SchemaSubjects(topic, keySchemaSuffix),
+		schemaID{confluentSchemaID: cid})
+	require.NoError(t, err)
+
+	res, _, err := avroKeyCodec.NativeFromBinary(data)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, int32(127), res.(map[string]interface{})["tu1"])
+}
+
 func TestAvroEnvelope(t *testing.T) {
 	t.Parallel()
 	cManager := &confluentSchemaManager{}

--- a/pkg/sink/codec/avro/decoder.go
+++ b/pkg/sink/codec/avro/decoder.go
@@ -129,9 +129,13 @@ func (d *decoder) NextDMLEvent() *commonEvent.DMLEvent {
 
 	// for the delete event, only have key part, it holds primary key or the unique key columns.
 	// for the insert / update, extract the value part, it holds all columns.
-	isDelete := len(d.value) == 0
+	isDelete := len(d.value) == 0 || d.isDeleteValue()
+	deleteCommitTs := uint64(0)
 	if isDelete {
 		// delete event only have key part, treat it as the value part also.
+		if d.isDeleteValue() {
+			deleteCommitTs = d.decodeDeleteCommitTs()
+		}
 		valueMap = keyMap
 		valueSchema = keySchema
 	} else {
@@ -144,6 +148,10 @@ func (d *decoder) NextDMLEvent() *commonEvent.DMLEvent {
 	event, err := assembleEvent(keyMap, valueMap, valueSchema, isDelete)
 	if err != nil {
 		log.Panic("assemble event failed", zap.Error(err))
+	}
+	if deleteCommitTs != 0 {
+		event.StartTs = deleteCommitTs
+		event.CommitTs = deleteCommitTs
 	}
 
 	// Delete event only has Primary Key Columns, but the checksum is calculated based on the whole row columns,
@@ -181,6 +189,23 @@ func (d *decoder) NextDMLEvent() *commonEvent.DMLEvent {
 	}
 
 	return event
+}
+
+func (d *decoder) isDeleteValue() bool {
+	return d.config.EnableTiDBExtension &&
+		d.config.AvroEnableWatermark &&
+		len(d.value) > 0 &&
+		d.value[0] == deleteByte
+}
+
+func (d *decoder) decodeDeleteCommitTs() uint64 {
+	if len(d.value) != 9 {
+		log.Panic("avro invalid delete value, expected delete marker plus commit-ts",
+			zap.String("data", util.RedactAny(d.value)))
+	}
+	commitTs := binary.BigEndian.Uint64(d.value[1:])
+	d.value = nil
+	return commitTs
 }
 
 // assembleEvent return a row changed event

--- a/pkg/sink/codec/avro/encoder.go
+++ b/pkg/sink/codec/avro/encoder.go
@@ -129,8 +129,8 @@ func (a *BatchEncoder) EncodeDDLEvent(e *commonEvent.DDLEvent) (*common.Message,
 		event := &ddlEvent{
 			Query:    e.Query,
 			Type:     e.GetDDLType(),
-			Schema:   e.GetSchemaName(),
-			Table:    e.GetTableName(),
+			Schema:   e.GetTargetSchemaName(),
+			Table:    e.GetTargetTableName(),
 			CommitTs: e.GetCommitTs(),
 		}
 		data, err := json.Marshal(event)

--- a/pkg/sink/codec/avro/encoder_test.go
+++ b/pkg/sink/codec/avro/encoder_test.go
@@ -104,6 +104,63 @@ func TestDDLEventE2E(t *testing.T) {
 	require.NotEmpty(t, decodedEvent.Query)
 }
 
+func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
+	codecConfig := common.NewConfig(config.ProtocolAvro)
+	codecConfig.EnableTiDBExtension = true
+	codecConfig.AvroDecimalHandlingMode = "string"
+	codecConfig.AvroBigintUnsignedHandlingMode = "string"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	encoder, err := SetupEncoderAndSchemaRegistry4Testing(ctx, codecConfig)
+	require.NoError(t, err)
+	defer TeardownEncoderAndSchemaRegistry4Testing()
+
+	topic := "avro-routed-test-topic"
+	require.NoError(t, encoder.AppendRowChangedEvent(ctx, topic, common.NewRoutedRowEvent4Test()))
+
+	messages := encoder.Build()
+	require.Len(t, messages, 1)
+
+	schemaM, err := NewConfluentSchemaManager(ctx, "http://127.0.0.1:8081", nil)
+	require.NoError(t, err)
+	decoder := NewDecoder(codecConfig, 0, schemaM, topic, nil)
+	decoder.AddKeyValue(messages[0].Key, messages[0].Value)
+
+	messageType, exists := decoder.HasNext()
+	require.True(t, exists)
+	require.Equal(t, common.MessageTypeRow, messageType)
+
+	decoded := decoder.NextDMLEvent()
+	require.Equal(t, "target_db", decoded.TableInfo.GetSchemaName())
+	require.Equal(t, "target_table", decoded.TableInfo.GetTableName())
+}
+
+func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
+	codecConfig := common.NewConfig(config.ProtocolAvro)
+	codecConfig.EnableTiDBExtension = true
+	codecConfig.AvroEnableWatermark = true
+
+	encoder := newAvroEncoderForTest(codecConfig.ChangefeedID.Keyspace(), nil, codecConfig)
+	routedDDL := common.NewRoutedDDLEvent4Test()
+	message, err := encoder.EncodeDDLEvent(routedDDL)
+	require.NoError(t, err)
+
+	topic := "avro-routed-ddl-test-topic"
+	decoder := NewDecoder(codecConfig, 0, nil, topic, nil)
+	decoder.AddKeyValue(message.Key, message.Value)
+
+	messageType, exists := decoder.HasNext()
+	require.True(t, exists)
+	require.Equal(t, common.MessageTypeDDL, messageType)
+
+	decoded := decoder.NextDDLEvent()
+	require.Equal(t, "target_db", decoded.SchemaName)
+	require.Equal(t, "target_table", decoded.TableName)
+	require.Equal(t, routedDDL.Query, decoded.Query)
+}
+
 func TestResolvedE2E(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sink/codec/avro/encoder_test.go
+++ b/pkg/sink/codec/avro/encoder_test.go
@@ -110,8 +110,7 @@ func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
 	codecConfig.AvroDecimalHandlingMode = "string"
 	codecConfig.AvroBigintUnsignedHandlingMode = "string"
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	encoder, err := SetupEncoderAndSchemaRegistry4Testing(ctx, codecConfig)
 	require.NoError(t, err)

--- a/pkg/sink/codec/avro/helper.go
+++ b/pkg/sink/codec/avro/helper.go
@@ -46,10 +46,11 @@ const (
 )
 
 const (
-	// avro does not send ddl and checkpoint message, the following 2 field is used to distinguish
-	// TiCDC DDL event and checkpoint event, only used for testing purpose, not for production
+	// avro does not send ddl and checkpoint messages, the following bytes are used
+	// to distinguish TiCDC internal events, only used for testing purpose, not for production.
 	ddlByte        = uint8(1)
 	checkpointByte = uint8(2)
+	deleteByte     = uint8(3)
 )
 
 var type2TiDBType = map[byte]string{

--- a/pkg/sink/codec/canal/canal_json_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_encoder_test.go
@@ -20,91 +20,13 @@ import (
 	"testing"
 
 	"github.com/pingcap/ticdc/downstreamadapter/sink/columnselector"
-	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/compression"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
-	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/ast"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
-
-func newRoutedCanalTableInfo() *commonType.TableInfo {
-	idFieldType := types.NewFieldType(mysql.TypeLong)
-	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
-	nameFieldType := types.NewFieldType(mysql.TypeVarchar)
-	nameFieldType.SetFlen(32)
-
-	return commonType.WrapTableInfo("source_db", &model.TableInfo{
-		ID:       20,
-		Name:     ast.NewCIStr("source_table"),
-		UpdateTS: 100,
-		Columns: []*model.ColumnInfo{
-			{
-				ID:        1,
-				Name:      ast.NewCIStr("id"),
-				FieldType: *idFieldType,
-				State:     model.StatePublic,
-				Offset:    0,
-			},
-			{
-				ID:        2,
-				Name:      ast.NewCIStr("name"),
-				FieldType: *nameFieldType,
-				State:     model.StatePublic,
-				Offset:    1,
-			},
-		},
-	}).CloneWithRouting("target_db", "target_table")
-}
-
-func newRoutedCanalDMLEvent() *commonEvent.DMLEvent {
-	tableInfo := newRoutedCanalTableInfo()
-	event := commonEvent.NewDMLEvent(
-		commonType.NewDispatcherID(),
-		tableInfo.TableName.TableID,
-		1,
-		2,
-		tableInfo,
-	)
-	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
-	rows.AppendRow(chunk.MutRowFromValues(int64(1), "alice").ToRow())
-	event.SetRows(rows)
-	event.RowTypes = append(event.RowTypes, commonType.RowTypeInsert)
-	event.RowKeys = append(event.RowKeys, []byte("row-key"))
-	event.Length = 1
-	event.TableInfoVersion = tableInfo.GetUpdateTS()
-	return event
-}
-
-func newRoutedCanalDDLEvent() *commonEvent.DDLEvent {
-	tableInfo := newRoutedCanalTableInfo()
-	sourceDDL := &commonEvent.DDLEvent{
-		Version:    commonEvent.DDLEventVersion1,
-		Type:       byte(model.ActionCreateTable),
-		SchemaName: "source_db",
-		TableName:  "source_table",
-		Query:      "CREATE TABLE `source_db`.`source_table` (`id` INT PRIMARY KEY)",
-		TableInfo:  tableInfo,
-		FinishedTs: 100,
-	}
-	return commonEvent.NewRoutedDDLEvent(
-		sourceDDL,
-		"CREATE TABLE `target_db`.`target_table` (`id` INT PRIMARY KEY)",
-		"target_db",
-		"target_table",
-		"",
-		"",
-		tableInfo,
-		nil,
-		nil,
-	)
-}
 
 func dml2rowEvent(t *testing.T, dml *commonEvent.DMLEvent) *commonEvent.RowEvent {
 	row, ok := dml.GetNextRow()
@@ -279,7 +201,7 @@ func TestCanalJSONCompressionE2E(t *testing.T) {
 }
 
 func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
-	dmlEvent := newRoutedCanalDMLEvent()
+	dmlEvent := common.NewRoutedDMLEvent4Test()
 	row, ok := dmlEvent.GetNextRow()
 	require.True(t, ok)
 
@@ -319,7 +241,7 @@ func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
 	require.NoError(t, err)
 	encoder := encIface.(*JSONRowEventEncoder)
 
-	message, err := encoder.EncodeDDLEvent(newRoutedCanalDDLEvent())
+	message, err := encoder.EncodeDDLEvent(common.NewRoutedDDLEvent4Test())
 	require.NoError(t, err)
 
 	decoder, err := NewDecoder(ctx, codecConfig, nil)

--- a/pkg/sink/codec/canal/canal_json_txn_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_txn_encoder_test.go
@@ -56,7 +56,7 @@ func TestCanalJSONTxnEventEncoderUsesTargetNames(t *testing.T) {
 	t.Parallel()
 
 	encoder := NewJSONTxnEventEncoder(common.NewConfig(config.ProtocolCanalJSON))
-	require.NoError(t, encoder.AppendTxnEvent(newRoutedCanalDMLEvent()))
+	require.NoError(t, encoder.AppendTxnEvent(common.NewRoutedDMLEvent4Test()))
 
 	messages := encoder.Build()
 	require.Len(t, messages, 1)

--- a/pkg/sink/codec/common/utils.go
+++ b/pkg/sink/codec/common/utils.go
@@ -18,7 +18,13 @@ import (
 	"testing"
 
 	"github.com/pingcap/ticdc/downstreamadapter/sink/columnselector"
+	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -195,6 +201,98 @@ func NewLargeEvent4Test(t *testing.T) (*commonEvent.DDLEvent, *commonEvent.RowEv
 		NeedAddedTables: []commonEvent.Table{{TableID: 1, SchemaID: 1}},
 	}
 	return ddlEvent, insertEvent, updateEvent, deleteEvent
+}
+
+// NewRoutedTableInfo4Test creates a small routed table info shared by codec tests.
+func NewRoutedTableInfo4Test() *commonType.TableInfo {
+	idFieldType := types.NewFieldType(mysql.TypeLong)
+	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
+	nameFieldType := types.NewFieldType(mysql.TypeVarchar)
+	nameFieldType.SetFlen(32)
+
+	return commonType.WrapTableInfo("source_db", &model.TableInfo{
+		ID:       20,
+		Name:     ast.NewCIStr("source_table"),
+		UpdateTS: 100,
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *idFieldType,
+				State:     model.StatePublic,
+				Offset:    0,
+			},
+			{
+				ID:        2,
+				Name:      ast.NewCIStr("name"),
+				FieldType: *nameFieldType,
+				State:     model.StatePublic,
+				Offset:    1,
+			},
+		},
+	}).CloneWithRouting("target_db", "target_table")
+}
+
+// NewRoutedDMLEvent4Test creates an insert DML whose source table is routed to target_db.target_table.
+func NewRoutedDMLEvent4Test() *commonEvent.DMLEvent {
+	tableInfo := NewRoutedTableInfo4Test()
+	event := commonEvent.NewDMLEvent(
+		commonType.NewDispatcherID(),
+		tableInfo.TableName.TableID,
+		1,
+		2,
+		tableInfo,
+	)
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
+	rows.AppendRow(chunk.MutRowFromValues(int64(1), "alice").ToRow())
+	event.SetRows(rows)
+	event.RowTypes = append(event.RowTypes, commonType.RowTypeInsert)
+	event.RowKeys = append(event.RowKeys, []byte("row-key"))
+	event.Length = 1
+	event.TableInfoVersion = tableInfo.GetUpdateTS()
+	return event
+}
+
+// NewRoutedRowEvent4Test creates a row event whose source table is routed to target_db.target_table.
+func NewRoutedRowEvent4Test() *commonEvent.RowEvent {
+	dml := NewRoutedDMLEvent4Test()
+	row, ok := dml.GetNextRow()
+	dml.Rewind()
+	if !ok {
+		panic("routed dml test event has no row")
+	}
+	return &commonEvent.RowEvent{
+		TableInfo:      dml.TableInfo,
+		CommitTs:       dml.CommitTs,
+		Event:          row,
+		ColumnSelector: columnselector.NewDefaultColumnSelector(),
+		Callback:       func() {},
+	}
+}
+
+// NewRoutedDDLEvent4Test creates a routed CREATE TABLE DDL event.
+func NewRoutedDDLEvent4Test() *commonEvent.DDLEvent {
+	tableInfo := NewRoutedTableInfo4Test()
+	sourceDDL := &commonEvent.DDLEvent{
+		Version:    commonEvent.DDLEventVersion1,
+		Type:       byte(model.ActionCreateTable),
+		SchemaName: "source_db",
+		TableName:  "source_table",
+		Query:      "CREATE TABLE `source_db`.`source_table` (`id` INT PRIMARY KEY, `name` VARCHAR(32))",
+		TableInfo:  tableInfo,
+		FinishedTs: 100,
+	}
+	return commonEvent.NewRoutedDDLEvent(
+		sourceDDL,
+		"CREATE TABLE `target_db`.`target_table` (`id` INT PRIMARY KEY, `name` VARCHAR(32))",
+		"target_db",
+		"target_table",
+		"",
+		"",
+		tableInfo,
+		nil,
+		nil,
+	)
 }
 
 // LargeColumnKeyValues returns the key values of large columns

--- a/pkg/sink/codec/debezium/codec.go
+++ b/pkg/sink/codec/debezium/codec.go
@@ -1217,8 +1217,8 @@ func (c *dbzCodec) EncodeDDLEvent(
 							}
 						})
 						jWriter.WriteArrayField("columns", func() {
-							parseColumns(e.Query, e.TableInfo.GetColumns())
-							for pos, col := range e.TableInfo.GetColumns() {
+							columns := parseColumns(e.Query, e.TableInfo.GetColumns())
+							for pos, col := range columns {
 								if col.Hidden {
 									continue
 								}

--- a/pkg/sink/codec/debezium/codec.go
+++ b/pkg/sink/codec/debezium/codec.go
@@ -861,6 +861,8 @@ func (c *dbzCodec) EncodeKey(
 	defer util.ReturnJSONWriter(jWriter)
 
 	var err error
+	schemaName := e.TableInfo.GetTargetSchemaName()
+	tableName := e.TableInfo.GetTargetTableName()
 	jWriter.WriteObject(func() {
 		jWriter.WriteObjectField("payload", func() {
 			columns := e.TableInfo.GetColumns()
@@ -878,7 +880,7 @@ func (c *dbzCodec) EncodeKey(
 			jWriter.WriteObjectField("schema", func() {
 				jWriter.WriteStringField("type", "struct")
 				jWriter.WriteStringField("name",
-					fmt.Sprintf("%s.Key", getSchemaTopicName(c.clusterID, e.TableInfo.GetSchemaName(), e.TableInfo.GetTableName())))
+					fmt.Sprintf("%s.Key", getSchemaTopicName(c.clusterID, schemaName, tableName)))
 				jWriter.WriteBoolField("optional", false)
 				jWriter.WriteArrayField("fields", func() {
 					columns := e.TableInfo.GetColumns()
@@ -905,6 +907,8 @@ func (c *dbzCodec) EncodeValue(
 	commitTime := oracle.GetTimeFromTS(e.CommitTs)
 
 	var err error
+	schemaName := e.TableInfo.GetTargetSchemaName()
+	tableName := e.TableInfo.GetTargetTableName()
 
 	jWriter.WriteObject(func() {
 		jWriter.WriteObjectField("payload", func() {
@@ -917,8 +921,8 @@ func (c *dbzCodec) EncodeValue(
 				jWriter.WriteInt64Field("ts_ms", commitTime.UnixMilli())
 				// snapshot field is a string of true,last,false,incremental
 				jWriter.WriteStringField("snapshot", "false")
-				jWriter.WriteStringField("db", e.TableInfo.GetSchemaName())
-				jWriter.WriteStringField("table", e.TableInfo.GetTableName())
+				jWriter.WriteStringField("db", schemaName)
+				jWriter.WriteStringField("table", tableName)
 				jWriter.WriteInt64Field("server_id", 0)
 				jWriter.WriteNullField("gtid")
 				jWriter.WriteStringField("file", "")
@@ -976,7 +980,7 @@ func (c *dbzCodec) EncodeValue(
 				jWriter.WriteStringField("type", "struct")
 				jWriter.WriteBoolField("optional", false)
 				jWriter.WriteStringField("name",
-					fmt.Sprintf("%s.Envelope", getSchemaTopicName(c.clusterID, e.TableInfo.GetSchemaName(), e.TableInfo.GetTableName())))
+					fmt.Sprintf("%s.Envelope", getSchemaTopicName(c.clusterID, schemaName, tableName)))
 				jWriter.WriteIntField("version", 1)
 				jWriter.WriteArrayField("fields", func() {
 					// schema is the same for `before` and `after`. So we build a new buffer to
@@ -1006,7 +1010,7 @@ func (c *dbzCodec) EncodeValue(
 						jWriter.WriteStringField("type", "struct")
 						jWriter.WriteBoolField("optional", true)
 						jWriter.WriteStringField("name",
-							fmt.Sprintf("%s.Value", getSchemaTopicName(c.clusterID, e.TableInfo.GetSchemaName(), e.TableInfo.GetTableName())))
+							fmt.Sprintf("%s.Value", getSchemaTopicName(c.clusterID, schemaName, tableName)))
 						jWriter.WriteStringField("field", "before")
 						jWriter.WriteArrayField("fields", func() {
 							jWriter.WriteRaw(fieldsJSON)
@@ -1016,7 +1020,7 @@ func (c *dbzCodec) EncodeValue(
 						jWriter.WriteStringField("type", "struct")
 						jWriter.WriteBoolField("optional", true)
 						jWriter.WriteStringField("name",
-							fmt.Sprintf("%s.Value", getSchemaTopicName(c.clusterID, e.TableInfo.GetSchemaName(), e.TableInfo.GetTableName())))
+							fmt.Sprintf("%s.Value", getSchemaTopicName(c.clusterID, schemaName, tableName)))
 						jWriter.WriteStringField("field", "after")
 						jWriter.WriteArrayField("fields", func() {
 							jWriter.WriteRaw(fieldsJSON)
@@ -1185,14 +1189,14 @@ func (c *dbzCodec) EncodeDDLEvent(
 					switch e.GetDDLType() {
 					case timodel.ActionRenameTable:
 						jWriter.WriteStringField("id", fmt.Sprintf("\"%s\".\"%s\",\"%s\".\"%s\"",
-							e.ExtraSchemaName,
-							e.ExtraTableName,
+							e.GetTargetExtraSchemaName(),
+							e.GetTargetExtraTableName(),
 							dbName,
 							tableName))
 					case timodel.ActionExchangeTablePartition:
 						jWriter.WriteStringField("id", fmt.Sprintf("\"%s\".\"%s\"",
-							e.ExtraSchemaName,
-							e.ExtraTableName))
+							e.GetTargetExtraSchemaName(),
+							e.GetTargetExtraTableName()))
 					case timodel.ActionDropTable:
 						jWriter.WriteStringField("id", fmt.Sprintf("\"%s\".\"%s\"",
 							dbName,

--- a/pkg/sink/codec/debezium/debezium_test.go
+++ b/pkg/sink/codec/debezium/debezium_test.go
@@ -101,6 +101,58 @@ func (s *debeziumSuite) requireDebeziumJSONEq(dbzOutput []byte, tiCDCOutput []by
 	}
 }
 
+func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
+	cfg := common.NewConfig(config.ProtocolDebezium)
+	cfg.EnableTiDBExtension = true
+	cfg.TimeZone = time.UTC
+
+	encoder := NewBatchEncoder(cfg, "dbserver1")
+	rowEvent := common.NewRoutedRowEvent4Test()
+	require.NoError(t, encoder.AppendRowChangedEvent(context.Background(), "", rowEvent))
+
+	messages := encoder.Build()
+	require.Len(t, messages, 1)
+
+	decoder := NewDecoder(cfg, 0, nil)
+	decoder.AddKeyValue(messages[0].Key, messages[0].Value)
+
+	messageType, hasNext := decoder.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeRow, messageType)
+
+	decoded := decoder.NextDMLEvent()
+	require.Equal(t, "target_db", decoded.TableInfo.GetSchemaName())
+	require.Equal(t, "target_table", decoded.TableInfo.GetTableName())
+
+	change, ok := decoded.GetNextRow()
+	require.True(t, ok)
+	common.CompareRow(t, rowEvent.Event, rowEvent.TableInfo, change, decoded.TableInfo)
+}
+
+func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
+	cfg := common.NewConfig(config.ProtocolDebezium)
+	cfg.EnableTiDBExtension = true
+	cfg.TimeZone = time.UTC
+
+	encoder := NewBatchEncoder(cfg, "dbserver1")
+	routedDDL := common.NewRoutedDDLEvent4Test()
+	message, err := encoder.EncodeDDLEvent(routedDDL)
+	require.NoError(t, err)
+	require.NotNil(t, message)
+
+	decoder := NewDecoder(cfg, 0, nil)
+	decoder.AddKeyValue(message.Key, message.Value)
+
+	messageType, hasNext := decoder.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeDDL, messageType)
+
+	decoded := decoder.NextDDLEvent()
+	require.Equal(t, "target_db", decoded.SchemaName)
+	require.Equal(t, "target_table", decoded.TableName)
+	require.Equal(t, routedDDL.Query, decoded.Query)
+}
+
 func TestDebeziumSuiteEnableSchema(t *testing.T) {
 	suite.Run(t, &debeziumSuite{
 		disableSchema: false,

--- a/pkg/sink/codec/debezium/helper.go
+++ b/pkg/sink/codec/debezium/helper.go
@@ -291,7 +291,7 @@ func getBitFromUint64(n int, v uint64) []byte {
 }
 
 func getDBTableName(e *commonEvent.DDLEvent) (string, string) {
-	return e.SchemaName, e.TableName
+	return e.GetTargetSchemaName(), e.GetTargetTableName()
 }
 
 func getSchemaTopicName(namespace string, schema string, table string) string {

--- a/pkg/sink/codec/debezium/helper.go
+++ b/pkg/sink/codec/debezium/helper.go
@@ -108,6 +108,10 @@ func parseColumns(sql string, columns []*timodel.ColumnInfo) []*timodel.ColumnIn
 	stmt, err := p.ParseOneStmt(sql, mysql.DefaultCharset, mysql.DefaultCollationName)
 	if err != nil {
 		log.Error("format query parse one stmt failed", zap.Error(err))
+		return cloned
+	}
+	if stmt == nil {
+		return cloned
 	}
 
 	columnsMap := make(map[ast.CIStr]*timodel.ColumnInfo, len(cloned))

--- a/pkg/sink/codec/debezium/helper.go
+++ b/pkg/sink/codec/debezium/helper.go
@@ -90,18 +90,32 @@ func parseOptions(options []*ast.ColumnOption, c *timodel.ColumnInfo) {
 	}
 }
 
-func parseColumns(sql string, columns []*timodel.ColumnInfo) {
+func parseColumns(sql string, columns []*timodel.ColumnInfo) []*timodel.ColumnInfo {
+	// Clone columns to avoid mutating the originals, which may be shared
+	// with other goroutines via columnSchema (see CloneWithRouting).
+	cloned := make([]*timodel.ColumnInfo, len(columns))
+	for i, col := range columns {
+		c := *col
+		if elems := col.GetElems(); len(elems) > 0 {
+			newElems := make([]string, len(elems))
+			copy(newElems, elems)
+			c.SetElems(newElems)
+		}
+		cloned[i] = &c
+	}
+
 	p := parser.New()
 	stmt, err := p.ParseOneStmt(sql, mysql.DefaultCharset, mysql.DefaultCollationName)
 	if err != nil {
 		log.Error("format query parse one stmt failed", zap.Error(err))
 	}
 
-	columnsMap := make(map[ast.CIStr]*timodel.ColumnInfo, len(columns))
-	for _, col := range columns {
+	columnsMap := make(map[ast.CIStr]*timodel.ColumnInfo, len(cloned))
+	for _, col := range cloned {
 		columnsMap[col.Name] = col
 	}
 	stmt.Accept(&visiter{columnsMap: columnsMap})
+	return cloned
 }
 
 func parseBit(s string, n int) string {

--- a/pkg/sink/codec/debezium/helper_test.go
+++ b/pkg/sink/codec/debezium/helper_test.go
@@ -91,6 +91,26 @@ func TestParseColumnsDoesNotMutateInput(t *testing.T) {
 	require.Equal(t, "CURRENT_TIMESTAMP", parsed[2].GetDefaultValue())
 }
 
+func TestParseColumnsReturnsClonedOnParseFailure(t *testing.T) {
+	columnInfos := []*timodel.ColumnInfo{
+		{
+			Name:      ast.NewCIStr("val1"),
+			FieldType: *types.NewFieldType(mysql.TypeDuration),
+		},
+	}
+	originalDecimal := columnInfos[0].GetDecimal()
+
+	var parsed []*timodel.ColumnInfo
+	require.NotPanics(t, func() {
+		parsed = parseColumns("CREATE TABLE test (", columnInfos)
+	})
+
+	require.Len(t, parsed, 1)
+	require.NotSame(t, columnInfos[0], parsed[0])
+	require.Equal(t, originalDecimal, parsed[0].GetDecimal())
+	require.Equal(t, originalDecimal, columnInfos[0].GetDecimal())
+}
+
 func TestGetSchemaTopicName(t *testing.T) {
 	namespace := "default"
 	schema := "1A.B"

--- a/pkg/sink/codec/debezium/helper_test.go
+++ b/pkg/sink/codec/debezium/helper_test.go
@@ -47,7 +47,7 @@ func TestGetColumns(t *testing.T) {
 			FieldType: *types.NewFieldType(mysql.TypeYear),
 		},
 	}
-	parseColumns(sql, columnInfos)
+	columnInfos = parseColumns(sql, columnInfos)
 	require.Equal(t, columnInfos[1].GetDefaultValue(), "CURRENT_TIMESTAMP")
 	require.Equal(t, columnInfos[2].GetDecimal(), 2)
 	require.Equal(t, columnInfos[2].GetDefaultValue(), "0")

--- a/pkg/sink/codec/debezium/helper_test.go
+++ b/pkg/sink/codec/debezium/helper_test.go
@@ -58,6 +58,39 @@ func TestGetColumns(t *testing.T) {
 	require.Equal(t, columnInfos[4].Comment, "")
 }
 
+func TestParseColumnsDoesNotMutateInput(t *testing.T) {
+	sql := "CREATE TABLE test (id INT PRIMARY KEY, val1 time(2) default 0, val2 timestamp(3) default now());"
+	columnInfos := []*timodel.ColumnInfo{
+		{
+			Name:      ast.NewCIStr("id"),
+			FieldType: *types.NewFieldType(mysql.TypeLong),
+		},
+		{
+			Name:      ast.NewCIStr("val1"),
+			FieldType: *types.NewFieldType(mysql.TypeDuration),
+		},
+		{
+			Name:      ast.NewCIStr("val2"),
+			FieldType: *types.NewFieldType(mysql.TypeTimestamp),
+		},
+	}
+	originalVal1Decimal := columnInfos[1].GetDecimal()
+	originalVal2Decimal := columnInfos[2].GetDecimal()
+
+	parsed := parseColumns(sql, columnInfos)
+
+	require.NotSame(t, columnInfos[1], parsed[1])
+	require.NotSame(t, columnInfos[2], parsed[2])
+	require.Equal(t, originalVal1Decimal, columnInfos[1].GetDecimal())
+	require.Equal(t, originalVal2Decimal, columnInfos[2].GetDecimal())
+	require.Nil(t, columnInfos[1].GetDefaultValue())
+	require.Nil(t, columnInfos[2].GetDefaultValue())
+	require.Equal(t, 2, parsed[1].GetDecimal())
+	require.Equal(t, "0", parsed[1].GetDefaultValue())
+	require.Equal(t, 3, parsed[2].GetDecimal())
+	require.Equal(t, "CURRENT_TIMESTAMP", parsed[2].GetDefaultValue())
+}
+
 func TestGetSchemaTopicName(t *testing.T) {
 	namespace := "default"
 	schema := "1A.B"

--- a/pkg/sink/codec/open/codec.go
+++ b/pkg/sink/codec/open/codec.go
@@ -45,8 +45,8 @@ func encodeRowChangedEvent(
 
 	keyWriter.WriteObject(func() {
 		keyWriter.WriteUint64Field("ts", e.CommitTs)
-		keyWriter.WriteStringField("scm", e.TableInfo.GetSchemaName())
-		keyWriter.WriteStringField("tbl", e.TableInfo.GetTableName())
+		keyWriter.WriteStringField("scm", e.TableInfo.GetTargetSchemaName())
+		keyWriter.WriteStringField("tbl", e.TableInfo.GetTargetTableName())
 		keyWriter.WriteIntField("t", int(common.MessageTypeRow))
 
 		if largeMessageOnlyHandleKeyColumns {
@@ -126,8 +126,8 @@ func encodeDDLEvent(e *commonEvent.DDLEvent, config *common.Config) ([]byte, []b
 
 	keyWriter.WriteObject(func() {
 		keyWriter.WriteUint64Field("ts", e.FinishedTs)
-		keyWriter.WriteStringField("scm", e.SchemaName)
-		keyWriter.WriteStringField("tbl", e.TableName)
+		keyWriter.WriteStringField("scm", e.GetTargetSchemaName())
+		keyWriter.WriteStringField("tbl", e.GetTargetTableName())
 		keyWriter.WriteIntField("t", int(common.MessageTypeDDL))
 	})
 

--- a/pkg/sink/codec/open/encoder_test.go
+++ b/pkg/sink/codec/open/encoder_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
@@ -650,6 +654,120 @@ func TestCreateTableDDL(t *testing.T) {
 	require.Equal(t, ddlEvent.SchemaName, obtained.SchemaName)
 	require.Equal(t, ddlEvent.TableName, obtained.TableName)
 	require.Equal(t, ddlEvent.FinishedTs, obtained.FinishedTs)
+}
+
+func newRoutedOpenTableInfo() *commonTable.TableInfo {
+	idFieldType := types.NewFieldType(mysql.TypeLong)
+	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
+	nameFieldType := types.NewFieldType(mysql.TypeVarchar)
+	nameFieldType.SetFlen(32)
+
+	return commonTable.WrapTableInfo("source_db", &model.TableInfo{
+		ID:       20,
+		Name:     ast.NewCIStr("source_table"),
+		UpdateTS: 100,
+		Columns: []*model.ColumnInfo{
+			{
+				ID:        1,
+				Name:      ast.NewCIStr("id"),
+				FieldType: *idFieldType,
+				State:     model.StatePublic,
+				Offset:    0,
+			},
+			{
+				ID:        2,
+				Name:      ast.NewCIStr("name"),
+				FieldType: *nameFieldType,
+				State:     model.StatePublic,
+				Offset:    1,
+			},
+		},
+	}).CloneWithRouting("target_db", "target_table")
+}
+
+func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
+	tableInfo := newRoutedOpenTableInfo()
+	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
+	rows.AppendRow(chunk.MutRowFromValues(int64(1), "alice").ToRow())
+
+	rowEvent := &commonEvent.RowEvent{
+		TableInfo:      tableInfo,
+		CommitTs:       100,
+		Event:          commonEvent.RowChange{Row: rows.GetRow(0), RowType: commonTable.RowTypeInsert},
+		ColumnSelector: columnselector.NewDefaultColumnSelector(),
+		Callback:       func() {},
+	}
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolOpen)
+
+	encoder, err := NewBatchEncoder(ctx, codecConfig)
+	require.NoError(t, err)
+	require.NoError(t, encoder.AppendRowChangedEvent(ctx, "", rowEvent))
+
+	messages := encoder.Build()
+	require.Len(t, messages, 1)
+
+	decoder, err := NewDecoder(ctx, 0, codecConfig, nil)
+	require.NoError(t, err)
+	decoder.AddKeyValue(messages[0].Key, messages[0].Value)
+
+	messageType, hasNext := decoder.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeRow, messageType)
+
+	decoded := decoder.NextDMLEvent()
+	require.Equal(t, "target_db", decoded.TableInfo.GetSchemaName())
+	require.Equal(t, "target_table", decoded.TableInfo.GetTableName())
+
+	change, ok := decoded.GetNextRow()
+	require.True(t, ok)
+	common.CompareRow(t, rowEvent.Event, rowEvent.TableInfo, change, decoded.TableInfo)
+}
+
+func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
+	tableInfo := newRoutedOpenTableInfo()
+	sourceDDL := &commonEvent.DDLEvent{
+		Query:      "create table `source_db`.`source_table` (`id` int primary key, `name` varchar(32))",
+		Type:       byte(model.ActionCreateTable),
+		SchemaName: "source_db",
+		TableName:  "source_table",
+		TableInfo:  tableInfo,
+		FinishedTs: 100,
+	}
+	routedDDL := commonEvent.NewRoutedDDLEvent(
+		sourceDDL,
+		"create table `target_db`.`target_table` (`id` int primary key, `name` varchar(32))",
+		"target_db",
+		"target_table",
+		"",
+		"",
+		tableInfo,
+		nil,
+		nil,
+	)
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolOpen)
+
+	encoder, err := NewBatchEncoder(ctx, codecConfig)
+	require.NoError(t, err)
+
+	message, err := encoder.EncodeDDLEvent(routedDDL)
+	require.NoError(t, err)
+
+	decoder, err := NewDecoder(ctx, 0, codecConfig, nil)
+	require.NoError(t, err)
+	decoder.AddKeyValue(message.Key, message.Value)
+
+	messageType, hasNext := decoder.HasNext()
+	require.True(t, hasNext)
+	require.Equal(t, common.MessageTypeDDL, messageType)
+
+	decoded := decoder.NextDDLEvent()
+	require.Equal(t, "target_db", decoded.SchemaName)
+	require.Equal(t, "target_table", decoded.TableName)
+	require.Equal(t, routedDDL.Query, decoded.Query)
 }
 
 func TestEncoderOneMessage(t *testing.T) {

--- a/pkg/sink/codec/open/encoder_test.go
+++ b/pkg/sink/codec/open/encoder_test.go
@@ -24,10 +24,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/sink/codec/common"
-	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/ast"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
@@ -656,47 +652,8 @@ func TestCreateTableDDL(t *testing.T) {
 	require.Equal(t, ddlEvent.FinishedTs, obtained.FinishedTs)
 }
 
-func newRoutedOpenTableInfo() *commonTable.TableInfo {
-	idFieldType := types.NewFieldType(mysql.TypeLong)
-	idFieldType.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
-	nameFieldType := types.NewFieldType(mysql.TypeVarchar)
-	nameFieldType.SetFlen(32)
-
-	return commonTable.WrapTableInfo("source_db", &model.TableInfo{
-		ID:       20,
-		Name:     ast.NewCIStr("source_table"),
-		UpdateTS: 100,
-		Columns: []*model.ColumnInfo{
-			{
-				ID:        1,
-				Name:      ast.NewCIStr("id"),
-				FieldType: *idFieldType,
-				State:     model.StatePublic,
-				Offset:    0,
-			},
-			{
-				ID:        2,
-				Name:      ast.NewCIStr("name"),
-				FieldType: *nameFieldType,
-				State:     model.StatePublic,
-				Offset:    1,
-			},
-		},
-	}).CloneWithRouting("target_db", "target_table")
-}
-
 func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
-	tableInfo := newRoutedOpenTableInfo()
-	rows := chunk.NewChunkWithCapacity(tableInfo.GetFieldSlice(), 1)
-	rows.AppendRow(chunk.MutRowFromValues(int64(1), "alice").ToRow())
-
-	rowEvent := &commonEvent.RowEvent{
-		TableInfo:      tableInfo,
-		CommitTs:       100,
-		Event:          commonEvent.RowChange{Row: rows.GetRow(0), RowType: commonTable.RowTypeInsert},
-		ColumnSelector: columnselector.NewDefaultColumnSelector(),
-		Callback:       func() {},
-	}
+	rowEvent := common.NewRoutedRowEvent4Test()
 
 	ctx := context.Background()
 	codecConfig := common.NewConfig(config.ProtocolOpen)
@@ -726,26 +683,7 @@ func TestEncodeRoutedDMLEventUsesTargetNames(t *testing.T) {
 }
 
 func TestEncodeRoutedDDLEventUsesTargetNames(t *testing.T) {
-	tableInfo := newRoutedOpenTableInfo()
-	sourceDDL := &commonEvent.DDLEvent{
-		Query:      "create table `source_db`.`source_table` (`id` int primary key, `name` varchar(32))",
-		Type:       byte(model.ActionCreateTable),
-		SchemaName: "source_db",
-		TableName:  "source_table",
-		TableInfo:  tableInfo,
-		FinishedTs: 100,
-	}
-	routedDDL := commonEvent.NewRoutedDDLEvent(
-		sourceDDL,
-		"create table `target_db`.`target_table` (`id` int primary key, `name` varchar(32))",
-		"target_db",
-		"target_table",
-		"",
-		"",
-		tableInfo,
-		nil,
-		nil,
-	)
+	routedDDL := common.NewRoutedDDLEvent4Test()
 
 	ctx := context.Background()
 	codecConfig := common.NewConfig(config.ProtocolOpen)

--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -124,8 +124,8 @@ func newTableSchemaMap(tableInfo *commonType.TableInfo) interface{} {
 	}
 
 	result := map[string]interface{}{
-		"database": tableInfo.TableName.Schema,
-		"table":    tableInfo.TableName.Table,
+		"database": tableInfo.GetTargetSchemaName(),
+		"table":    tableInfo.GetTargetTableName(),
 		"tableID":  tableInfo.TableName.TableID,
 		"version":  int64(tableInfo.GetUpdateTS()),
 		"columns":  columnsSchema,
@@ -254,8 +254,8 @@ func (a *avroMarshaller) newDMLMessageMap(
 ) map[string]interface{} {
 	dmlMessagePayload := dmlMessagePayloadPool.Get().(map[string]interface{})
 	dmlMessagePayload["version"] = defaultVersion
-	dmlMessagePayload["database"] = event.TableInfo.GetSchemaName()
-	dmlMessagePayload["table"] = event.TableInfo.GetTableName()
+	dmlMessagePayload["database"] = event.TableInfo.GetTargetSchemaName()
+	dmlMessagePayload["table"] = event.TableInfo.GetTargetTableName()
 	dmlMessagePayload["tableID"] = event.GetTableID()
 	dmlMessagePayload["commitTs"] = int64(event.CommitTs)
 	dmlMessagePayload["buildTs"] = time.Now().UnixMilli()

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -194,6 +194,56 @@ func TestEncodeDMLEnableChecksum(t *testing.T) {
 	// require.Nil(t, decodedRow)
 }
 
+func TestEncodeRoutedEventsUsesTargetNames(t *testing.T) {
+	ctx := context.Background()
+	for _, format := range []common.EncodingFormatType{
+		common.EncodingFormatJSON,
+		common.EncodingFormatAvro,
+	} {
+		codecConfig := common.NewConfig(config.ProtocolSimple)
+		codecConfig.EncodingFormat = format
+
+		encIface, err := NewEncoder(ctx, codecConfig)
+		require.NoError(t, err)
+		encoder := encIface.(*Encoder)
+
+		rowEventDecoder, err := NewDecoder(ctx, codecConfig, nil)
+		require.NoError(t, err)
+		decoder := rowEventDecoder.(*Decoder)
+
+		routedDDL := common.NewRoutedDDLEvent4Test()
+		ddlMessage, err := encoder.EncodeDDLEvent(routedDDL)
+		require.NoError(t, err)
+		decoder.AddKeyValue(ddlMessage.Key, ddlMessage.Value)
+
+		messageType, hasNext := decoder.HasNext()
+		require.True(t, hasNext)
+		require.Equal(t, common.MessageTypeDDL, messageType)
+
+		decodedDDL := decoder.NextDDLEvent()
+		require.Equal(t, "target_db", decodedDDL.SchemaName)
+		require.Equal(t, "target_table", decodedDDL.TableName)
+		require.Equal(t, routedDDL.Query, decodedDDL.Query)
+		require.Equal(t, "target_db", decodedDDL.TableInfo.GetSchemaName())
+		require.Equal(t, "target_table", decodedDDL.TableInfo.GetTableName())
+
+		rowEvent := common.NewRoutedRowEvent4Test()
+		require.NoError(t, encoder.AppendRowChangedEvent(ctx, "", rowEvent))
+
+		messages := encoder.Build()
+		require.Len(t, messages, 1)
+		decoder.AddKeyValue(messages[0].Key, messages[0].Value)
+
+		messageType, hasNext = decoder.HasNext()
+		require.True(t, hasNext)
+		require.Equal(t, common.MessageTypeRow, messageType)
+
+		decodedDML := decoder.NextDMLEvent()
+		require.Equal(t, "target_db", decodedDML.TableInfo.GetSchemaName())
+		require.Equal(t, "target_table", decodedDML.TableInfo.GetTableName())
+	}
+}
+
 func TestE2EPartitionTable(t *testing.T) {
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -224,8 +224,8 @@ func newTableSchema(tableInfo *commonType.TableInfo) *TableSchema {
 	}
 
 	return &TableSchema{
-		Schema:  tableInfo.TableName.Schema,
-		Table:   tableInfo.TableName.Table,
+		Schema:  tableInfo.GetTargetSchemaName(),
+		Table:   tableInfo.GetTargetTableName(),
 		TableID: tableInfo.TableName.TableID,
 		Version: tableInfo.GetUpdateTS(),
 		Columns: columns,
@@ -323,8 +323,8 @@ func (a *jsonMarshaller) newDMLMessage(
 ) *message {
 	m := &message{
 		Version:            defaultVersion,
-		Schema:             event.TableInfo.GetSchemaName(),
-		Table:              event.TableInfo.GetTableName(),
+		Schema:             event.TableInfo.GetTargetSchemaName(),
+		Table:              event.TableInfo.GetTargetTableName(),
 		TableID:            event.GetTableID(),
 		CommitTs:           event.CommitTs,
 		BuildTs:            time.Now().UnixMilli(),

--- a/tests/integration_tests/redo_apply_table_route/run.sh
+++ b/tests/integration_tests/redo_apply_table_route/run.sh
@@ -76,8 +76,12 @@ function verify_normal_table_route() {
 	local source_extra_count
 	local target_extra_count
 	source_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_db.users;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
-	target_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
 	source_extra_count=$(query_count "SELECT COUNT(*) AS cnt FROM source_extra_db.external_users;" "$UP_TIDB_HOST" "$UP_TIDB_PORT")
+
+	wait_query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" "$source_users_count" 90
+	wait_query_count "SELECT COUNT(*) AS cnt FROM target_extra_db.external_users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" "$source_extra_count" 90
+
+	target_users_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_db.users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
 	target_extra_count=$(query_count "SELECT COUNT(*) AS cnt FROM target_extra_db.external_users_routed;" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT")
 
 	require_equal "$target_users_count" "$source_users_count" "normal table route users count mismatch"

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -46,7 +46,7 @@ mysql_groups=(
 	# G06
 	'http_api http_api_compatibility http_api_tls_old_arch fail_over_ddl_G synced_status same_upstream_downstream'
 	# G07
-	'fail_over_ddl_H changefeed_update_config synced_status_with_redo'
+	'fail_over_ddl_H changefeed_update_config synced_status_with_redo redo_apply_table_route'
 	# G08
 	'capture_session_done_during_task changefeed_dup_error_restart mysql_sink_retry fail_over_ddl_I table_route'
 	# G09

--- a/tests/integration_tests/run_light_it_in_ci.sh
+++ b/tests/integration_tests/run_light_it_in_ci.sh
@@ -87,7 +87,7 @@ kafka_groups=(
 	# G07
 	'kafka_messages kafka_big_messages kafka_compression fail_over_ddl_H changefeed_update_config'
 	# G08
-	'capture_session_done_during_task fail_over_ddl_I'
+	'capture_session_done_during_task fail_over_ddl_I table_route'
 	# G09
 	'cdc_server_tips ddl_sequence log_redaction fail_over_ddl_J'
 	# G10

--- a/tests/integration_tests/table_route/run.sh
+++ b/tests/integration_tests/table_route/run.sh
@@ -114,9 +114,42 @@ function run_storage() {
 	run_storage_case csv
 }
 
+function run_kafka_case() {
+	local protocol=$1
+	local work_dir="$WORK_DIR/$protocol"
+	local topic_name="ticdc-table-route-$protocol-$RANDOM"
+	local sink_uri="kafka://127.0.0.1:9092/$topic_name?protocol=$protocol&partition-num=1&kafka-version=${KAFKA_VERSION}&max-message-bytes=10485760"
+	if [ "$protocol" = "canal-json" ]; then
+		sink_uri="$sink_uri&enable-tidb-extension=true"
+	fi
+
+	rm -rf "$work_dir" && mkdir -p "$work_dir"
+
+	start_tidb_cluster --workdir "$work_dir"
+
+	run_cdc_server --workdir "$work_dir" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+
+	cdc_cli_changefeed create --sink-uri="$sink_uri" --config="$CUR/conf/changefeed.toml"
+	run_kafka_consumer "$work_dir" "$sink_uri" "$CUR/conf/changefeed.toml" "" "_$protocol"
+
+	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+
+	verify_table_route_result "$work_dir"
+	verify_table_route_drop_database
+
+	stop_test "$work_dir"
+	check_logs "$work_dir"
+}
+
+function run_kafka() {
+	run_kafka_case canal-json
+	run_kafka_case open-protocol
+}
+
 function run() {
 	case "$SINK_TYPE" in
 	mysql) run_mysql ;;
+	kafka) run_kafka ;;
 	storage) run_storage ;;
 	*) return ;;
 	esac

--- a/tests/integration_tests/table_route/run.sh
+++ b/tests/integration_tests/table_route/run.sh
@@ -10,9 +10,12 @@ SINK_TYPE="$1"
 
 function verify_table_route_result() {
 	local work_dir=$1
+	local target_db=${2:-target_db}
+	local target_extra_db=${3:-target_extra_db}
+	local diff_config=${4:-$CUR/conf/diff_config.toml}
 
-	check_table_exists target_db.finish_mark_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
-	check_sync_diff "$work_dir" "$CUR/conf/diff_config.toml" 120
+	check_table_exists "$target_db.finish_mark_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
+	check_sync_diff "$work_dir" "$diff_config" 120
 
 	check_table_not_exists source_db.users "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_table_not_exists source_db.orders "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
@@ -21,31 +24,37 @@ function verify_table_route_result() {
 	check_table_not_exists source_extra_db.users_view_from_default "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_table_not_exists source_extra_db.orders_column_view_from_default "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_table_not_exists source_extra_db.partitioned_events_like_from_default "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	check_table_not_exists target_db.temp_table_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	check_table_not_exists target_db.cross_move_source_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	check_table_not_exists target_db.multi_rename_a_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	check_table_not_exists target_db.multi_rename_b_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	check_table_not_exists target_db.to_be_dropped_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
-	run_sql "SHOW CREATE VIEW target_db.user_order_view_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists "$target_db.temp_table_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists "$target_db.cross_move_source_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists "$target_db.multi_rename_a_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists "$target_db.multi_rename_b_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_table_not_exists "$target_db.to_be_dropped_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	run_sql "SHOW CREATE VIEW ${target_db}.user_order_view_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_contains "user_order_view_routed"
 	check_contains "users_routed"
 	check_contains "orders_routed"
-	run_sql "SHOW CREATE VIEW target_extra_db.users_view_from_default_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	run_sql "SHOW CREATE VIEW ${target_extra_db}.users_view_from_default_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_contains "users_view_from_default_routed"
-	check_contains "target_db"
+	check_contains "$target_db"
 	check_contains "users_routed"
-	run_sql "SHOW CREATE VIEW target_extra_db.orders_column_view_from_default_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	run_sql "SHOW CREATE VIEW ${target_extra_db}.orders_column_view_from_default_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
 	check_contains "orders_column_view_from_default_routed"
-	check_contains 'target_db`.`orders_routed`.`id'
-	check_contains 'FROM `target_db`.`orders_routed`'
-	check_table_not_exists target_db.transient_view_routed "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+	check_contains "\`${target_db}\`.\`orders_routed\`.\`id\`"
+	check_contains "FROM \`${target_db}\`.\`orders_routed\`"
+	check_table_not_exists "$target_db.transient_view_routed" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT"
+}
+
+function drop_table_route_source_databases() {
+	run_sql "DROP DATABASE source_extra_db" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+	run_sql "DROP DATABASE source_db" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
 }
 
 function verify_table_route_drop_database() {
-	run_sql "DROP DATABASE source_extra_db" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
-	run_sql "DROP DATABASE source_db" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
-	check_db_not_exists target_extra_db "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
-	check_db_not_exists target_db "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
+	local target_db=${1:-target_db}
+	local target_extra_db=${2:-target_extra_db}
+
+	check_db_not_exists "$target_extra_db" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
+	check_db_not_exists "$target_db" "$DOWN_TIDB_HOST" "$DOWN_TIDB_PORT" 90
 }
 
 function check_storage_files_use_target_names() {
@@ -74,6 +83,7 @@ function run_mysql() {
 	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
 
 	verify_table_route_result "$WORK_DIR"
+	drop_table_route_source_databases
 	verify_table_route_drop_database
 
 	cleanup_process "$CDC_BINARY"
@@ -103,6 +113,7 @@ function run_storage_case() {
 
 	verify_table_route_result "$work_dir"
 	check_storage_files_use_target_names "$storage_dir"
+	drop_table_route_source_databases
 	verify_table_route_drop_database
 
 	stop_test "$work_dir"
@@ -114,36 +125,138 @@ function run_storage() {
 	run_storage_case csv
 }
 
-function run_kafka_case() {
-	local protocol=$1
-	local work_dir="$WORK_DIR/$protocol"
-	local topic_name="ticdc-table-route-$protocol-$RANDOM"
-	local sink_uri="kafka://127.0.0.1:9092/$topic_name?protocol=$protocol&partition-num=1&kafka-version=${KAFKA_VERSION}&max-message-bytes=10485760"
-	if [ "$protocol" = "canal-json" ]; then
-		sink_uri="$sink_uri&enable-tidb-extension=true"
+function start_schema_registry() {
+	if curl -o /dev/null -s "http://127.0.0.1:8088"; then
+		return
 	fi
 
-	rm -rf "$work_dir" && mkdir -p "$work_dir"
+	echo 'Starting schema registry...'
+	./bin/bin/schema-registry-start -daemon ./bin/etc/schema-registry/schema-registry.properties
+	local i=0
+	while ! curl -o /dev/null -s "http://127.0.0.1:8088"; do
+		i=$((i + 1))
+		if [ "$i" -gt 30 ]; then
+			echo 'Failed to start schema registry'
+			exit 1
+		fi
+		sleep 2
+	done
+	curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"compatibility": "NONE"}' http://127.0.0.1:8088/config
+}
 
-	start_tidb_cluster --workdir "$work_dir"
+function render_table_route_configs() {
+	local work_dir=$1
+	local target_db=$2
+	local target_extra_db=$3
+	local changefeed_config=$4
+	local diff_config=$5
 
-	run_cdc_server --workdir "$work_dir" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+	sed -e "s/target_extra_db/${target_extra_db}/g" \
+		-e "s/target_db/${target_db}/g" \
+		"$CUR/conf/changefeed.toml" >"$changefeed_config"
 
-	cdc_cli_changefeed create --sink-uri="$sink_uri" --config="$CUR/conf/changefeed.toml"
-	run_kafka_consumer "$work_dir" "$sink_uri" "$CUR/conf/changefeed.toml" "" "_$protocol"
+	sed -e "s/target_extra_db/${target_extra_db}/g" \
+		-e "s/target_db/${target_db}/g" \
+		-e "s|/tmp/tidb_cdc_test/table_route/sync_diff/output|${work_dir}/sync_diff/output|g" \
+		"$CUR/conf/diff_config.toml" >"$diff_config"
+}
 
-	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+function kafka_sink_uri() {
+	local topic_name=$1
+	local protocol=$2
+	local extra_params=$3
+	local sink_uri="kafka://127.0.0.1:9092/${topic_name}?protocol=${protocol}&partition-num=1&kafka-version=${KAFKA_VERSION}&max-message-bytes=10485760"
+	if [ "$extra_params" != "" ]; then
+		sink_uri="${sink_uri}&${extra_params}"
+	fi
+	echo "$sink_uri"
+}
 
-	verify_table_route_result "$work_dir"
-	verify_table_route_drop_database
+function run_table_route_kafka_consumer() {
+	local work_dir=$1
+	local sink_uri=$2
+	local changefeed_config=$3
+	local schema_registry_uri=$4
+	local log_suffix=$5
+	local protocol_case=$6
+	local downstream_uri="mysql://root@127.0.0.1:3306/?safe-mode=true&batch-dml-enable=false&enable-ddl-ts=false"
 
-	stop_test "$work_dir"
-	check_logs "$work_dir"
+	local args=(
+		--log-file "$work_dir/cdc_kafka_consumer${log_suffix}.log"
+		--log-level debug
+		--upstream-uri "$sink_uri"
+		--downstream-uri "$downstream_uri"
+		--config "$changefeed_config"
+	)
+	if [ "$schema_registry_uri" != "" ]; then
+		args+=(--schema-registry-uri "$schema_registry_uri")
+	fi
+	if [[ "$protocol_case" == simple_* ]]; then
+		args+=(--upstream-tidb-dsn "root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/?")
+	fi
+
+	cdc_kafka_consumer "${args[@]}" >>"$work_dir/cdc_kafka_consumer_stdout${log_suffix}.log" 2>&1 &
 }
 
 function run_kafka() {
-	run_kafka_case canal-json
-	run_kafka_case open-protocol
+	local schema_registry_uri="http://127.0.0.1:8088"
+	local cases=(
+		"canal_json|canal-json||enable-tidb-extension=true"
+		"open_protocol|open-protocol||"
+		"simple_json|simple||"
+		"simple_avro|simple||encoding-format=avro"
+		"avro|avro|$schema_registry_uri|enable-tidb-extension=true&avro-enable-watermark=true&avro-decimal-handling-mode=string&avro-bigint-unsigned-handling-mode=string"
+		"debezium|debezium||enable-tidb-extension=true"
+	)
+
+	rm -rf "$WORK_DIR" && mkdir -p "$WORK_DIR"
+	start_schema_registry
+	start_tidb_cluster --workdir "$WORK_DIR"
+	run_cdc_server --workdir "$WORK_DIR" --binary "$CDC_BINARY" --cluster-id "$KEYSPACE_NAME"
+
+	local case_entry
+	for case_entry in "${cases[@]}"; do
+		local protocol_case protocol schema_registry extra_params
+		IFS='|' read -r protocol_case protocol schema_registry extra_params <<<"$case_entry"
+		local work_dir="$WORK_DIR/$protocol_case"
+		local target_db="target_${protocol_case}_db"
+		local target_extra_db="target_${protocol_case}_extra_db"
+		local changefeed_config="$work_dir/changefeed.toml"
+		local diff_config="$work_dir/diff_config.toml"
+		local topic_case="${protocol_case//_/-}"
+		local topic_name="ticdc-table-route-${topic_case}-${RANDOM}"
+		local sink_uri
+		sink_uri=$(kafka_sink_uri "$topic_name" "$protocol" "$extra_params")
+
+		mkdir -p "$work_dir"
+		render_table_route_configs "$work_dir" "$target_db" "$target_extra_db" "$changefeed_config" "$diff_config"
+
+		if [ "$schema_registry" != "" ]; then
+			cdc_cli_changefeed create -c "table-route-${topic_case}" --sink-uri="$sink_uri" --config="$changefeed_config" --schema-registry="$schema_registry"
+		else
+			cdc_cli_changefeed create -c "table-route-${topic_case}" --sink-uri="$sink_uri" --config="$changefeed_config"
+		fi
+		run_table_route_kafka_consumer "$work_dir" "$sink_uri" "$changefeed_config" "$schema_registry" "_$protocol_case" "$protocol_case"
+	done
+
+	run_sql_file "$CUR/data/test.sql" "$UP_TIDB_HOST" "$UP_TIDB_PORT"
+
+	for case_entry in "${cases[@]}"; do
+		local protocol_case protocol schema_registry extra_params
+		IFS='|' read -r protocol_case protocol schema_registry extra_params <<<"$case_entry"
+		local work_dir="$WORK_DIR/$protocol_case"
+		verify_table_route_result "$work_dir" "target_${protocol_case}_db" "target_${protocol_case}_extra_db" "$work_dir/diff_config.toml"
+	done
+
+	drop_table_route_source_databases
+	for case_entry in "${cases[@]}"; do
+		local protocol_case protocol schema_registry extra_params
+		IFS='|' read -r protocol_case protocol schema_registry extra_params <<<"$case_entry"
+		verify_table_route_drop_database "target_${protocol_case}_db" "target_${protocol_case}_extra_db"
+	done
+
+	cleanup_process "$CDC_BINARY"
+	check_logs "$WORK_DIR"
 }
 
 function run() {

--- a/tests/integration_tests/table_route/run.sh
+++ b/tests/integration_tests/table_route/run.sh
@@ -179,7 +179,7 @@ function run_table_route_kafka_consumer() {
 	local schema_registry_uri=$4
 	local log_suffix=$5
 	local protocol_case=$6
-	local downstream_uri="mysql://root@127.0.0.1:3306/?safe-mode=true&batch-dml-enable=false&enable-ddl-ts=false"
+	local downstream_uri="mysql://root@${DOWN_TIDB_HOST}:${DOWN_TIDB_PORT}/?safe-mode=true&batch-dml-enable=false&enable-ddl-ts=false"
 
 	local args=(
 		--log-file "$work_dir/cdc_kafka_consumer${log_suffix}.log"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4820 

Kafka sink table routing was not consistently covered across encoding protocols, and several Kafka protocol encoders still emitted source schema/table names in routed DML or DDL messages. This could make downstream consumers see `source_db.source_table` instead of the routed target names.

The table route integration test also did not exercise Kafka sink protocols, and `redo_apply_table_route` was not included in the light integration test matrix.

### What is changed and how it works?

- Use routed target schema/table names when encoding Kafka events for routed tables in open protocol, simple protocol, Avro, and Debezium.
- Keep non-routed events unchanged by falling back to the original schema/table names when no route is configured.
- Extend `cdc_kafka_consumer` DDL handling for simple and Debezium protocols, and ignore simple protocol bootstrap DDL messages with empty SQL.
- Add shared routed table/DML/DDL test helpers for codec tests, and reuse them across canal-json, open protocol, simple, Avro, and Debezium tests.
- Rework the Kafka branch of the `table_route` integration test to run supported protocols in one case by creating one changefeed/topic/consumer per protocol and routing each protocol to a distinct downstream target database.
- Add `redo_apply_table_route` and Kafka `table_route` coverage to the light integration test matrix.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
  - `go test ./pkg/sink/codec/canal -run 'TestEncodeRouted|TestCanalJSONTxnEventEncoderUsesTargetNames'`
  - `go test -tags=intest ./pkg/sink/codec/open -run 'TestEncodeRouted'`
  - `go test ./pkg/sink/codec/simple -run 'TestEncodeRouted'`
  - `go test ./pkg/sink/codec/avro -run 'TestEncodeRouted'`
  - `go test ./pkg/sink/codec/debezium -run 'TestEncodeRouted'`
  - `go test ./cmd/kafka-consumer`
  - `bash -n tests/integration_tests/table_route/run.sh`
  - `tools/bin/shfmt -d tests/integration_tests/table_route/run.sh`
  - `git diff --check`

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No performance regression is expected. For changefeeds without table routing, encoded schema/table names keep the same values as before. For routed tables, Kafka protocols now emit target schema/table names, which is the intended table-route behavior.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This PR fixes Kafka sink table-route behavior and extends tests without changing user-facing configuration or monitoring semantics.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Codec outputs consistently use routed target schema/table names across protocols, and Avro decoding correctly recognizes routed deletes with commit timestamps.

* **New Features**
  * Table-routing test flow expanded to run against Kafka sinks with per-protocol cases and schema registry support.
  * Kafka consumer writer accepts additional protocols and improved DDL handling behavior.

* **Tests**
  * Added unit and E2E tests validating routed DML/DDLs, Avro delete handling, and cross-protocol routing.

* **Chores**
  * CI light-test groups and routing scripts updated to support new Kafka/test permutations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->