### PR TITLE
metrics: show error time in changefeed error details panel

### DIFF
--- a/coordinator/helper.go
+++ b/coordinator/helper.go
@@ -15,6 +15,7 @@ package coordinator
 
 import (
 	"strings"
+	"time"
 
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/messaging"
@@ -49,6 +50,7 @@ type changefeedErrorMetricLabels struct {
 	keyspace   string
 	changefeed string
 	state      string
+	errorTime  string
 	code       string
 	message    string
 }
@@ -73,7 +75,7 @@ func sameRunningErrorSignature(lhs *config.RunningError, rhs *config.RunningErro
 }
 
 func (l changefeedErrorMetricLabels) labelValues() []string {
-	return []string{l.keyspace, l.changefeed, l.state, l.code, l.message}
+	return []string{l.keyspace, l.changefeed, l.state, l.errorTime, l.code, l.message}
 }
 
 func normalizeChangefeedErrorMetricMessage(message string) string {
@@ -82,6 +84,15 @@ func normalizeChangefeedErrorMetricMessage(message string) string {
 		return message
 	}
 	return message[:changefeedErrorMetricMsgLimit-3] + "..."
+}
+
+func normalizeChangefeedErrorMetricTime(errorTime time.Time) string {
+	// Keep the label stable across nodes with different local time zones while remaining
+	// directly readable in Grafana's table view.
+	if errorTime.IsZero() {
+		return ""
+	}
+	return errorTime.UTC().Format(time.RFC3339)
 }
 
 func getChangefeedErrorMetricLabels(info *config.ChangeFeedInfo) (changefeedErrorMetricLabels, bool) {
@@ -104,6 +115,7 @@ func getChangefeedErrorMetricLabels(info *config.ChangeFeedInfo) (changefeedErro
 		keyspace:   info.ChangefeedID.Keyspace(),
 		changefeed: info.ChangefeedID.Name(),
 		state:      string(info.State),
+		errorTime:  normalizeChangefeedErrorMetricTime(runningErr.Time),
 		code:       runningErr.Code,
 		message:    normalizeChangefeedErrorMetricMessage(runningErr.Message),
 	}, true

--- a/coordinator/helper_test.go
+++ b/coordinator/helper_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetChangefeedErrorMetricLabelsIncludesErrorTime verifies that a current warning is exported
+// with a stable UTC occurrence timestamp, normalized message text, and the rest of the panel labels.
+func TestGetChangefeedErrorMetricLabelsIncludesErrorTime(t *testing.T) {
+	errorTime := time.Date(2026, time.May, 18, 10, 11, 12, 0, time.FixedZone("CST", 8*60*60))
+	changefeedID := common.NewChangeFeedIDWithName("test-changefeed", common.DefaultKeyspaceName)
+	info := &config.ChangeFeedInfo{
+		ChangefeedID: changefeedID,
+		State:        config.StateWarning,
+		Warning: &config.RunningError{
+			Time:    errorTime,
+			Code:    "CDC:ErrSinkRetry",
+			Message: "sink retry \n warning",
+		},
+	}
+
+	labels, ok := getChangefeedErrorMetricLabels(info)
+	require.True(t, ok)
+	require.Equal(t, changefeedErrorMetricLabels{
+		keyspace:   common.DefaultKeyspaceName,
+		changefeed: "test-changefeed",
+		state:      string(config.StateWarning),
+		errorTime:  "2026-05-18T02:11:12Z",
+		code:       "CDC:ErrSinkRetry",
+		message:    "sink retry warning",
+	}, labels)
+}
+
+// TestNormalizeChangefeedErrorMetricTimeHandlesZeroTime verifies that historical or incomplete
+// error records without an occurrence timestamp render as an empty field instead of a misleading date.
+func TestNormalizeChangefeedErrorMetricTimeHandlesZeroTime(t *testing.T) {
+	require.Equal(t, "", normalizeChangefeedErrorMetricTime(time.Time{}))
+}

--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -4665,6 +4665,18 @@
                     "value": 180
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error_time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
               }
             ]
           },
@@ -4682,7 +4694,7 @@
           "pluginVersion": "7.5.17",
           "targets": [
             {
-              "expr": "max by (namespace, changefeed, state, code, message) (ticdc_owner_changefeed_error_info{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", namespace=~\"$namespace\", changefeed=~\"$changefeed\"})",
+              "expr": "max by (namespace, changefeed, state, code, error_time, message) (ticdc_owner_changefeed_error_info{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", namespace=~\"$namespace\", changefeed=~\"$changefeed\"})",
               "format": "time_series",
               "instant": true,
               "refId": "A"
@@ -4704,11 +4716,12 @@
                   "__name__": true
                 },
                 "indexByName": {
-                  "changefeed": 1,
-                  "code": 3,
-                  "message": 4,
                   "namespace": 0,
-                  "state": 2
+                  "changefeed": 1,
+                  "state": 2,
+                  "error_time": 3,
+                  "code": 4,
+                  "message": 5
                 },
                 "renameByName": {}
               }

--- a/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
@@ -4665,6 +4665,18 @@
                     "value": 180
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error_time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
               }
             ]
           },
@@ -4682,7 +4694,7 @@
           "pluginVersion": "7.5.17",
           "targets": [
             {
-              "expr": "max by (keyspace_name, changefeed, state, code, message) (ticdc_owner_changefeed_error_info{k8s_cluster=\"$k8s_cluster\", sharedpool_id=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", changefeed=~\"$changefeed\"})",
+              "expr": "max by (keyspace_name, changefeed, state, code, error_time, message) (ticdc_owner_changefeed_error_info{k8s_cluster=\"$k8s_cluster\", sharedpool_id=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", changefeed=~\"$changefeed\"})",
               "format": "time_series",
               "instant": true,
               "refId": "A"
@@ -4704,11 +4716,12 @@
                   "__name__": true
                 },
                 "indexByName": {
-                  "changefeed": 1,
-                  "code": 3,
-                  "message": 4,
                   "keyspace_name": 0,
-                  "state": 2
+                  "changefeed": 1,
+                  "state": 2,
+                  "error_time": 3,
+                  "code": 4,
+                  "message": 5
                 },
                 "renameByName": {}
               }

--- a/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
@@ -2408,6 +2408,18 @@
                     "value": 180
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error_time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 180
+                  }
+                ]
               }
             ]
           },
@@ -2425,7 +2437,7 @@
           "pluginVersion": "7.5.17",
           "targets": [
             {
-              "expr": "max by (keyspace_name, changefeed, state, code, message) (ticdc_owner_changefeed_error_info{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", changefeed=~\"$changefeed\"})",
+              "expr": "max by (keyspace_name, changefeed, state, code, error_time, message) (ticdc_owner_changefeed_error_info{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", changefeed=~\"$changefeed\"})",
               "format": "time_series",
               "instant": true,
               "refId": "A"
@@ -2447,11 +2459,12 @@
                   "__name__": true
                 },
                 "indexByName": {
-                  "changefeed": 1,
-                  "code": 3,
-                  "message": 4,
                   "keyspace_name": 0,
-                  "state": 2
+                  "changefeed": 1,
+                  "state": 2,
+                  "error_time": 3,
+                  "code": 4,
+                  "message": 5
                 },
                 "renameByName": {}
               }

--- a/pkg/metrics/changefeed.go
+++ b/pkg/metrics/changefeed.go
@@ -73,13 +73,15 @@ var (
 			Help:      "The status of changefeeds",
 		}, []string{getKeyspaceLabel(), "changefeed"})
 
+	// ChangefeedErrorInfoGauge records the current warning or failed reason and its occurrence time
+	// for each changefeed.
 	ChangefeedErrorInfoGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "ticdc",
 			Subsystem: "owner",
 			Name:      "changefeed_error_info",
-			Help:      "The current warning or failed reason of changefeeds",
-		}, []string{getKeyspaceLabel(), "changefeed", "state", "code", "message"})
+			Help:      "The current warning or failed reason and occurrence time of changefeeds",
+		}, []string{getKeyspaceLabel(), "changefeed", "state", "error_time", "code", "message"})
 
 	ChangefeedCheckpointTsLagGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5085

### What is changed and how it works?

- Expose the current changefeed error occurrence time through the `ticdc_owner_changefeed_error_info` metric as an `error_time` label.
- Render `error_time` in the `Changefeed Error Details` Grafana panel for both standard and next-generation dashboards.
- Format non-zero error times as UTC RFC3339 strings and leave missing historical timestamps blank.
- Add unit coverage for the new metric-label formatting behavior.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test
<img width="1779" height="157" alt="img_v3_0211q_ad0021e1-a099-4610-bbda-469fd888ffcg" src="https://github.com/user-attachments/assets/6e881ff1-d05d-4fef-aa9c-ae5e83624eeb" />


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No expected performance regression. This extends the current error-info metric with one stable label for the active error occurrence time. Existing selectors remain valid, while consumers that depend on the exact label set should account for the added `error_time` label.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No separate documentation update is needed. The affected Grafana dashboard definitions are updated in this PR.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Changefeed error metrics now capture the time errors occurred (UTC format) for improved troubleshooting and error tracking.
  * Updated monitoring dashboards to display error timestamps alongside error details.

* **Tests**
  * Added unit tests for error timestamp handling and metric label validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->