### PR TITLE
api, table_route: static check the table route conflict when create / update changefeed

### DIFF
--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ticdc/api/middleware"
+	"github.com/pingcap/ticdc/downstreamadapter/routing"
 	"github.com/pingcap/ticdc/downstreamadapter/sink"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/columnselector"
 	"github.com/pingcap/ticdc/downstreamadapter/sink/eventrouter"
@@ -45,7 +46,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/txnutil/gc"
 	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/pkg/version"
-	tidbkv "github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
@@ -252,7 +253,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 		cancel()
 	}()
 
-	var kvStorage tidbkv.Storage
+	var kvStorage kv.Storage
 	keyspaceManager := appcontext.GetService[keyspace.Manager](appcontext.KeyspaceManager)
 	kvStorage, err = keyspaceManager.GetStorage(ctx, keyspaceName)
 	if err != nil {
@@ -280,7 +281,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 		allTables        []common.TableName
 	)
 	protocol, _ := config.ParseSinkProtocolFromString(util.GetOrZero(replicaCfg.Sink.Protocol))
-	ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	tableInfos, ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -288,6 +289,15 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 	if !util.GetOrZero(replicaCfg.ForceReplicate) && !util.GetOrZero(cfg.ReplicaConfig.IgnoreIneligibleTable) {
 		if len(ineligibleTables) != 0 {
 			err = errors.ErrTableIneligible.GenWithStackByArgs(ineligibleTables)
+			_ = c.Error(err)
+			return
+		}
+	}
+
+	// Static table route conflict check
+	checkInfos := filterTableInfosForRouteConflict(tableInfos, ineligibleTables, replicaCfg)
+	if len(checkInfos) > 0 && len(replicaCfg.Sink.DispatchRules) > 0 {
+		if err = routing.ValidateNoStaticRouteConflict(changefeedID, util.GetOrZero(replicaCfg.CaseSensitive), replicaCfg.Sink.DispatchRules, checkInfos); err != nil {
 			_ = c.Error(err)
 			return
 		}
@@ -489,7 +499,7 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	_, ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -864,14 +874,14 @@ func (h *OpenAPIV2) ResumeChangefeed(c *gin.Context) {
 		}
 		protocol, _ := config.ParseSinkProtocolFromString(util.GetOrZero(cfInfo.Config.Sink.Protocol))
 
-		var kvStorage tidbkv.Storage
+		var kvStorage kv.Storage
 		keyspaceManager := appcontext.GetService[keyspace.Manager](appcontext.KeyspaceManager)
 		kvStorage, err = keyspaceManager.GetStorage(ctx, changefeedDisplayName.Keyspace)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
-		ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, cfInfo.Config, kvStorage, newCheckpointTs, scheme, topic, protocol)
+		_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, cfInfo.Config, kvStorage, newCheckpointTs, scheme, topic, protocol)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -994,6 +1004,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		targetTsUpdated, sinkURIUpdated, configUpdated))
 
 	var (
+		tableInfos       []*common.TableInfo
 		ineligibleTables []common.TableName
 		eligibleTables   []common.TableName
 		allTables        []common.TableName
@@ -1031,7 +1042,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		}
 
 		// use checkpointTs get snapshot from kv storage
-		ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
+		tableInfos, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
 		if err != nil {
 			_ = c.Error(errors.ErrChangefeedUpdateRefused.GenWithStackByCause(err))
 			return
@@ -1039,6 +1050,15 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		if !util.GetOrZero(oldCfInfo.Config.ForceReplicate) && !util.GetOrZero(oldCfInfo.Config.IgnoreIneligibleTable) {
 			if len(ineligibleTables) != 0 {
 				_ = c.Error(errors.ErrTableIneligible.GenWithStackByArgs(ineligibleTables))
+				return
+			}
+		}
+
+		// Static table route conflict check
+		checkInfos := filterTableInfosForRouteConflict(tableInfos, ineligibleTables, oldCfInfo.Config)
+		if len(checkInfos) > 0 && len(oldCfInfo.Config.Sink.DispatchRules) > 0 {
+			if err = routing.ValidateNoStaticRouteConflict(oldCfInfo.ChangefeedID, util.GetOrZero(oldCfInfo.Config.CaseSensitive), oldCfInfo.Config.Sink.DispatchRules, checkInfos); err != nil {
+				_ = c.Error(err)
 				return
 			}
 		}
@@ -1703,17 +1723,17 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 func getVerifiedTables(
 	ctx context.Context,
 	replicaConfig *config.ReplicaConfig,
-	storage tidbkv.Storage, startTs uint64,
+	storage kv.Storage, startTs uint64,
 	scheme string, topic string, protocol config.Protocol,
-) ([]common.TableName, []common.TableName, []common.TableName, error) {
+) ([]*common.TableInfo, []common.TableName, []common.TableName, []common.TableName, error) {
 	f, err := filter.NewFilter(replicaConfig.Filter, "", util.GetOrZero(replicaConfig.CaseSensitive), util.GetOrZero(replicaConfig.ForceReplicate))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	tableInfos, ineligibleTables, eligibleTables, allTables, err := schemastore.
 		VerifyTables(f, storage, startTs)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	log.Info("verifyTables completed",
 		zap.Int("tableCount", len(tableInfos)),
@@ -1721,35 +1741,70 @@ func getVerifiedTables(
 
 	err = f.Verify(tableInfos)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if !config.IsMQScheme(scheme) {
-		return ineligibleTables, eligibleTables, allTables, nil
+		return tableInfos, ineligibleTables, eligibleTables, allTables, nil
 	}
 
 	eventRouter, err := eventrouter.NewEventRouter(replicaConfig.Sink, topic, config.IsPulsarScheme(scheme), protocol == config.ProtocolAvro)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	err = eventRouter.VerifyTables(tableInfos)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	selectors, err := columnselector.New(replicaConfig.Sink)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	err = selectors.VerifyTables(tableInfos, eventRouter)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	if ctx.Err() != nil {
-		return nil, nil, nil, errors.Trace(ctx.Err())
+		return nil, nil, nil, nil, errors.Trace(ctx.Err())
 	}
 
-	return ineligibleTables, eligibleTables, allTables, nil
+	return tableInfos, ineligibleTables, eligibleTables, allTables, nil
+}
+
+// filterTableInfosForRouteConflict filters tableInfos for static route conflict checks.
+// It excludes ineligible tables when IgnoreIneligibleTable is true and ForceReplicate is false.
+func filterTableInfosForRouteConflict(
+	tableInfos []*common.TableInfo,
+	ineligibleTables []common.TableName,
+	replicaCfg *config.ReplicaConfig,
+) []*common.TableInfo {
+	if util.GetOrZero(replicaCfg.ForceReplicate) || len(ineligibleTables) == 0 {
+		return tableInfos
+	}
+	if util.GetOrZero(replicaCfg.IgnoreIneligibleTable) {
+		type tableNameKey struct {
+			schema string
+			table  string
+		}
+		ineligible := make(map[tableNameKey]struct{}, len(ineligibleTables))
+		for _, t := range ineligibleTables {
+			ineligible[tableNameKey{schema: t.Schema, table: t.Table}] = struct{}{}
+		}
+		result := make([]*common.TableInfo, 0, len(tableInfos))
+		for _, ti := range tableInfos {
+			if ti == nil {
+				continue
+			}
+			tn := tableNameKey{schema: ti.GetSchemaName(), table: ti.GetTableName()}
+			if _, ok := ineligible[tn]; ok {
+				continue
+			}
+			result = append(result, ti)
+		}
+		return result
+	}
+	return tableInfos
 }
 
 func GetKeyspaceValueWithDefault(c *gin.Context) string {

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -1770,16 +1770,24 @@ func verifyRouteConflict(
 	ineligibleTables []common.TableName,
 	replicaCfg *config.ReplicaConfig,
 ) error {
-	if len(eligibleTables)+len(ineligibleTables) == 0 ||
-		replicaCfg == nil || replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
+	if len(eligibleTables)+len(ineligibleTables) == 0 || replicaCfg == nil ||
+		replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
 		return nil
+	}
+	if util.GetOrZero(replicaCfg.ForceReplicate) {
+		return routing.ValidateNoStaticRouteConflict(
+			changefeedID,
+			util.GetOrZero(replicaCfg.CaseSensitive),
+			replicaCfg.Sink.DispatchRules,
+			eligibleTables,
+			ineligibleTables,
+		)
 	}
 	return routing.ValidateNoStaticRouteConflict(
 		changefeedID,
 		util.GetOrZero(replicaCfg.CaseSensitive),
 		replicaCfg.Sink.DispatchRules,
 		eligibleTables,
-		ineligibleTables,
 	)
 }
 

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -1727,7 +1727,13 @@ func getVerifiedTables(
 		return nil, nil, nil, nil, err
 	}
 
-	if err := verifyRouteConflict(changefeedID, tableInfos, replicaConfig); err != nil {
+	// eligibleTables and ineligibleTables are both derived from tableInfos.
+	// allTables also includes table-filtered or unsupported tables, so it is not
+	// suitable for route conflict checks.
+	routeTables := make([]common.TableName, 0, len(eligibleTables)+len(ineligibleTables))
+	routeTables = append(routeTables, eligibleTables...)
+	routeTables = append(routeTables, ineligibleTables...)
+	if err := verifyRouteConflict(changefeedID, routeTables, replicaConfig); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -1769,17 +1775,17 @@ func verifyTable4MQ(
 
 func verifyRouteConflict(
 	changefeedID common.ChangeFeedID,
-	tableInfos []*common.TableInfo,
+	tableNames []common.TableName,
 	replicaCfg *config.ReplicaConfig,
 ) error {
-	if len(tableInfos) == 0 || replicaCfg == nil || replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
+	if len(tableNames) == 0 || replicaCfg == nil || replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
 		return nil
 	}
 	return routing.ValidateNoStaticRouteConflict(
 		changefeedID,
 		util.GetOrZero(replicaCfg.CaseSensitive),
 		replicaCfg.Sink.DispatchRules,
-		tableInfos,
+		tableNames,
 	)
 }
 

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -281,7 +281,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 		allTables        []common.TableName
 	)
 	protocol, _ := config.ParseSinkProtocolFromString(util.GetOrZero(replicaCfg.Sink.Protocol))
-	tableInfos, ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, changefeedID, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -289,15 +289,6 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 	if !util.GetOrZero(replicaCfg.ForceReplicate) && !util.GetOrZero(cfg.ReplicaConfig.IgnoreIneligibleTable) {
 		if len(ineligibleTables) != 0 {
 			err = errors.ErrTableIneligible.GenWithStackByArgs(ineligibleTables)
-			_ = c.Error(err)
-			return
-		}
-	}
-
-	// Static table route conflict check
-	checkInfos := filterTableInfosForRouteConflict(tableInfos, ineligibleTables, replicaCfg)
-	if len(checkInfos) > 0 && len(replicaCfg.Sink.DispatchRules) > 0 {
-		if err = routing.ValidateNoStaticRouteConflict(changefeedID, util.GetOrZero(replicaCfg.CaseSensitive), replicaCfg.Sink.DispatchRules, checkInfos); err != nil {
 			_ = c.Error(err)
 			return
 		}
@@ -499,7 +490,7 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	_, ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	_, ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, common.ChangeFeedID{}, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -881,7 +872,7 @@ func (h *OpenAPIV2) ResumeChangefeed(c *gin.Context) {
 			_ = c.Error(err)
 			return
 		}
-		_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, cfInfo.Config, kvStorage, newCheckpointTs, scheme, topic, protocol)
+		_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, cfInfo.ChangefeedID, cfInfo.Config, kvStorage, newCheckpointTs, scheme, topic, protocol)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -1004,7 +995,6 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		targetTsUpdated, sinkURIUpdated, configUpdated))
 
 	var (
-		tableInfos       []*common.TableInfo
 		ineligibleTables []common.TableName
 		eligibleTables   []common.TableName
 		allTables        []common.TableName
@@ -1042,7 +1032,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		}
 
 		// use checkpointTs get snapshot from kv storage
-		tableInfos, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
+		_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, oldCfInfo.ChangefeedID, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
 		if err != nil {
 			_ = c.Error(errors.ErrChangefeedUpdateRefused.GenWithStackByCause(err))
 			return
@@ -1054,14 +1044,6 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 			}
 		}
 
-		// Static table route conflict check
-		checkInfos := filterTableInfosForRouteConflict(tableInfos, ineligibleTables, oldCfInfo.Config)
-		if len(checkInfos) > 0 && len(oldCfInfo.Config.Sink.DispatchRules) > 0 {
-			if err = routing.ValidateNoStaticRouteConflict(oldCfInfo.ChangefeedID, util.GetOrZero(oldCfInfo.Config.CaseSensitive), oldCfInfo.Config.Sink.DispatchRules, checkInfos); err != nil {
-				_ = c.Error(err)
-				return
-			}
-		}
 	}
 
 	// verify sink
@@ -1722,6 +1704,7 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 
 func getVerifiedTables(
 	ctx context.Context,
+	changefeedID common.ChangeFeedID,
 	replicaConfig *config.ReplicaConfig,
 	storage kv.Storage, startTs uint64,
 	scheme string, topic string, protocol config.Protocol,
@@ -1730,38 +1713,21 @@ func getVerifiedTables(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	tableInfos, ineligibleTables, eligibleTables, allTables, err := schemastore.
-		VerifyTables(f, storage, startTs)
+	tableInfos, ineligibleTables, eligibleTables, allTables, err := schemastore.VerifyTables(f, storage, startTs)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	log.Info("verifyTables completed",
-		zap.Int("tableCount", len(tableInfos)),
-		zap.Uint64("startTs", startTs))
 
 	err = f.Verify(tableInfos)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	if !config.IsMQScheme(scheme) {
-		return tableInfos, ineligibleTables, eligibleTables, allTables, nil
-	}
 
-	eventRouter, err := eventrouter.NewEventRouter(replicaConfig.Sink, topic, config.IsPulsarScheme(scheme), protocol == config.ProtocolAvro)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	err = eventRouter.VerifyTables(tableInfos)
-	if err != nil {
+	if err := verifyTable4MQ(replicaConfig, scheme, topic, protocol, tableInfos); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	selectors, err := columnselector.New(replicaConfig.Sink)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	err = selectors.VerifyTables(tableInfos, eventRouter)
-	if err != nil {
+	if err := verifyRouteConflict(changefeedID, tableInfos, replicaConfig); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -1772,39 +1738,49 @@ func getVerifiedTables(
 	return tableInfos, ineligibleTables, eligibleTables, allTables, nil
 }
 
-// filterTableInfosForRouteConflict filters tableInfos for static route conflict checks.
-// It excludes ineligible tables when IgnoreIneligibleTable is true and ForceReplicate is false.
-func filterTableInfosForRouteConflict(
+func verifyTable4MQ(
+	replicaConfig *config.ReplicaConfig,
+	scheme string,
+	topic string,
+	protocol config.Protocol,
 	tableInfos []*common.TableInfo,
-	ineligibleTables []common.TableName,
+) error {
+	if !config.IsMQScheme(scheme) {
+		return nil
+	}
+
+	eventRouter, err := eventrouter.NewEventRouter(replicaConfig.Sink, topic, config.IsPulsarScheme(scheme), protocol == config.ProtocolAvro)
+	if err != nil {
+		return err
+	}
+	if err = eventRouter.VerifyTables(tableInfos); err != nil {
+		return err
+	}
+
+	selectors, err := columnselector.New(replicaConfig.Sink)
+	if err != nil {
+		return err
+	}
+	if err = selectors.VerifyTables(tableInfos, eventRouter); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyRouteConflict(
+	changefeedID common.ChangeFeedID,
+	tableInfos []*common.TableInfo,
 	replicaCfg *config.ReplicaConfig,
-) []*common.TableInfo {
-	if util.GetOrZero(replicaCfg.ForceReplicate) || len(ineligibleTables) == 0 {
-		return tableInfos
+) error {
+	if len(tableInfos) == 0 || replicaCfg == nil || replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
+		return nil
 	}
-	if util.GetOrZero(replicaCfg.IgnoreIneligibleTable) {
-		type tableNameKey struct {
-			schema string
-			table  string
-		}
-		ineligible := make(map[tableNameKey]struct{}, len(ineligibleTables))
-		for _, t := range ineligibleTables {
-			ineligible[tableNameKey{schema: t.Schema, table: t.Table}] = struct{}{}
-		}
-		result := make([]*common.TableInfo, 0, len(tableInfos))
-		for _, ti := range tableInfos {
-			if ti == nil {
-				continue
-			}
-			tn := tableNameKey{schema: ti.GetSchemaName(), table: ti.GetTableName()}
-			if _, ok := ineligible[tn]; ok {
-				continue
-			}
-			result = append(result, ti)
-		}
-		return result
-	}
-	return tableInfos
+	return routing.ValidateNoStaticRouteConflict(
+		changefeedID,
+		util.GetOrZero(replicaCfg.CaseSensitive),
+		replicaCfg.Sink.DispatchRules,
+		tableInfos,
+	)
 }
 
 func GetKeyspaceValueWithDefault(c *gin.Context) string {

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -281,7 +281,7 @@ func (h *OpenAPIV2) CreateChangefeed(c *gin.Context) {
 		allTables        []common.TableName
 	)
 	protocol, _ := config.ParseSinkProtocolFromString(util.GetOrZero(replicaCfg.Sink.Protocol))
-	_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, changefeedID, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, changefeedID, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -490,7 +490,7 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	_, ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, common.ChangeFeedID{}, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, common.ChangeFeedID{}, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -872,7 +872,7 @@ func (h *OpenAPIV2) ResumeChangefeed(c *gin.Context) {
 			_ = c.Error(err)
 			return
 		}
-		_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, cfInfo.ChangefeedID, cfInfo.Config, kvStorage, newCheckpointTs, scheme, topic, protocol)
+		ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, cfInfo.ChangefeedID, cfInfo.Config, kvStorage, newCheckpointTs, scheme, topic, protocol)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -1032,7 +1032,7 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 		}
 
 		// use checkpointTs get snapshot from kv storage
-		_, ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, oldCfInfo.ChangefeedID, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
+		ineligibleTables, eligibleTables, allTables, err = getVerifiedTables(ctx, oldCfInfo.ChangefeedID, oldCfInfo.Config, kvStorage, status.CheckpointTs, scheme, topic, protocol)
 		if err != nil {
 			_ = c.Error(errors.ErrChangefeedUpdateRefused.GenWithStackByCause(err))
 			return
@@ -1043,7 +1043,6 @@ func (h *OpenAPIV2) UpdateChangefeed(c *gin.Context) {
 				return
 			}
 		}
-
 	}
 
 	// verify sink
@@ -1708,34 +1707,34 @@ func getVerifiedTables(
 	replicaConfig *config.ReplicaConfig,
 	storage kv.Storage, startTs uint64,
 	scheme string, topic string, protocol config.Protocol,
-) ([]*common.TableInfo, []common.TableName, []common.TableName, []common.TableName, error) {
+) ([]common.TableName, []common.TableName, []common.TableName, error) {
 	f, err := filter.NewFilter(replicaConfig.Filter, "", util.GetOrZero(replicaConfig.CaseSensitive), util.GetOrZero(replicaConfig.ForceReplicate))
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 	tableInfos, ineligibleTables, eligibleTables, allTables, err := schemastore.VerifyTables(f, storage, startTs)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	err = f.Verify(tableInfos)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if err := verifyTable4MQ(replicaConfig, scheme, topic, protocol, tableInfos); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if err := verifyRouteConflict(changefeedID, eligibleTables, ineligibleTables, replicaConfig); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if ctx.Err() != nil {
-		return nil, nil, nil, nil, errors.Trace(ctx.Err())
+		return nil, nil, nil, errors.Trace(ctx.Err())
 	}
 
-	return tableInfos, ineligibleTables, eligibleTables, allTables, nil
+	return ineligibleTables, eligibleTables, allTables, nil
 }
 
 func verifyTable4MQ(
@@ -1761,10 +1760,7 @@ func verifyTable4MQ(
 	if err != nil {
 		return err
 	}
-	if err = selectors.VerifyTables(tableInfos, eventRouter); err != nil {
-		return err
-	}
-	return nil
+	return selectors.VerifyTables(tableInfos, eventRouter)
 }
 
 func verifyRouteConflict(

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -1727,13 +1727,7 @@ func getVerifiedTables(
 		return nil, nil, nil, nil, err
 	}
 
-	// eligibleTables and ineligibleTables are both derived from tableInfos.
-	// allTables also includes table-filtered or unsupported tables, so it is not
-	// suitable for route conflict checks.
-	routeTables := make([]common.TableName, 0, len(eligibleTables)+len(ineligibleTables))
-	routeTables = append(routeTables, eligibleTables...)
-	routeTables = append(routeTables, ineligibleTables...)
-	if err := verifyRouteConflict(changefeedID, routeTables, replicaConfig); err != nil {
+	if err := verifyRouteConflict(changefeedID, eligibleTables, ineligibleTables, replicaConfig); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -1775,17 +1769,20 @@ func verifyTable4MQ(
 
 func verifyRouteConflict(
 	changefeedID common.ChangeFeedID,
-	tableNames []common.TableName,
+	eligibleTables []common.TableName,
+	ineligibleTables []common.TableName,
 	replicaCfg *config.ReplicaConfig,
 ) error {
-	if len(tableNames) == 0 || replicaCfg == nil || replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
+	if len(eligibleTables)+len(ineligibleTables) == 0 ||
+		replicaCfg == nil || replicaCfg.Sink == nil || len(replicaCfg.Sink.DispatchRules) == 0 {
 		return nil
 	}
 	return routing.ValidateNoStaticRouteConflict(
 		changefeedID,
 		util.GetOrZero(replicaCfg.CaseSensitive),
 		replicaCfg.Sink.DispatchRules,
-		tableNames,
+		eligibleTables,
+		ineligibleTables,
 	)
 }
 

--- a/api/v2/changefeed.go
+++ b/api/v2/changefeed.go
@@ -490,7 +490,8 @@ func (h *OpenAPIV2) VerifyTable(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, common.ChangeFeedID{}, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
+	changefeedID := common.NewChangeFeedIDWithName(cfg.ID, keyspaceName)
+	ineligibleTables, eligibleTables, allTables, err := getVerifiedTables(ctx, changefeedID, replicaCfg, kvStorage, cfg.StartTs, scheme, topic, protocol)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/api/v2/changefeed_test.go
+++ b/api/v2/changefeed_test.go
@@ -17,6 +17,10 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +51,58 @@ func mustParseURLError(t *testing.T, rawURL string) error {
 	_, err := url.Parse(rawURL)
 	require.Error(t, err)
 	return err
+}
+
+func TestVerifyRouteConflict(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := common.NewChangeFeedIDWithName("test-changefeed", common.DefaultKeyspaceName)
+	replicaCfg := config.GetDefaultReplicaConfig()
+	replicaCfg.Sink.DispatchRules = []*config.DispatchRule{
+		{Matcher: []string{"db1.*"}, TargetSchema: "archive", TargetTable: "{table}"},
+		{Matcher: []string{"db2.*"}, TargetSchema: "archive", TargetTable: "{table}"},
+	}
+
+	eligibleTables := []common.TableName{{Schema: "db1", Table: "orders"}}
+	ineligibleTables := []common.TableName{{Schema: "db2", Table: "orders"}}
+
+	replicaCfg.ForceReplicate = util.AddressOf(false)
+	replicaCfg.IgnoreIneligibleTable = util.AddressOf(true)
+	require.NoError(t, verifyRouteConflict(changefeedID, eligibleTables, ineligibleTables, replicaCfg))
+
+	replicaCfg.IgnoreIneligibleTable = util.AddressOf(false)
+	require.NoError(t, verifyRouteConflict(changefeedID, eligibleTables, ineligibleTables, replicaCfg))
+
+	err := verifyRouteConflict(
+		changefeedID,
+		[]common.TableName{{Schema: "db1", Table: "orders"}, {Schema: "db2", Table: "orders"}},
+		ineligibleTables,
+		replicaCfg,
+	)
+	require.Error(t, err)
+	require.True(t, errors.ErrTableRouteConflict.Equal(err))
+
+	replicaCfg.ForceReplicate = util.AddressOf(true)
+	err = verifyRouteConflict(changefeedID, eligibleTables, ineligibleTables, replicaCfg)
+	require.Error(t, err)
+	require.True(t, errors.ErrTableRouteConflict.Equal(err))
+	require.Contains(t, err.Error(), "target `archive`.`orders`")
+	require.Contains(t, err.Error(), "source `db1`.`orders`")
+	require.Contains(t, err.Error(), "source `db2`.`orders`")
+
+	replicaCfg.ForceReplicate = util.AddressOf(false)
+	replicaCfg.Sink.DispatchRules = []*config.DispatchRule{
+		{Matcher: []string{"db2.*"}, TargetSchema: "db1", TargetTable: "{table}"},
+	}
+	err = verifyRouteConflict(
+		changefeedID,
+		[]common.TableName{{Schema: "db1", Table: "orders"}, {Schema: "db2", Table: "orders"}},
+		nil,
+		replicaCfg,
+	)
+	require.Error(t, err)
+	require.True(t, errors.ErrTableRouteConflict.Equal(err))
+	require.Contains(t, err.Error(), "target `db1`.`orders`")
+	require.Contains(t, err.Error(), "source `db1`.`orders`")
+	require.Contains(t, err.Error(), "source `db2`.`orders`")
 }

--- a/downstreamadapter/routing/ddl_query_rewriter.go
+++ b/downstreamadapter/routing/ddl_query_rewriter.go
@@ -106,7 +106,7 @@ func (r Router) rewriteSingleDDLQuery(query string, defaultSchema string) (strin
 		targetTables = make([]commonEvent.SchemaTableName, 0, len(sourceTables))
 	)
 	for _, srcTable := range sourceTables {
-		targetSchema, targetTable, changed, _, _, err := r.route(srcTable.SchemaName, srcTable.TableName)
+		targetSchema, targetTable, changed, err := r.route(srcTable.SchemaName, srcTable.TableName)
 		if err != nil {
 			return "", err
 		}

--- a/downstreamadapter/routing/ddl_query_rewriter.go
+++ b/downstreamadapter/routing/ddl_query_rewriter.go
@@ -106,7 +106,7 @@ func (r Router) rewriteSingleDDLQuery(query string, defaultSchema string) (strin
 		targetTables = make([]commonEvent.SchemaTableName, 0, len(sourceTables))
 	)
 	for _, srcTable := range sourceTables {
-		binding, err := r.route(srcTable.SchemaName, srcTable.TableName, 0)
+		binding, err := r.route(srcTable.SchemaName, srcTable.TableName)
 		if err != nil {
 			return "", err
 		}

--- a/downstreamadapter/routing/ddl_query_rewriter.go
+++ b/downstreamadapter/routing/ddl_query_rewriter.go
@@ -106,16 +106,16 @@ func (r Router) rewriteSingleDDLQuery(query string, defaultSchema string) (strin
 		targetTables = make([]commonEvent.SchemaTableName, 0, len(sourceTables))
 	)
 	for _, srcTable := range sourceTables {
-		targetSchema, targetTable, changed, err := r.route(srcTable.SchemaName, srcTable.TableName)
+		binding, err := r.route(srcTable.SchemaName, srcTable.TableName)
 		if err != nil {
 			return "", err
 		}
-		if changed {
+		if binding.routed() {
 			routed = true
 		}
 		targetTables = append(targetTables, commonEvent.SchemaTableName{
-			SchemaName: targetSchema,
-			TableName:  targetTable,
+			SchemaName: binding.Target.Schema,
+			TableName:  binding.Target.Table,
 		})
 	}
 

--- a/downstreamadapter/routing/ddl_query_rewriter.go
+++ b/downstreamadapter/routing/ddl_query_rewriter.go
@@ -106,7 +106,7 @@ func (r Router) rewriteSingleDDLQuery(query string, defaultSchema string) (strin
 		targetTables = make([]commonEvent.SchemaTableName, 0, len(sourceTables))
 	)
 	for _, srcTable := range sourceTables {
-		targetSchema, targetTable, changed, err := r.route(srcTable.SchemaName, srcTable.TableName)
+		targetSchema, targetTable, changed, _, _, err := r.route(srcTable.SchemaName, srcTable.TableName)
 		if err != nil {
 			return "", err
 		}

--- a/downstreamadapter/routing/ddl_query_rewriter.go
+++ b/downstreamadapter/routing/ddl_query_rewriter.go
@@ -106,7 +106,7 @@ func (r Router) rewriteSingleDDLQuery(query string, defaultSchema string) (strin
 		targetTables = make([]commonEvent.SchemaTableName, 0, len(sourceTables))
 	)
 	for _, srcTable := range sourceTables {
-		binding, err := r.route(srcTable.SchemaName, srcTable.TableName)
+		binding, err := r.route(srcTable.SchemaName, srcTable.TableName, 0)
 		if err != nil {
 			return "", err
 		}

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -14,35 +14,49 @@
 package routing
 
 import (
+	"github.com/pingcap/log"
+	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/errors"
+	"go.uber.org/zap"
 )
 
 type targetKey = tableKey
 
-// TargetTableRegistry tracks which upstream logical table owns each downstream
-// target. Different logical sources mapping to the same target is a conflict;
-// multiple replicas of the same logical source may share a target.
+// TargetTableRegistry tracks which upstream source table name owns each downstream
+// target table name. Different source names mapping to the same target is a conflict;
+// registering the same source-target mapping repeatedly is idempotent.
 type TargetTableRegistry struct {
-	memo map[targetKey]routeBinding
+	changefeedID common.ChangeFeedID
+	memo         map[targetKey]routeBinding
 }
 
 // NewTargetTableRegistry creates an empty registry.
-func NewTargetTableRegistry() *TargetTableRegistry {
+func NewTargetTableRegistry(changefeedID common.ChangeFeedID) *TargetTableRegistry {
 	return &TargetTableRegistry{
-		memo: make(map[targetKey]routeBinding),
+		changefeedID: changefeedID,
+		memo:         make(map[targetKey]routeBinding),
 	}
 }
 
-// Add validates and records a source-to-target binding.
+// Add validates and records a source-to-target table name mapping.
 func (r *TargetTableRegistry) Add(binding routeBinding) error {
 	existing, ok := r.memo[binding.Target]
 	if !ok {
 		r.memo[binding.Target] = binding
 		return nil
 	}
-	if existing.Source.Schema == binding.Source.Schema && existing.Source.Table == binding.Source.Table {
+	if existing.Source.Equal(binding.Source) {
 		return nil
 	}
+	log.Warn("table route conflict detected",
+		zap.String("keyspace", r.changefeedID.Keyspace()),
+		zap.String("changefeed", r.changefeedID.Name()),
+		zap.String("targetSchema", binding.Target.Schema),
+		zap.String("targetTable", binding.Target.Table),
+		zap.String("existingSourceSchema", existing.Source.Schema),
+		zap.String("existingSourceTable", existing.Source.Table),
+		zap.String("incomingSourceSchema", binding.Source.Schema),
+		zap.String("incomingSourceTable", binding.Source.Table))
 	return errors.ErrTableRouteConflict.FastGenByArgs(
 		binding.Target.Schema, binding.Target.Table,
 		existing.Source.Schema, existing.Source.Table,

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -1,0 +1,202 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/errors"
+)
+
+// TargetKey identifies a downstream target table.
+type TargetKey struct {
+	Schema string
+	Table  string
+}
+
+// SourceKey identifies an upstream logical table.
+type SourceKey struct {
+	LogicalTableID int64
+	Schema         string
+	Table          string
+}
+
+// RouteBinding records one source-to-target route mapping.
+type RouteBinding struct {
+	Source         SourceKey
+	ReplicaTableID int64
+	SourceSchemaID int64
+	Target         TargetKey
+
+	RuleIndex int
+	Matcher   []string
+}
+
+// TargetTableRegistry tracks which upstream logical table owns each downstream
+// target. Different logical sources mapping to the same target is a conflict;
+// multiple replicas of the same logical source may share a target.
+type TargetTableRegistry struct {
+	changefeedID common.ChangeFeedID
+
+	ownerSources map[TargetKey]SourceKey
+	bindings     map[int64]RouteBinding
+	bySourceID   map[int64]map[int64]struct{} // logicalTableID -> replicaTableIDs
+}
+
+// SetChangefeedID annotates conflict errors emitted by this registry.
+func (r *TargetTableRegistry) SetChangefeedID(changefeedID common.ChangeFeedID) {
+	r.changefeedID = changefeedID
+}
+
+// NewTargetTableRegistry creates a registry from initial bindings.
+func NewTargetTableRegistry(bindings []RouteBinding) (*TargetTableRegistry, error) {
+	r := &TargetTableRegistry{
+		ownerSources: make(map[TargetKey]SourceKey),
+		bindings:     make(map[int64]RouteBinding, len(bindings)),
+		bySourceID:   make(map[int64]map[int64]struct{}),
+	}
+	for _, b := range bindings {
+		if err := r.ValidateAdd(b); err != nil {
+			return nil, err
+		}
+		r.unsafeInsert(b)
+	}
+	return r, nil
+}
+
+// Snapshot returns a deterministic copy of all current bindings.
+func (r *TargetTableRegistry) Snapshot() []RouteBinding {
+	result := make([]RouteBinding, 0, len(r.bindings))
+	for _, b := range r.bindings {
+		result = append(result, b)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Target.Schema != result[j].Target.Schema {
+			return result[i].Target.Schema < result[j].Target.Schema
+		}
+		if result[i].Target.Table != result[j].Target.Table {
+			return result[i].Target.Table < result[j].Target.Table
+		}
+		return result[i].ReplicaTableID < result[j].ReplicaTableID
+	})
+	return result
+}
+
+// ValidateAdd checks whether binding can be added without conflict.
+func (r *TargetTableRegistry) ValidateAdd(binding RouteBinding) error {
+	existingSource, ok := r.ownerSources[binding.Target]
+	if !ok {
+		return nil
+	}
+	if existingSource.LogicalTableID == binding.Source.LogicalTableID {
+		return nil
+	}
+	existingBinding := r.findBindingBySource(existingSource.LogicalTableID)
+	return r.newConflictError(existingBinding, binding)
+}
+
+func (r *TargetTableRegistry) unsafeInsert(binding RouteBinding) {
+	r.bindings[binding.ReplicaTableID] = binding
+	r.ownerSources[binding.Target] = binding.Source
+	if _, ok := r.bySourceID[binding.Source.LogicalTableID]; !ok {
+		r.bySourceID[binding.Source.LogicalTableID] = make(map[int64]struct{})
+	}
+	r.bySourceID[binding.Source.LogicalTableID][binding.ReplicaTableID] = struct{}{}
+}
+
+func (r *TargetTableRegistry) findBindingBySource(logicalTableID int64) RouteBinding {
+	replicas, ok := r.bySourceID[logicalTableID]
+	if !ok {
+		return RouteBinding{}
+	}
+	for id := range replicas {
+		if b, exists := r.bindings[id]; exists {
+			return b
+		}
+	}
+	return RouteBinding{}
+}
+
+// NewRouteBinding constructs a RouteBinding from a table info and route result.
+func NewRouteBinding(
+	tableInfo *common.TableInfo,
+	replicaTableID, sourceSchemaID int64,
+	result RouteResult,
+) RouteBinding {
+	return RouteBinding{
+		Source: SourceKey{
+			LogicalTableID: tableInfo.TableName.TableID,
+			Schema:         tableInfo.GetSchemaName(),
+			Table:          tableInfo.GetTableName(),
+		},
+		ReplicaTableID: replicaTableID,
+		SourceSchemaID: sourceSchemaID,
+		Target: TargetKey{
+			Schema: result.TargetSchema,
+			Table:  result.TargetTable,
+		},
+		RuleIndex: result.RuleIndex,
+		Matcher:   result.Matcher,
+	}
+}
+
+// TableRouteConflictError carries structured conflict details.
+type TableRouteConflictError struct {
+	Changefeed string
+	Target     TargetKey
+	Existing   RouteBinding
+	Incoming   RouteBinding
+}
+
+// Error implements the error interface with a human-readable conflict message.
+func (a *TableRouteConflictError) Error() string {
+	changefeed := ""
+	if a.Changefeed != "" {
+		changefeed = fmt.Sprintf(" in changefeed %s", a.Changefeed)
+	}
+	return fmt.Sprintf(
+		"table route conflict%s: "+
+			"target `%s`.`%s` is mapped by both "+
+			"source `%s`.`%s` tableID=%d rule=%d matcher=%s "+
+			"and source `%s`.`%s` tableID=%d rule=%d matcher=%s",
+		changefeed,
+		a.Target.Schema, a.Target.Table,
+		a.Existing.Source.Schema, a.Existing.Source.Table,
+		a.Existing.Source.LogicalTableID, a.Existing.RuleIndex,
+		formatMatcher(a.Existing.Matcher),
+		a.Incoming.Source.Schema, a.Incoming.Source.Table,
+		a.Incoming.Source.LogicalTableID, a.Incoming.RuleIndex,
+		formatMatcher(a.Incoming.Matcher),
+	)
+}
+
+func (r *TargetTableRegistry) newConflictError(existing, incoming RouteBinding) error {
+	return errors.ErrTableRouteConflict.GenWithStackByArgs(
+		&TableRouteConflictError{
+			Changefeed: r.changefeedID.Name(),
+			Target:     existing.Target,
+			Existing:   existing,
+			Incoming:   incoming,
+		},
+	)
+}
+
+func formatMatcher(matcher []string) string {
+	if len(matcher) == 0 {
+		return "[]"
+	}
+	return fmt.Sprintf("%v", matcher)
+}

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -14,7 +14,6 @@
 package routing
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/pingcap/ticdc/pkg/common"
@@ -94,7 +93,10 @@ func (r *TargetTableRegistry) ValidateAdd(binding RouteBinding) error {
 		return nil
 	}
 	existingBinding := r.findBindingBySource(existingSource.LogicalTableID)
-	return r.newConflictError(existingBinding, binding)
+	return errors.ErrTableRouteConflict.FastGenByArgs("target `%s`.`%s` is mapped by both `%s`.`%s` and `%s`.`%s`",
+		existingBinding.Target.Schema, existingBinding.Target.Table,
+		existingSource.Schema, existingSource.Table,
+		binding.Target.Schema, binding.Target.Table)
 }
 
 // Add validates and records a source-to-target binding.
@@ -122,52 +124,4 @@ func (r *TargetTableRegistry) findBindingBySource(logicalTableID int64) RouteBin
 		}
 	}
 	return RouteBinding{}
-}
-
-// TableRouteConflictError carries structured conflict details.
-type TableRouteConflictError struct {
-	Changefeed string
-	Target     TargetKey
-	Existing   RouteBinding
-	Incoming   RouteBinding
-}
-
-// Error implements the error interface with a human-readable conflict message.
-func (a *TableRouteConflictError) Error() string {
-	changefeed := ""
-	if a.Changefeed != "" {
-		changefeed = fmt.Sprintf(" in changefeed %s", a.Changefeed)
-	}
-	return fmt.Sprintf(
-		"table route conflict%s: "+
-			"target `%s`.`%s` is mapped by both "+
-			"source `%s`.`%s` tableID=%d rule=%d matcher=%s "+
-			"and source `%s`.`%s` tableID=%d rule=%d matcher=%s",
-		changefeed,
-		a.Target.Schema, a.Target.Table,
-		a.Existing.Source.Schema, a.Existing.Source.Table,
-		a.Existing.Source.LogicalTableID, a.Existing.RuleIndex,
-		formatMatcher(a.Existing.Matcher),
-		a.Incoming.Source.Schema, a.Incoming.Source.Table,
-		a.Incoming.Source.LogicalTableID, a.Incoming.RuleIndex,
-		formatMatcher(a.Incoming.Matcher),
-	)
-}
-
-func (r *TargetTableRegistry) newConflictError(existing, incoming RouteBinding) error {
-	return errors.ErrTableRouteConflict.GenWithStackByArgs(
-		&TableRouteConflictError{
-			Changefeed: r.changefeedID.Name(),
-			Target:     existing.Target,
-			Existing:   existing,
-			Incoming:   incoming,
-		},
-	)
-}
-
-func formatMatcher(matcher []string) string {
-	if len(matcher) == 0 {
-		return "[]"
-	}
-	return fmt.Sprintf("%v", matcher)
 }

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -56,25 +56,14 @@ type TargetTableRegistry struct {
 	bySourceID   map[int64]map[int64]struct{} // logicalTableID -> replicaTableIDs
 }
 
-// SetChangefeedID annotates conflict errors emitted by this registry.
-func (r *TargetTableRegistry) SetChangefeedID(changefeedID common.ChangeFeedID) {
-	r.changefeedID = changefeedID
-}
-
-// NewTargetTableRegistry creates a registry from initial bindings.
-func NewTargetTableRegistry(bindings []RouteBinding) (*TargetTableRegistry, error) {
-	r := &TargetTableRegistry{
+// NewTargetTableRegistry creates an empty registry.
+func NewTargetTableRegistry(changefeedID common.ChangeFeedID) *TargetTableRegistry {
+	return &TargetTableRegistry{
+		changefeedID: changefeedID,
 		ownerSources: make(map[TargetKey]SourceKey),
-		bindings:     make(map[int64]RouteBinding, len(bindings)),
+		bindings:     make(map[int64]RouteBinding),
 		bySourceID:   make(map[int64]map[int64]struct{}),
 	}
-	for _, b := range bindings {
-		if err := r.ValidateAdd(b); err != nil {
-			return nil, err
-		}
-		r.unsafeInsert(b)
-	}
-	return r, nil
 }
 
 // Snapshot returns a deterministic copy of all current bindings.
@@ -108,13 +97,18 @@ func (r *TargetTableRegistry) ValidateAdd(binding RouteBinding) error {
 	return r.newConflictError(existingBinding, binding)
 }
 
-func (r *TargetTableRegistry) unsafeInsert(binding RouteBinding) {
+// Add validates and records a source-to-target binding.
+func (r *TargetTableRegistry) Add(binding RouteBinding) error {
+	if err := r.ValidateAdd(binding); err != nil {
+		return err
+	}
 	r.bindings[binding.ReplicaTableID] = binding
 	r.ownerSources[binding.Target] = binding.Source
 	if _, ok := r.bySourceID[binding.Source.LogicalTableID]; !ok {
 		r.bySourceID[binding.Source.LogicalTableID] = make(map[int64]struct{})
 	}
 	r.bySourceID[binding.Source.LogicalTableID][binding.ReplicaTableID] = struct{}{}
+	return nil
 }
 
 func (r *TargetTableRegistry) findBindingBySource(logicalTableID int64) RouteBinding {
@@ -128,29 +122,6 @@ func (r *TargetTableRegistry) findBindingBySource(logicalTableID int64) RouteBin
 		}
 	}
 	return RouteBinding{}
-}
-
-// NewRouteBinding constructs a RouteBinding from a table info and route result.
-func NewRouteBinding(
-	tableInfo *common.TableInfo,
-	replicaTableID, sourceSchemaID int64,
-	result RouteResult,
-) RouteBinding {
-	return RouteBinding{
-		Source: SourceKey{
-			LogicalTableID: tableInfo.TableName.TableID,
-			Schema:         tableInfo.GetSchemaName(),
-			Table:          tableInfo.GetTableName(),
-		},
-		ReplicaTableID: replicaTableID,
-		SourceSchemaID: sourceSchemaID,
-		Target: TargetKey{
-			Schema: result.TargetSchema,
-			Table:  result.TargetTable,
-		},
-		RuleIndex: result.RuleIndex,
-		Matcher:   result.Matcher,
-	}
 }
 
 // TableRouteConflictError carries structured conflict details.

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -17,50 +17,33 @@ import (
 	"github.com/pingcap/ticdc/pkg/errors"
 )
 
-// TargetKey identifies a downstream target table.
-type TargetKey struct {
-	Schema string
-	Table  string
-}
-
-// SourceKey identifies an upstream logical table.
-type SourceKey struct {
-	LogicalTableID int64
-	Schema         string
-	Table          string
-}
-
-// RouteBinding records one source-to-target route mapping.
-type RouteBinding struct {
-	Source SourceKey
-	Target TargetKey
-}
-
 // TargetTableRegistry tracks which upstream logical table owns each downstream
 // target. Different logical sources mapping to the same target is a conflict;
 // multiple replicas of the same logical source may share a target.
 type TargetTableRegistry struct {
-	owners map[TargetKey]RouteBinding
+	memo map[targetKey]routeBinding
 }
 
 // NewTargetTableRegistry creates an empty registry.
 func NewTargetTableRegistry() *TargetTableRegistry {
 	return &TargetTableRegistry{
-		owners: make(map[TargetKey]RouteBinding),
+		memo: make(map[targetKey]routeBinding),
 	}
 }
 
 // Add validates and records a source-to-target binding.
-func (r *TargetTableRegistry) Add(binding RouteBinding) error {
-	if existing, ok := r.owners[binding.Target]; ok {
-		if existing.Source.LogicalTableID != binding.Source.LogicalTableID {
-			return errors.ErrTableRouteConflict.FastGenByArgs(
-				binding.Target.Schema, binding.Target.Table,
-				existing.Source.Schema, existing.Source.Table,
-				binding.Source.Schema, binding.Source.Table)
-		}
+func (r *TargetTableRegistry) Add(binding routeBinding) error {
+	existing, ok := r.memo[binding.Target]
+	if !ok {
+		r.memo[binding.Target] = binding
+		return nil
 	}
 
-	r.owners[binding.Target] = binding
-	return nil
+	if existing.Source.LogicalTableID == binding.Source.LogicalTableID {
+		return nil
+	}
+	return errors.ErrTableRouteConflict.FastGenByArgs(
+		binding.Target.Schema, binding.Target.Table,
+		existing.Source.Schema, existing.Source.Table,
+		binding.Source.Schema, binding.Source.Table)
 }

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -14,9 +14,6 @@
 package routing
 
 import (
-	"sort"
-
-	"github.com/pingcap/ticdc/pkg/common"
 	"github.com/pingcap/ticdc/pkg/errors"
 )
 
@@ -35,93 +32,35 @@ type SourceKey struct {
 
 // RouteBinding records one source-to-target route mapping.
 type RouteBinding struct {
-	Source         SourceKey
-	ReplicaTableID int64
-	SourceSchemaID int64
-	Target         TargetKey
-
-	RuleIndex int
-	Matcher   []string
+	Source SourceKey
+	Target TargetKey
 }
 
 // TargetTableRegistry tracks which upstream logical table owns each downstream
 // target. Different logical sources mapping to the same target is a conflict;
 // multiple replicas of the same logical source may share a target.
 type TargetTableRegistry struct {
-	changefeedID common.ChangeFeedID
-
-	ownerSources map[TargetKey]SourceKey
-	bindings     map[int64]RouteBinding
-	bySourceID   map[int64]map[int64]struct{} // logicalTableID -> replicaTableIDs
+	owners map[TargetKey]RouteBinding
 }
 
 // NewTargetTableRegistry creates an empty registry.
-func NewTargetTableRegistry(changefeedID common.ChangeFeedID) *TargetTableRegistry {
+func NewTargetTableRegistry() *TargetTableRegistry {
 	return &TargetTableRegistry{
-		changefeedID: changefeedID,
-		ownerSources: make(map[TargetKey]SourceKey),
-		bindings:     make(map[int64]RouteBinding),
-		bySourceID:   make(map[int64]map[int64]struct{}),
+		owners: make(map[TargetKey]RouteBinding),
 	}
-}
-
-// Snapshot returns a deterministic copy of all current bindings.
-func (r *TargetTableRegistry) Snapshot() []RouteBinding {
-	result := make([]RouteBinding, 0, len(r.bindings))
-	for _, b := range r.bindings {
-		result = append(result, b)
-	}
-	sort.Slice(result, func(i, j int) bool {
-		if result[i].Target.Schema != result[j].Target.Schema {
-			return result[i].Target.Schema < result[j].Target.Schema
-		}
-		if result[i].Target.Table != result[j].Target.Table {
-			return result[i].Target.Table < result[j].Target.Table
-		}
-		return result[i].ReplicaTableID < result[j].ReplicaTableID
-	})
-	return result
-}
-
-// ValidateAdd checks whether binding can be added without conflict.
-func (r *TargetTableRegistry) ValidateAdd(binding RouteBinding) error {
-	existingSource, ok := r.ownerSources[binding.Target]
-	if !ok {
-		return nil
-	}
-	if existingSource.LogicalTableID == binding.Source.LogicalTableID {
-		return nil
-	}
-	existingBinding := r.findBindingBySource(existingSource.LogicalTableID)
-	return errors.ErrTableRouteConflict.FastGenByArgs("target `%s`.`%s` is mapped by both `%s`.`%s` and `%s`.`%s`",
-		existingBinding.Target.Schema, existingBinding.Target.Table,
-		existingSource.Schema, existingSource.Table,
-		binding.Target.Schema, binding.Target.Table)
 }
 
 // Add validates and records a source-to-target binding.
 func (r *TargetTableRegistry) Add(binding RouteBinding) error {
-	if err := r.ValidateAdd(binding); err != nil {
-		return err
-	}
-	r.bindings[binding.ReplicaTableID] = binding
-	r.ownerSources[binding.Target] = binding.Source
-	if _, ok := r.bySourceID[binding.Source.LogicalTableID]; !ok {
-		r.bySourceID[binding.Source.LogicalTableID] = make(map[int64]struct{})
-	}
-	r.bySourceID[binding.Source.LogicalTableID][binding.ReplicaTableID] = struct{}{}
-	return nil
-}
-
-func (r *TargetTableRegistry) findBindingBySource(logicalTableID int64) RouteBinding {
-	replicas, ok := r.bySourceID[logicalTableID]
-	if !ok {
-		return RouteBinding{}
-	}
-	for id := range replicas {
-		if b, exists := r.bindings[id]; exists {
-			return b
+	if existing, ok := r.owners[binding.Target]; ok {
+		if existing.Source.LogicalTableID != binding.Source.LogicalTableID {
+			return errors.ErrTableRouteConflict.FastGenByArgs(
+				binding.Target.Schema, binding.Target.Table,
+				existing.Source.Schema, existing.Source.Table,
+				binding.Source.Schema, binding.Source.Table)
 		}
 	}
-	return RouteBinding{}
+
+	r.owners[binding.Target] = binding
+	return nil
 }

--- a/downstreamadapter/routing/registry.go
+++ b/downstreamadapter/routing/registry.go
@@ -17,6 +17,8 @@ import (
 	"github.com/pingcap/ticdc/pkg/errors"
 )
 
+type targetKey = tableKey
+
 // TargetTableRegistry tracks which upstream logical table owns each downstream
 // target. Different logical sources mapping to the same target is a conflict;
 // multiple replicas of the same logical source may share a target.
@@ -38,8 +40,7 @@ func (r *TargetTableRegistry) Add(binding routeBinding) error {
 		r.memo[binding.Target] = binding
 		return nil
 	}
-
-	if existing.Source.LogicalTableID == binding.Source.LogicalTableID {
+	if existing.Source.Schema == binding.Source.Schema && existing.Source.Table == binding.Source.Table {
 		return nil
 	}
 	return errors.ErrTableRouteConflict.FastGenByArgs(

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -101,5 +101,4 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 	require.Contains(t, err.Error(), "target `db1`.`orders`")
 	require.Contains(t, err.Error(), "source `db1`.`orders`")
 	require.Contains(t, err.Error(), "source `db2`.`orders`")
-
 }

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -23,10 +23,8 @@ import (
 )
 
 func makeBinding(
-	logicalID, replicaID, schemaID int64,
+	logicalID int64,
 	sourceSchema, sourceTable, targetSchema, targetTable string,
-	ruleIndex int,
-	matcher []string,
 ) RouteBinding {
 	return RouteBinding{
 		Source: SourceKey{
@@ -34,87 +32,45 @@ func makeBinding(
 			Schema:         sourceSchema,
 			Table:          sourceTable,
 		},
-		ReplicaTableID: replicaID,
-		SourceSchemaID: schemaID,
 		Target: TargetKey{
 			Schema: targetSchema,
 			Table:  targetTable,
 		},
-		RuleIndex: ruleIndex,
-		Matcher:   matcher,
 	}
 }
 
-func TestNewTargetTableRegistry(t *testing.T) {
+func TestTargetTableRegistryAdd(t *testing.T) {
 	t.Parallel()
-
-	t.Run("empty bindings", func(t *testing.T) {
-		t.Parallel()
-		r := NewTargetTableRegistry(common.ChangeFeedID{})
-		require.NotNil(t, r)
-		require.Empty(t, r.Snapshot())
-	})
 
 	t.Run("non-conflicting bindings", func(t *testing.T) {
 		t.Parallel()
-		bindings := []RouteBinding{
-			makeBinding(1, 1, 10, "db1", "t1", "db1", "t1", -1, nil),
-			makeBinding(2, 2, 10, "db1", "t2", "archive", "t2", 0, []string{"db1.*"}),
-		}
-		r := NewTargetTableRegistry(common.ChangeFeedID{})
-		for _, binding := range bindings {
-			require.NoError(t, r.Add(binding))
-		}
-		require.Len(t, r.Snapshot(), 2)
+		r := NewTargetTableRegistry()
+		require.NotNil(t, r)
+
+		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(makeBinding(2, "db1", "t2", "archive", "t2")))
 	})
 
 	t.Run("conflicting bindings fail", func(t *testing.T) {
 		t.Parallel()
-		bindings := []RouteBinding{
-			makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}),
-			makeBinding(2, 2, 20, "db2", "t1", "archive", "orders", 0, []string{"db2.*"}),
-		}
-		r := NewTargetTableRegistry(common.ChangeFeedID{})
-		require.NoError(t, r.Add(bindings[0]))
-		err := r.Add(bindings[1])
+		r := NewTargetTableRegistry()
+
+		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "archive", "orders")))
+		err := r.Add(makeBinding(2, "db2", "t1", "archive", "orders"))
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRouteConflict.Equal(err))
+		require.Contains(t, err.Error(), "target `archive`.`orders`")
+		require.Contains(t, err.Error(), "source `db1`.`t1`")
+		require.Contains(t, err.Error(), "source `db2`.`t1`")
 	})
 
 	t.Run("same source multi-replica allowed", func(t *testing.T) {
 		t.Parallel()
-		bindings := []RouteBinding{
-			makeBinding(1, 100, 10, "db1", "t1", "db1", "t1", -1, nil),
-			makeBinding(1, 101, 10, "db1", "t1", "db1", "t1", -1, nil),
-		}
-		r := NewTargetTableRegistry(common.ChangeFeedID{})
-		for _, binding := range bindings {
-			require.NoError(t, r.Add(binding))
-		}
-		require.Len(t, r.Snapshot(), 2)
+		r := NewTargetTableRegistry()
+
+		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "db1", "t1")))
 	})
-}
-
-func TestTargetTableRegistryValidateAdd(t *testing.T) {
-	t.Parallel()
-
-	r := NewTargetTableRegistry(common.ChangeFeedID{})
-	require.NoError(t, r.Add(makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"})))
-
-	err := r.ValidateAdd(makeBinding(2, 2, 20, "db2", "t2", "archive", "customers", 0, []string{"db2.*"}))
-	require.NoError(t, err)
-
-	err = r.ValidateAdd(makeBinding(1, 3, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}))
-	require.NoError(t, err)
-
-	err = r.ValidateAdd(makeBinding(2, 2, 20, "db2", "t2", "archive", "orders", 0, []string{"db2.*"}))
-	require.Error(t, err)
-	require.True(t, errors.ErrTableRouteConflict.Equal(err))
-	require.Contains(t, err.Error(), "target `archive`.`orders`")
-	require.Contains(t, err.Error(), "source `db1`.`t1`")
-	require.Contains(t, err.Error(), "source `db2`.`t2`")
-	require.Contains(t, err.Error(), "matcher=[db1.*]")
-	require.Contains(t, err.Error(), "matcher=[db2.*]")
 }
 
 func TestValidateNoStaticRouteConflict(t *testing.T) {
@@ -126,16 +82,18 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 		{Matcher: []string{"db2.*"}, TargetSchema: "archive", TargetTable: "{table}"},
 	}
 
-	err := ValidateNoStaticRouteConflict(changefeedID, false, rules, []common.TableName{
-		newRouteConflictTableName(1, "db1", "orders"),
-		newRouteConflictTableName(2, "db2", "orders"),
-	})
+	err := ValidateNoStaticRouteConflict(
+		changefeedID,
+		false,
+		rules,
+		[]common.TableName{newRouteConflictTableName(1, "db1", "orders")},
+		[]common.TableName{newRouteConflictTableName(2, "db2", "orders")},
+	)
 	require.Error(t, err)
 	require.True(t, errors.ErrTableRouteConflict.Equal(err))
-	require.Contains(t, err.Error(), "test-changefeed")
 	require.Contains(t, err.Error(), "target `archive`.`orders`")
-	require.Contains(t, err.Error(), "rule=0")
-	require.Contains(t, err.Error(), "rule=1")
+	require.Contains(t, err.Error(), "source `db1`.`orders`")
+	require.Contains(t, err.Error(), "source `db2`.`orders`")
 
 	err = ValidateNoStaticRouteConflict(changefeedID, false, rules, []common.TableName{
 		newRouteConflictTableName(1, "db1", "orders"),

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -30,16 +30,16 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		r := NewTargetTableRegistry()
 		require.NotNil(t, r)
 
-		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "db1", "t1")))
-		require.NoError(t, r.Add(newRouteBinding(2, "db1", "t2", "archive", "t2")))
+		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(newRouteBinding("db1", "t2", "archive", "t2")))
 	})
 
 	t.Run("conflicting bindings fail", func(t *testing.T) {
 		t.Parallel()
 		r := NewTargetTableRegistry()
 
-		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "archive", "orders")))
-		err := r.Add(newRouteBinding(2, "db2", "t1", "archive", "orders"))
+		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "archive", "orders")))
+		err := r.Add(newRouteBinding("db2", "t1", "archive", "orders"))
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRouteConflict.Equal(err))
 		require.Contains(t, err.Error(), "target `archive`.`orders`")
@@ -51,8 +51,8 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		t.Parallel()
 		r := NewTargetTableRegistry()
 
-		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "db1", "t1")))
-		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "db1", "t1")))
 	})
 }
 
@@ -69,8 +69,8 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 		changefeedID,
 		false,
 		rules,
-		[]common.TableName{newRouteConflictTableName(1, "db1", "orders")},
-		[]common.TableName{newRouteConflictTableName(2, "db2", "orders")},
+		[]common.TableName{{Schema: "db1", Table: "orders"}},
+		[]common.TableName{{Schema: "db2", Table: "orders"}},
 	)
 	require.Error(t, err)
 	require.True(t, errors.ErrTableRouteConflict.Equal(err))
@@ -79,16 +79,8 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 	require.Contains(t, err.Error(), "source `db2`.`orders`")
 
 	err = ValidateNoStaticRouteConflict(changefeedID, false, rules, []common.TableName{
-		newRouteConflictTableName(1, "db1", "orders"),
-		newRouteConflictTableName(2, "db2", "customers"),
+		{Schema: "db1", Table: "orders"},
+		{Schema: "db2", Table: "customers"},
 	})
 	require.NoError(t, err)
-}
-
-func newRouteConflictTableName(tableID int64, schema, table string) common.TableName {
-	return common.TableName{
-		Schema:  schema,
-		Table:   table,
-		TableID: tableID,
-	}
 }

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"testing"
+
+	"github.com/pingcap/ticdc/pkg/common"
+	"github.com/pingcap/ticdc/pkg/config"
+	"github.com/pingcap/ticdc/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func makeBinding(
+	logicalID, replicaID, schemaID int64,
+	sourceSchema, sourceTable, targetSchema, targetTable string,
+	ruleIndex int,
+	matcher []string,
+) RouteBinding {
+	return RouteBinding{
+		Source: SourceKey{
+			LogicalTableID: logicalID,
+			Schema:         sourceSchema,
+			Table:          sourceTable,
+		},
+		ReplicaTableID: replicaID,
+		SourceSchemaID: schemaID,
+		Target: TargetKey{
+			Schema: targetSchema,
+			Table:  targetTable,
+		},
+		RuleIndex: ruleIndex,
+		Matcher:   matcher,
+	}
+}
+
+func TestNewTargetTableRegistry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty bindings", func(t *testing.T) {
+		t.Parallel()
+		r, err := NewTargetTableRegistry(nil)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		require.Empty(t, r.Snapshot())
+	})
+
+	t.Run("non-conflicting bindings", func(t *testing.T) {
+		t.Parallel()
+		bindings := []RouteBinding{
+			makeBinding(1, 1, 10, "db1", "t1", "db1", "t1", -1, nil),
+			makeBinding(2, 2, 10, "db1", "t2", "archive", "t2", 0, []string{"db1.*"}),
+		}
+		r, err := NewTargetTableRegistry(bindings)
+		require.NoError(t, err)
+		require.Len(t, r.Snapshot(), 2)
+	})
+
+	t.Run("conflicting bindings fail", func(t *testing.T) {
+		t.Parallel()
+		bindings := []RouteBinding{
+			makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}),
+			makeBinding(2, 2, 20, "db2", "t1", "archive", "orders", 0, []string{"db2.*"}),
+		}
+		_, err := NewTargetTableRegistry(bindings)
+		require.Error(t, err)
+		require.True(t, errors.ErrTableRouteConflict.Equal(err))
+	})
+
+	t.Run("same source multi-replica allowed", func(t *testing.T) {
+		t.Parallel()
+		bindings := []RouteBinding{
+			makeBinding(1, 100, 10, "db1", "t1", "db1", "t1", -1, nil),
+			makeBinding(1, 101, 10, "db1", "t1", "db1", "t1", -1, nil),
+		}
+		r, err := NewTargetTableRegistry(bindings)
+		require.NoError(t, err)
+		require.Len(t, r.Snapshot(), 2)
+	})
+}
+
+func TestTargetTableRegistryValidateAdd(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewTargetTableRegistry([]RouteBinding{
+		makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}),
+	})
+	require.NoError(t, err)
+
+	err = r.ValidateAdd(makeBinding(2, 2, 20, "db2", "t2", "archive", "customers", 0, []string{"db2.*"}))
+	require.NoError(t, err)
+
+	err = r.ValidateAdd(makeBinding(1, 3, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}))
+	require.NoError(t, err)
+
+	err = r.ValidateAdd(makeBinding(2, 2, 20, "db2", "t2", "archive", "orders", 0, []string{"db2.*"}))
+	require.Error(t, err)
+	require.True(t, errors.ErrTableRouteConflict.Equal(err))
+	require.Contains(t, err.Error(), "target `archive`.`orders`")
+	require.Contains(t, err.Error(), "source `db1`.`t1`")
+	require.Contains(t, err.Error(), "source `db2`.`t2`")
+	require.Contains(t, err.Error(), "matcher=[db1.*]")
+	require.Contains(t, err.Error(), "matcher=[db2.*]")
+}
+
+func TestValidateNoStaticRouteConflict(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := common.NewChangeFeedIDWithName("test-changefeed", common.DefaultKeyspaceName)
+	rules := []*config.DispatchRule{
+		{Matcher: []string{"db1.*"}, TargetSchema: "archive", TargetTable: "{table}"},
+		{Matcher: []string{"db2.*"}, TargetSchema: "archive", TargetTable: "{table}"},
+	}
+
+	err := ValidateNoStaticRouteConflict(changefeedID, false, rules, []*common.TableInfo{
+		newRouteConflictTableInfo(1, "db1", "orders"),
+		newRouteConflictTableInfo(2, "db2", "orders"),
+	})
+	require.Error(t, err)
+	require.True(t, errors.ErrTableRouteConflict.Equal(err))
+	require.Contains(t, err.Error(), "test-changefeed")
+	require.Contains(t, err.Error(), "target `archive`.`orders`")
+	require.Contains(t, err.Error(), "rule=0")
+	require.Contains(t, err.Error(), "rule=1")
+
+	err = ValidateNoStaticRouteConflict(changefeedID, false, rules, []*common.TableInfo{
+		newRouteConflictTableInfo(1, "db1", "orders"),
+		newRouteConflictTableInfo(2, "db2", "customers"),
+	})
+	require.NoError(t, err)
+}
+
+func newRouteConflictTableInfo(tableID int64, schema, table string) *common.TableInfo {
+	return &common.TableInfo{
+		TableName: common.TableName{
+			Schema:  schema,
+			Table:   table,
+			TableID: tableID,
+		},
+	}
+}

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -22,23 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeBinding(
-	logicalID int64,
-	sourceSchema, sourceTable, targetSchema, targetTable string,
-) RouteBinding {
-	return RouteBinding{
-		Source: SourceKey{
-			LogicalTableID: logicalID,
-			Schema:         sourceSchema,
-			Table:          sourceTable,
-		},
-		Target: TargetKey{
-			Schema: targetSchema,
-			Table:  targetTable,
-		},
-	}
-}
-
 func TestTargetTableRegistryAdd(t *testing.T) {
 	t.Parallel()
 
@@ -47,16 +30,16 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		r := NewTargetTableRegistry()
 		require.NotNil(t, r)
 
-		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "db1", "t1")))
-		require.NoError(t, r.Add(makeBinding(2, "db1", "t2", "archive", "t2")))
+		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(NewRouteBinding(2, "db1", "t2", "archive", "t2")))
 	})
 
 	t.Run("conflicting bindings fail", func(t *testing.T) {
 		t.Parallel()
 		r := NewTargetTableRegistry()
 
-		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "archive", "orders")))
-		err := r.Add(makeBinding(2, "db2", "t1", "archive", "orders"))
+		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "archive", "orders")))
+		err := r.Add(NewRouteBinding(2, "db2", "t1", "archive", "orders"))
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRouteConflict.Equal(err))
 		require.Contains(t, err.Error(), "target `archive`.`orders`")
@@ -68,8 +51,8 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		t.Parallel()
 		r := NewTargetTableRegistry()
 
-		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "db1", "t1")))
-		require.NoError(t, r.Add(makeBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "db1", "t1")))
 	})
 }
 

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -30,16 +30,16 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		r := NewTargetTableRegistry()
 		require.NotNil(t, r)
 
-		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "db1", "t1")))
-		require.NoError(t, r.Add(NewRouteBinding(2, "db1", "t2", "archive", "t2")))
+		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(newRouteBinding(2, "db1", "t2", "archive", "t2")))
 	})
 
 	t.Run("conflicting bindings fail", func(t *testing.T) {
 		t.Parallel()
 		r := NewTargetTableRegistry()
 
-		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "archive", "orders")))
-		err := r.Add(NewRouteBinding(2, "db2", "t1", "archive", "orders"))
+		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "archive", "orders")))
+		err := r.Add(newRouteBinding(2, "db2", "t1", "archive", "orders"))
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRouteConflict.Equal(err))
 		require.Contains(t, err.Error(), "target `archive`.`orders`")
@@ -51,8 +51,8 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		t.Parallel()
 		r := NewTargetTableRegistry()
 
-		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "db1", "t1")))
-		require.NoError(t, r.Add(NewRouteBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "db1", "t1")))
+		require.NoError(t, r.Add(newRouteBinding(1, "db1", "t1", "db1", "t1")))
 	})
 }
 

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -25,9 +25,10 @@ import (
 func TestTargetTableRegistryAdd(t *testing.T) {
 	t.Parallel()
 
+	changefeedID := common.NewChangeFeedIDWithName("test-changefeed", common.DefaultKeyspaceName)
 	t.Run("non-conflicting bindings", func(t *testing.T) {
 		t.Parallel()
-		r := NewTargetTableRegistry()
+		r := NewTargetTableRegistry(changefeedID)
 		require.NotNil(t, r)
 
 		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "db1", "t1")))
@@ -36,7 +37,7 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 
 	t.Run("conflicting bindings fail", func(t *testing.T) {
 		t.Parallel()
-		r := NewTargetTableRegistry()
+		r := NewTargetTableRegistry(changefeedID)
 
 		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "archive", "orders")))
 		err := r.Add(newRouteBinding("db2", "t1", "archive", "orders"))
@@ -47,9 +48,9 @@ func TestTargetTableRegistryAdd(t *testing.T) {
 		require.Contains(t, err.Error(), "source `db2`.`t1`")
 	})
 
-	t.Run("same source multi-replica allowed", func(t *testing.T) {
+	t.Run("same source mapping is idempotent", func(t *testing.T) {
 		t.Parallel()
-		r := NewTargetTableRegistry()
+		r := NewTargetTableRegistry(changefeedID)
 
 		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "db1", "t1")))
 		require.NoError(t, r.Add(newRouteBinding("db1", "t1", "db1", "t1")))
@@ -83,4 +84,22 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 		{Schema: "db2", Table: "customers"},
 	})
 	require.NoError(t, err)
+
+	err = ValidateNoStaticRouteConflict(
+		changefeedID,
+		false,
+		[]*config.DispatchRule{
+			{Matcher: []string{"db2.*"}, TargetSchema: "db1", TargetTable: "{table}"},
+		},
+		[]common.TableName{
+			{Schema: "db1", Table: "orders"},
+			{Schema: "db2", Table: "orders"},
+		},
+	)
+	require.Error(t, err)
+	require.True(t, errors.ErrTableRouteConflict.Equal(err))
+	require.Contains(t, err.Error(), "target `db1`.`orders`")
+	require.Contains(t, err.Error(), "source `db1`.`orders`")
+	require.Contains(t, err.Error(), "source `db2`.`orders`")
+
 }

--- a/downstreamadapter/routing/registry_test.go
+++ b/downstreamadapter/routing/registry_test.go
@@ -50,8 +50,7 @@ func TestNewTargetTableRegistry(t *testing.T) {
 
 	t.Run("empty bindings", func(t *testing.T) {
 		t.Parallel()
-		r, err := NewTargetTableRegistry(nil)
-		require.NoError(t, err)
+		r := NewTargetTableRegistry(common.ChangeFeedID{})
 		require.NotNil(t, r)
 		require.Empty(t, r.Snapshot())
 	})
@@ -62,8 +61,10 @@ func TestNewTargetTableRegistry(t *testing.T) {
 			makeBinding(1, 1, 10, "db1", "t1", "db1", "t1", -1, nil),
 			makeBinding(2, 2, 10, "db1", "t2", "archive", "t2", 0, []string{"db1.*"}),
 		}
-		r, err := NewTargetTableRegistry(bindings)
-		require.NoError(t, err)
+		r := NewTargetTableRegistry(common.ChangeFeedID{})
+		for _, binding := range bindings {
+			require.NoError(t, r.Add(binding))
+		}
 		require.Len(t, r.Snapshot(), 2)
 	})
 
@@ -73,7 +74,9 @@ func TestNewTargetTableRegistry(t *testing.T) {
 			makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}),
 			makeBinding(2, 2, 20, "db2", "t1", "archive", "orders", 0, []string{"db2.*"}),
 		}
-		_, err := NewTargetTableRegistry(bindings)
+		r := NewTargetTableRegistry(common.ChangeFeedID{})
+		require.NoError(t, r.Add(bindings[0]))
+		err := r.Add(bindings[1])
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRouteConflict.Equal(err))
 	})
@@ -84,8 +87,10 @@ func TestNewTargetTableRegistry(t *testing.T) {
 			makeBinding(1, 100, 10, "db1", "t1", "db1", "t1", -1, nil),
 			makeBinding(1, 101, 10, "db1", "t1", "db1", "t1", -1, nil),
 		}
-		r, err := NewTargetTableRegistry(bindings)
-		require.NoError(t, err)
+		r := NewTargetTableRegistry(common.ChangeFeedID{})
+		for _, binding := range bindings {
+			require.NoError(t, r.Add(binding))
+		}
 		require.Len(t, r.Snapshot(), 2)
 	})
 }
@@ -93,12 +98,10 @@ func TestNewTargetTableRegistry(t *testing.T) {
 func TestTargetTableRegistryValidateAdd(t *testing.T) {
 	t.Parallel()
 
-	r, err := NewTargetTableRegistry([]RouteBinding{
-		makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}),
-	})
-	require.NoError(t, err)
+	r := NewTargetTableRegistry(common.ChangeFeedID{})
+	require.NoError(t, r.Add(makeBinding(1, 1, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"})))
 
-	err = r.ValidateAdd(makeBinding(2, 2, 20, "db2", "t2", "archive", "customers", 0, []string{"db2.*"}))
+	err := r.ValidateAdd(makeBinding(2, 2, 20, "db2", "t2", "archive", "customers", 0, []string{"db2.*"}))
 	require.NoError(t, err)
 
 	err = r.ValidateAdd(makeBinding(1, 3, 10, "db1", "t1", "archive", "orders", 0, []string{"db1.*"}))
@@ -123,9 +126,9 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 		{Matcher: []string{"db2.*"}, TargetSchema: "archive", TargetTable: "{table}"},
 	}
 
-	err := ValidateNoStaticRouteConflict(changefeedID, false, rules, []*common.TableInfo{
-		newRouteConflictTableInfo(1, "db1", "orders"),
-		newRouteConflictTableInfo(2, "db2", "orders"),
+	err := ValidateNoStaticRouteConflict(changefeedID, false, rules, []common.TableName{
+		newRouteConflictTableName(1, "db1", "orders"),
+		newRouteConflictTableName(2, "db2", "orders"),
 	})
 	require.Error(t, err)
 	require.True(t, errors.ErrTableRouteConflict.Equal(err))
@@ -134,19 +137,17 @@ func TestValidateNoStaticRouteConflict(t *testing.T) {
 	require.Contains(t, err.Error(), "rule=0")
 	require.Contains(t, err.Error(), "rule=1")
 
-	err = ValidateNoStaticRouteConflict(changefeedID, false, rules, []*common.TableInfo{
-		newRouteConflictTableInfo(1, "db1", "orders"),
-		newRouteConflictTableInfo(2, "db2", "customers"),
+	err = ValidateNoStaticRouteConflict(changefeedID, false, rules, []common.TableName{
+		newRouteConflictTableName(1, "db1", "orders"),
+		newRouteConflictTableName(2, "db2", "customers"),
 	})
 	require.NoError(t, err)
 }
 
-func newRouteConflictTableInfo(tableID int64, schema, table string) *common.TableInfo {
-	return &common.TableInfo{
-		TableName: common.TableName{
-			Schema:  schema,
-			Table:   table,
-			TableID: tableID,
-		},
+func newRouteConflictTableName(tableID int64, schema, table string) common.TableName {
+	return common.TableName{
+		Schema:  schema,
+		Table:   table,
+		TableID: tableID,
 	}
 }

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -35,17 +35,6 @@ const (
 	TablePlaceholder = "{table}"
 )
 
-// RouteResult carries the outcome of routing a source schema/table pair.
-type RouteResult struct {
-	SourceSchema string
-	SourceTable  string
-	TargetSchema string
-	TargetTable  string
-	Changed      bool
-	RuleIndex    int
-	Matcher      []string
-}
-
 // rule represents a single routing rule.
 type rule struct {
 	filter           tfilter.Filter
@@ -98,35 +87,6 @@ func NewRouter(
 	return Router{
 		changefeedID: changefeedID,
 		rules:        routingRules,
-	}, nil
-}
-
-// RouteName returns the routing result for the given source schema and table,
-// including which rule matched (RuleIndex = -1 when no rule matches).
-func (r Router) RouteName(schema, table string) (RouteResult, error) {
-	if len(r.rules) == 0 {
-		return RouteResult{
-			SourceSchema: schema,
-			SourceTable:  table,
-			TargetSchema: schema,
-			TargetTable:  table,
-			Changed:      false,
-			RuleIndex:    -1,
-		}, nil
-	}
-
-	targetSchema, targetTable, changed, ruleIndex, matcher, err := r.route(schema, table)
-	if err != nil {
-		return RouteResult{}, err
-	}
-	return RouteResult{
-		SourceSchema: schema,
-		SourceTable:  table,
-		TargetSchema: targetSchema,
-		TargetTable:  targetTable,
-		Changed:      changed,
-		RuleIndex:    ruleIndex,
-		Matcher:      matcher,
 	}, nil
 }
 
@@ -367,39 +327,44 @@ func substituteExpression(expr, sourceSchema, sourceTable, defaultValue string) 
 	return result
 }
 
-// ValidateNoStaticRouteConflict checks whether the given tableInfos would produce
+// ValidateNoStaticRouteConflict checks whether the given tableNames would produce
 // any route conflicts under the provided dispatch rules. It returns ErrTableRouteConflict
 // on the first conflict found, or nil when there is no conflict.
 func ValidateNoStaticRouteConflict(
 	changefeedID common.ChangeFeedID,
 	caseSensitive bool,
 	rules []*config.DispatchRule,
-	tableInfos []*common.TableInfo,
+	tableNames []common.TableName,
 ) error {
 	router, err := NewRouter(changefeedID, caseSensitive, rules)
 	if err != nil {
 		return err
 	}
 
-	registry, err := NewTargetTableRegistry(nil)
-	if err != nil {
-		return err
-	}
-	registry.SetChangefeedID(changefeedID)
+	registry := NewTargetTableRegistry(changefeedID)
 
-	for _, ti := range tableInfos {
-		if ti == nil {
-			continue
-		}
-		result, routeErr := router.RouteName(ti.GetSchemaName(), ti.GetTableName())
-		if routeErr != nil {
-			return routeErr
-		}
-		binding := NewRouteBinding(ti, ti.TableName.TableID, 0, result)
-		if err := registry.ValidateAdd(binding); err != nil {
+	for _, tableName := range tableNames {
+		targetSchema, targetTable, _, ruleIndex, matcher, err := router.route(tableName.Schema, tableName.Table)
+		if err != nil {
 			return err
 		}
-		registry.unsafeInsert(binding)
+		binding := RouteBinding{
+			Source: SourceKey{
+				LogicalTableID: tableName.TableID,
+				Schema:         tableName.Schema,
+				Table:          tableName.Table,
+			},
+			ReplicaTableID: tableName.TableID,
+			Target: TargetKey{
+				Schema: targetSchema,
+				Table:  targetTable,
+			},
+			RuleIndex: ruleIndex,
+			Matcher:   matcher,
+		}
+		if err := registry.Add(binding); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -40,8 +40,6 @@ type rule struct {
 	filter           tfilter.Filter
 	targetSchemaExpr string
 	targetTableExpr  string
-	matcher          []string
-	index            int
 }
 
 // Router is used to support the table route functionality,
@@ -57,7 +55,7 @@ func NewRouter(
 	changefeedID common.ChangeFeedID, caseSensitive bool, rules []*config.DispatchRule,
 ) (Router, error) {
 	routingRules := make([]rule, 0, len(rules))
-	for ruleIndex, r := range rules {
+	for _, r := range rules {
 		if r.TargetSchema == "" && r.TargetTable == "" {
 			continue
 		}
@@ -79,8 +77,6 @@ func NewRouter(
 			filter:           f,
 			targetSchemaExpr: r.TargetSchema,
 			targetTableExpr:  r.TargetTable,
-			matcher:          r.Matcher,
-			index:            ruleIndex,
 		})
 	}
 
@@ -98,7 +94,7 @@ func (r Router) ApplyToTableInfo(tableInfo *common.TableInfo) (*common.TableInfo
 		return tableInfo, nil
 	}
 
-	targetSchema, targetTable, changed, _, _, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
+	targetSchema, targetTable, changed, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -149,12 +145,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 		return ddl, nil
 	}
 
-	targetSchemaName, targetTableName, _, _, _, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
+	targetSchemaName, targetTableName, _, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
 	if err != nil {
 		return nil, err
 	}
 
-	targetExtraSchemaName, targetExtraTableName, _, _, _, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
+	targetExtraSchemaName, targetExtraTableName, _, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -198,38 +194,35 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 	), nil
 }
 
-// route returns the target schema/table names, whether routing changed them,
-// the matched rule index (-1 if no match), and the rule's matcher.
-func (r Router) route(originSchema, originTable string) (targetSchema, targetTable string, changed bool, ruleIndex int, matcher []string, err error) {
+// route returns the target schema/table names and whether routing changed them.
+func (r Router) route(originSchema, originTable string) (targetSchema, targetTable string, changed bool, err error) {
 	if originSchema == "" {
-		return originSchema, originTable, false, -1, nil, nil
+		return originSchema, originTable, false, nil
 	}
 
-	matched, _, err := r.matchRule(originSchema, originTable)
+	matched, err := r.matchRule(originSchema, originTable)
 	if err != nil {
-		return "", "", false, -1, nil, err
+		return "", "", false, err
 	}
 	if matched == nil {
-		return originSchema, originTable, false, -1, nil, nil
+		return originSchema, originTable, false, nil
 	}
 
 	targetSchema = substituteExpression(matched.targetSchemaExpr, originSchema, originTable, originSchema)
 	if originTable == "" {
-		return targetSchema, "", targetSchema != originSchema, matched.index, matched.matcher, nil
+		return targetSchema, "", targetSchema != originSchema, nil
 	}
 
 	targetTable = substituteExpression(matched.targetTableExpr, originSchema, originTable, originTable)
-	return targetSchema, targetTable, targetSchema != originSchema || targetTable != originTable, matched.index, matched.matcher, nil
+	return targetSchema, targetTable, targetSchema != originSchema || targetTable != originTable, nil
 }
 
-// matchRule finds the first rule that matches the given schema/table and returns
-// its index. Returns nil, -1, nil when no rule matches.
-func (r Router) matchRule(schema, table string) (*rule, int, error) {
+// matchRule finds the first rule that matches the given schema/table.
+func (r Router) matchRule(schema, table string) (*rule, error) {
 	if table == "" {
 		var (
 			matched      *rule
 			targetSchema string
-			matchedIdx   = -1
 		)
 		for i := range r.rules {
 			if !r.rules[i].filter.MatchSchema(schema) {
@@ -240,24 +233,23 @@ func (r Router) matchRule(schema, table string) (*rule, int, error) {
 			if matched == nil {
 				matched = &r.rules[i]
 				targetSchema = currentTargetSchema
-				matchedIdx = i
 				continue
 			}
 			if currentTargetSchema != targetSchema {
-				return nil, -1, errors.ErrTableRoutingFailed.GenWithStack(
+				return nil, errors.ErrTableRoutingFailed.GenWithStack(
 					"ambiguous schema routing for schema %s: target schema %s conflicts with %s",
 					schema, currentTargetSchema, targetSchema)
 			}
 		}
-		return matched, matchedIdx, nil
+		return matched, nil
 	}
 
 	for i := range r.rules {
 		if r.rules[i].filter.MatchTable(schema, table) {
-			return &r.rules[i], i, nil
+			return &r.rules[i], nil
 		}
 	}
-	return nil, -1, nil
+	return nil, nil
 }
 
 // applyToMultipleTableInfos returns nil when no entry changes.
@@ -295,7 +287,7 @@ func (r Router) applyToBlockedTableNames(tableNames []commonEvent.SchemaTableNam
 
 	var result []commonEvent.SchemaTableName
 	for i, tableName := range tableNames {
-		targetSchema, targetTable, changed, _, _, err := r.route(tableName.SchemaName, tableName.TableName)
+		targetSchema, targetTable, changed, err := r.route(tableName.SchemaName, tableName.TableName)
 		if err != nil {
 			return nil, err
 		}
@@ -327,43 +319,42 @@ func substituteExpression(expr, sourceSchema, sourceTable, defaultValue string) 
 	return result
 }
 
-// ValidateNoStaticRouteConflict checks whether the given tableNames would produce
+// ValidateNoStaticRouteConflict checks whether the given table names would produce
 // any route conflicts under the provided dispatch rules. It returns ErrTableRouteConflict
 // on the first conflict found, or nil when there is no conflict.
 func ValidateNoStaticRouteConflict(
 	changefeedID common.ChangeFeedID,
 	caseSensitive bool,
 	rules []*config.DispatchRule,
-	tableNames []common.TableName,
+	tableNameGroups ...[]common.TableName,
 ) error {
 	router, err := NewRouter(changefeedID, caseSensitive, rules)
 	if err != nil {
 		return err
 	}
 
-	registry := NewTargetTableRegistry(changefeedID)
+	registry := NewTargetTableRegistry()
 
-	for _, tableName := range tableNames {
-		targetSchema, targetTable, _, ruleIndex, matcher, err := router.route(tableName.Schema, tableName.Table)
-		if err != nil {
-			return err
-		}
-		binding := RouteBinding{
-			Source: SourceKey{
-				LogicalTableID: tableName.TableID,
-				Schema:         tableName.Schema,
-				Table:          tableName.Table,
-			},
-			ReplicaTableID: tableName.TableID,
-			Target: TargetKey{
-				Schema: targetSchema,
-				Table:  targetTable,
-			},
-			RuleIndex: ruleIndex,
-			Matcher:   matcher,
-		}
-		if err := registry.Add(binding); err != nil {
-			return err
+	for _, tableNames := range tableNameGroups {
+		for _, tableName := range tableNames {
+			targetSchema, targetTable, _, err := router.route(tableName.Schema, tableName.Table)
+			if err != nil {
+				return err
+			}
+			binding := RouteBinding{
+				Source: SourceKey{
+					LogicalTableID: tableName.TableID,
+					Schema:         tableName.Schema,
+					Table:          tableName.Table,
+				},
+				Target: TargetKey{
+					Schema: targetSchema,
+					Table:  targetTable,
+				},
+			}
+			if err := registry.Add(binding); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -54,7 +54,7 @@ type routeBinding struct {
 	Target targetKey
 }
 
-func NewRouteBinding(tableID int64, schema, table, targetSchema, targetTable string) routeBinding {
+func newRouteBinding(tableID int64, schema, table, targetSchema, targetTable string) routeBinding {
 	return routeBinding{
 		Source: sourceKey{
 			LogicalTableID: tableID,
@@ -135,7 +135,7 @@ func (r Router) ApplyToTableInfo(tableInfo *common.TableInfo) (*common.TableInfo
 		return tableInfo, nil
 	}
 
-	binding, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
+	binding, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName(), tableInfo.TableName.TableID)
 	if err != nil {
 		return nil, err
 	}
@@ -186,12 +186,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 		return ddl, nil
 	}
 
-	binding, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
+	binding, err := r.route(ddl.GetSchemaName(), ddl.GetTableName(), ddl.GetTableID())
 	if err != nil {
 		return nil, err
 	}
 
-	extraBinding, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
+	extraBinding, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName(), 0)
 	if err != nil {
 		return nil, err
 	}
@@ -236,12 +236,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 }
 
 // route returns the target schema/table names and whether routing changed them.
-func (r Router) route(originSchema, originTable string) (binding routeBinding, err error) {
+func (r Router) route(originSchema, originTable string, tableID int64) (binding routeBinding, err error) {
 	// In CDC runtime, table names should always carry schema.
 	// Empty schema means this name pair is absent, so keep it unchanged.
 	// This also prevents wildcard rules like *.* from matching it.
 	if originSchema == "" {
-		return NewRouteBinding(0, originSchema, originTable, originSchema, originTable), nil
+		return newRouteBinding(tableID, originSchema, originTable, originSchema, originTable), nil
 	}
 
 	rule, err := r.matchRule(originSchema, originTable)
@@ -249,16 +249,16 @@ func (r Router) route(originSchema, originTable string) (binding routeBinding, e
 		return routeBinding{}, err
 	}
 	if rule == nil {
-		return NewRouteBinding(0, originSchema, originTable, originSchema, originTable), nil
+		return newRouteBinding(tableID, originSchema, originTable, originSchema, originTable), nil
 	}
 
 	targetSchema := substituteExpression(rule.targetSchemaExpr, originSchema, originTable, originSchema)
 	if originTable == "" {
-		return NewRouteBinding(0, originSchema, originTable, targetSchema, originTable), nil
+		return newRouteBinding(tableID, originSchema, originTable, targetSchema, originTable), nil
 	}
 
 	targetTable := substituteExpression(rule.targetTableExpr, originSchema, originTable, originTable)
-	return NewRouteBinding(0, originSchema, originTable, targetSchema, targetTable), nil
+	return newRouteBinding(tableID, originSchema, originTable, targetSchema, targetTable), nil
 }
 
 // matchRule finds the first rule that matches the given schema/table.
@@ -331,7 +331,7 @@ func (r Router) applyToBlockedTableNames(tableNames []commonEvent.SchemaTableNam
 
 	var result []commonEvent.SchemaTableName
 	for i, tableName := range tableNames {
-		binding, err := r.route(tableName.SchemaName, tableName.TableName)
+		binding, err := r.route(tableName.SchemaName, tableName.TableName, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +383,7 @@ func ValidateNoStaticRouteConflict(
 	registry := NewTargetTableRegistry()
 	for _, tableNames := range tableNameGroups {
 		for _, tableName := range tableNames {
-			binding, err := router.route(tableName.Schema, tableName.Table)
+			binding, err := router.route(tableName.Schema, tableName.Table, tableName.TableID)
 			if err != nil {
 				return err
 			}

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -35,6 +35,43 @@ const (
 	TablePlaceholder = "{table}"
 )
 
+// targetKey identifies a downstream target table.
+type targetKey struct {
+	Schema string
+	Table  string
+}
+
+// sourceKey identifies an upstream logical table.
+type sourceKey struct {
+	LogicalTableID int64
+	Schema         string
+	Table          string
+}
+
+// routeBinding records one source-to-target route mapping.
+type routeBinding struct {
+	Source sourceKey
+	Target targetKey
+}
+
+func NewRouteBinding(tableID int64, schema, table, targetSchema, targetTable string) routeBinding {
+	return routeBinding{
+		Source: sourceKey{
+			LogicalTableID: tableID,
+			Schema:         schema,
+			Table:          table,
+		},
+		Target: targetKey{
+			Schema: targetSchema,
+			Table:  targetTable,
+		},
+	}
+}
+
+func (b routeBinding) routed() bool {
+	return b.Source.Schema != b.Target.Schema || b.Source.Table != b.Target.Table
+}
+
 // rule represents a single routing rule.
 type rule struct {
 	filter           tfilter.Filter
@@ -47,6 +84,10 @@ type rule struct {
 type Router struct {
 	changefeedID common.ChangeFeedID
 	rules        []rule
+}
+
+func (r Router) enabled() bool {
+	return len(r.rules) != 0
 }
 
 // NewRouter creates a new Router from dispatch rules.
@@ -94,14 +135,14 @@ func (r Router) ApplyToTableInfo(tableInfo *common.TableInfo) (*common.TableInfo
 		return tableInfo, nil
 	}
 
-	targetSchema, targetTable, changed, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
+	binding, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
 	if err != nil {
 		return nil, err
 	}
-	if !changed {
+	if !binding.routed() {
 		return tableInfo, nil
 	}
-	return tableInfo.CloneWithRouting(targetSchema, targetTable), nil
+	return tableInfo.CloneWithRouting(binding.Target.Schema, binding.Target.Table), nil
 }
 
 // ApplyToDDLEvent returns the original DDL event unless routing changes the DDL query;
@@ -145,12 +186,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 		return ddl, nil
 	}
 
-	targetSchemaName, targetTableName, _, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
+	binding, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
 	if err != nil {
 		return nil, err
 	}
 
-	targetExtraSchemaName, targetExtraTableName, _, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
+	extraBinding, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -184,10 +225,10 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 	return commonEvent.NewRoutedDDLEvent(
 		ddl,
 		newQuery,
-		targetSchemaName,
-		targetTableName,
-		targetExtraSchemaName,
-		targetExtraTableName,
+		binding.Target.Schema,
+		binding.Target.Table,
+		extraBinding.Target.Schema,
+		extraBinding.Target.Table,
 		tableInfo,
 		multipleTableInfos,
 		blockedTableNames,
@@ -195,26 +236,29 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 }
 
 // route returns the target schema/table names and whether routing changed them.
-func (r Router) route(originSchema, originTable string) (targetSchema, targetTable string, changed bool, err error) {
+func (r Router) route(originSchema, originTable string) (binding routeBinding, err error) {
+	// In CDC runtime, table names should always carry schema.
+	// Empty schema means this name pair is absent, so keep it unchanged.
+	// This also prevents wildcard rules like *.* from matching it.
 	if originSchema == "" {
-		return originSchema, originTable, false, nil
+		return NewRouteBinding(0, originSchema, originTable, originSchema, originTable), nil
 	}
 
-	matched, err := r.matchRule(originSchema, originTable)
+	rule, err := r.matchRule(originSchema, originTable)
 	if err != nil {
-		return "", "", false, err
+		return routeBinding{}, err
 	}
-	if matched == nil {
-		return originSchema, originTable, false, nil
+	if rule == nil {
+		return NewRouteBinding(0, originSchema, originTable, originSchema, originTable), nil
 	}
 
-	targetSchema = substituteExpression(matched.targetSchemaExpr, originSchema, originTable, originSchema)
+	targetSchema := substituteExpression(rule.targetSchemaExpr, originSchema, originTable, originSchema)
 	if originTable == "" {
-		return targetSchema, "", targetSchema != originSchema, nil
+		return NewRouteBinding(0, originSchema, originTable, targetSchema, originTable), nil
 	}
 
-	targetTable = substituteExpression(matched.targetTableExpr, originSchema, originTable, originTable)
-	return targetSchema, targetTable, targetSchema != originSchema || targetTable != originTable, nil
+	targetTable := substituteExpression(rule.targetTableExpr, originSchema, originTable, originTable)
+	return NewRouteBinding(0, originSchema, originTable, targetSchema, targetTable), nil
 }
 
 // matchRule finds the first rule that matches the given schema/table.
@@ -287,19 +331,19 @@ func (r Router) applyToBlockedTableNames(tableNames []commonEvent.SchemaTableNam
 
 	var result []commonEvent.SchemaTableName
 	for i, tableName := range tableNames {
-		targetSchema, targetTable, changed, err := r.route(tableName.SchemaName, tableName.TableName)
+		binding, err := r.route(tableName.SchemaName, tableName.TableName)
 		if err != nil {
 			return nil, err
 		}
-		if !changed {
+		if !binding.routed() {
 			continue
 		}
 		if result == nil {
 			result = append([]commonEvent.SchemaTableName(nil), tableNames...)
 		}
 		result[i] = commonEvent.SchemaTableName{
-			SchemaName: targetSchema,
-			TableName:  targetTable,
+			SchemaName: binding.Target.Schema,
+			TableName:  binding.Target.Table,
 		}
 	}
 	return result, nil
@@ -332,25 +376,16 @@ func ValidateNoStaticRouteConflict(
 	if err != nil {
 		return err
 	}
+	if !router.enabled() {
+		return nil
+	}
 
 	registry := NewTargetTableRegistry()
-
 	for _, tableNames := range tableNameGroups {
 		for _, tableName := range tableNames {
-			targetSchema, targetTable, _, err := router.route(tableName.Schema, tableName.Table)
+			binding, err := router.route(tableName.Schema, tableName.Table)
 			if err != nil {
 				return err
-			}
-			binding := RouteBinding{
-				Source: SourceKey{
-					LogicalTableID: tableName.TableID,
-					Schema:         tableName.Schema,
-					Table:          tableName.Table,
-				},
-				Target: TargetKey{
-					Schema: targetSchema,
-					Table:  targetTable,
-				},
 			}
 			if err := registry.Add(binding); err != nil {
 				return err

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -40,6 +40,10 @@ type tableKey struct {
 	Table  string
 }
 
+func (k tableKey) Equal(other tableKey) bool {
+	return k.Schema == other.Schema && k.Table == other.Table
+}
+
 // routeBinding records one source-to-target route mapping.
 type routeBinding struct {
 	Source tableKey
@@ -60,7 +64,7 @@ func newRouteBinding(schema, table, targetSchema, targetTable string) routeBindi
 }
 
 func (b routeBinding) routed() bool {
-	return b.Source.Schema != b.Target.Schema || b.Source.Table != b.Target.Table
+	return !b.Source.Equal(b.Target)
 }
 
 // rule represents a single routing rule.
@@ -226,7 +230,7 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 	), nil
 }
 
-// route returns the target schema/table names and whether routing changed them.
+// route returns the source-to-target table name binding.
 func (r Router) route(originSchema, originTable string) (binding routeBinding, err error) {
 	// In CDC runtime, table names should always carry schema.
 	// Empty schema means this name pair is absent, so keep it unchanged.
@@ -371,7 +375,7 @@ func ValidateNoStaticRouteConflict(
 		return nil
 	}
 
-	registry := NewTargetTableRegistry()
+	registry := NewTargetTableRegistry(changefeedID)
 	for _, tableNames := range tableNameGroups {
 		for _, tableName := range tableNames {
 			binding, err := router.route(tableName.Schema, tableName.Table)

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -35,11 +35,24 @@ const (
 	TablePlaceholder = "{table}"
 )
 
+// RouteResult carries the outcome of routing a source schema/table pair.
+type RouteResult struct {
+	SourceSchema string
+	SourceTable  string
+	TargetSchema string
+	TargetTable  string
+	Changed      bool
+	RuleIndex    int
+	Matcher      []string
+}
+
 // rule represents a single routing rule.
 type rule struct {
 	filter           tfilter.Filter
 	targetSchemaExpr string
 	targetTableExpr  string
+	matcher          []string
+	index            int
 }
 
 // Router is used to support the table route functionality,
@@ -55,7 +68,7 @@ func NewRouter(
 	changefeedID common.ChangeFeedID, caseSensitive bool, rules []*config.DispatchRule,
 ) (Router, error) {
 	routingRules := make([]rule, 0, len(rules))
-	for _, r := range rules {
+	for ruleIndex, r := range rules {
 		if r.TargetSchema == "" && r.TargetTable == "" {
 			continue
 		}
@@ -77,12 +90,43 @@ func NewRouter(
 			filter:           f,
 			targetSchemaExpr: r.TargetSchema,
 			targetTableExpr:  r.TargetTable,
+			matcher:          r.Matcher,
+			index:            ruleIndex,
 		})
 	}
 
 	return Router{
 		changefeedID: changefeedID,
 		rules:        routingRules,
+	}, nil
+}
+
+// RouteName returns the routing result for the given source schema and table,
+// including which rule matched (RuleIndex = -1 when no rule matches).
+func (r Router) RouteName(schema, table string) (RouteResult, error) {
+	if len(r.rules) == 0 {
+		return RouteResult{
+			SourceSchema: schema,
+			SourceTable:  table,
+			TargetSchema: schema,
+			TargetTable:  table,
+			Changed:      false,
+			RuleIndex:    -1,
+		}, nil
+	}
+
+	targetSchema, targetTable, changed, ruleIndex, matcher, err := r.route(schema, table)
+	if err != nil {
+		return RouteResult{}, err
+	}
+	return RouteResult{
+		SourceSchema: schema,
+		SourceTable:  table,
+		TargetSchema: targetSchema,
+		TargetTable:  targetTable,
+		Changed:      changed,
+		RuleIndex:    ruleIndex,
+		Matcher:      matcher,
 	}, nil
 }
 
@@ -94,7 +138,7 @@ func (r Router) ApplyToTableInfo(tableInfo *common.TableInfo) (*common.TableInfo
 		return tableInfo, nil
 	}
 
-	targetSchema, targetTable, changed, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
+	targetSchema, targetTable, changed, _, _, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -145,12 +189,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 		return ddl, nil
 	}
 
-	targetSchemaName, targetTableName, _, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
+	targetSchemaName, targetTableName, _, _, _, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
 	if err != nil {
 		return nil, err
 	}
 
-	targetExtraSchemaName, targetExtraTableName, _, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
+	targetExtraSchemaName, targetExtraTableName, _, _, _, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -194,41 +238,38 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 	), nil
 }
 
-// route returns the target schema/table names and whether routing changed them.
-func (r Router) route(originSchema, originTable string) (targetSchema, targetTable string, changed bool, err error) {
-	// In CDC runtime, table names should always carry schema.
-	// Empty schema means this name pair is absent, so keep it unchanged.
-	// This also prevents wildcard rules like *.* from matching it.
+// route returns the target schema/table names, whether routing changed them,
+// the matched rule index (-1 if no match), and the rule's matcher.
+func (r Router) route(originSchema, originTable string) (targetSchema, targetTable string, changed bool, ruleIndex int, matcher []string, err error) {
 	if originSchema == "" {
-		return originSchema, originTable, false, nil
+		return originSchema, originTable, false, -1, nil, nil
 	}
 
-	rule, err := r.matchRule(originSchema, originTable)
+	matched, _, err := r.matchRule(originSchema, originTable)
 	if err != nil {
-		return "", "", false, err
+		return "", "", false, -1, nil, err
 	}
-	if rule == nil {
-		return originSchema, originTable, false, nil
+	if matched == nil {
+		return originSchema, originTable, false, -1, nil, nil
 	}
 
-	targetSchema = substituteExpression(rule.targetSchemaExpr, originSchema, originTable, originSchema)
-	// Schema-level DDLs can rewrite the target schema, but must not synthesize a target table.
+	targetSchema = substituteExpression(matched.targetSchemaExpr, originSchema, originTable, originSchema)
 	if originTable == "" {
-		return targetSchema, "", targetSchema != originSchema, nil
+		return targetSchema, "", targetSchema != originSchema, matched.index, matched.matcher, nil
 	}
 
-	targetTable = substituteExpression(rule.targetTableExpr, originSchema, originTable, originTable)
-	return targetSchema, targetTable, targetSchema != originSchema || targetTable != originTable, nil
+	targetTable = substituteExpression(matched.targetTableExpr, originSchema, originTable, originTable)
+	return targetSchema, targetTable, targetSchema != originSchema || targetTable != originTable, matched.index, matched.matcher, nil
 }
 
-// matchRule finds the first rule that matches the given schema/table.
-// Table routing keeps first-match semantics. Schema-only routing rejects fan-out
-// to different target schemas because there is no table name to choose a rule.
-func (r Router) matchRule(schema, table string) (*rule, error) {
+// matchRule finds the first rule that matches the given schema/table and returns
+// its index. Returns nil, -1, nil when no rule matches.
+func (r Router) matchRule(schema, table string) (*rule, int, error) {
 	if table == "" {
 		var (
 			matched      *rule
 			targetSchema string
+			matchedIdx   = -1
 		)
 		for i := range r.rules {
 			if !r.rules[i].filter.MatchSchema(schema) {
@@ -239,23 +280,24 @@ func (r Router) matchRule(schema, table string) (*rule, error) {
 			if matched == nil {
 				matched = &r.rules[i]
 				targetSchema = currentTargetSchema
+				matchedIdx = i
 				continue
 			}
 			if currentTargetSchema != targetSchema {
-				return nil, errors.ErrTableRoutingFailed.GenWithStack(
+				return nil, -1, errors.ErrTableRoutingFailed.GenWithStack(
 					"ambiguous schema routing for schema %s: target schema %s conflicts with %s",
 					schema, currentTargetSchema, targetSchema)
 			}
 		}
-		return matched, nil
+		return matched, matchedIdx, nil
 	}
 
 	for i := range r.rules {
 		if r.rules[i].filter.MatchTable(schema, table) {
-			return &r.rules[i], nil
+			return &r.rules[i], i, nil
 		}
 	}
-	return nil, nil
+	return nil, -1, nil
 }
 
 // applyToMultipleTableInfos returns nil when no entry changes.
@@ -293,7 +335,7 @@ func (r Router) applyToBlockedTableNames(tableNames []commonEvent.SchemaTableNam
 
 	var result []commonEvent.SchemaTableName
 	for i, tableName := range tableNames {
-		targetSchema, targetTable, changed, err := r.route(tableName.SchemaName, tableName.TableName)
+		targetSchema, targetTable, changed, _, _, err := r.route(tableName.SchemaName, tableName.TableName)
 		if err != nil {
 			return nil, err
 		}
@@ -323,4 +365,41 @@ func substituteExpression(expr, sourceSchema, sourceTable, defaultValue string) 
 	result = strings.ReplaceAll(result, SchemaPlaceholder, sourceSchema)
 	result = strings.ReplaceAll(result, TablePlaceholder, sourceTable)
 	return result
+}
+
+// ValidateNoStaticRouteConflict checks whether the given tableInfos would produce
+// any route conflicts under the provided dispatch rules. It returns ErrTableRouteConflict
+// on the first conflict found, or nil when there is no conflict.
+func ValidateNoStaticRouteConflict(
+	changefeedID common.ChangeFeedID,
+	caseSensitive bool,
+	rules []*config.DispatchRule,
+	tableInfos []*common.TableInfo,
+) error {
+	router, err := NewRouter(changefeedID, caseSensitive, rules)
+	if err != nil {
+		return err
+	}
+
+	registry, err := NewTargetTableRegistry(nil)
+	if err != nil {
+		return err
+	}
+	registry.SetChangefeedID(changefeedID)
+
+	for _, ti := range tableInfos {
+		if ti == nil {
+			continue
+		}
+		result, routeErr := router.RouteName(ti.GetSchemaName(), ti.GetTableName())
+		if routeErr != nil {
+			return routeErr
+		}
+		binding := NewRouteBinding(ti, ti.TableName.TableID, 0, result)
+		if err := registry.ValidateAdd(binding); err != nil {
+			return err
+		}
+		registry.unsafeInsert(binding)
+	}
+	return nil
 }

--- a/downstreamadapter/routing/router.go
+++ b/downstreamadapter/routing/router.go
@@ -35,33 +35,24 @@ const (
 	TablePlaceholder = "{table}"
 )
 
-// targetKey identifies a downstream target table.
-type targetKey struct {
+type tableKey struct {
 	Schema string
 	Table  string
 }
 
-// sourceKey identifies an upstream logical table.
-type sourceKey struct {
-	LogicalTableID int64
-	Schema         string
-	Table          string
-}
-
 // routeBinding records one source-to-target route mapping.
 type routeBinding struct {
-	Source sourceKey
-	Target targetKey
+	Source tableKey
+	Target tableKey
 }
 
-func newRouteBinding(tableID int64, schema, table, targetSchema, targetTable string) routeBinding {
+func newRouteBinding(schema, table, targetSchema, targetTable string) routeBinding {
 	return routeBinding{
-		Source: sourceKey{
-			LogicalTableID: tableID,
-			Schema:         schema,
-			Table:          table,
+		Source: tableKey{
+			Schema: schema,
+			Table:  table,
 		},
-		Target: targetKey{
+		Target: tableKey{
 			Schema: targetSchema,
 			Table:  targetTable,
 		},
@@ -135,7 +126,7 @@ func (r Router) ApplyToTableInfo(tableInfo *common.TableInfo) (*common.TableInfo
 		return tableInfo, nil
 	}
 
-	binding, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName(), tableInfo.TableName.TableID)
+	binding, err := r.route(tableInfo.GetSchemaName(), tableInfo.GetTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -186,12 +177,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 		return ddl, nil
 	}
 
-	binding, err := r.route(ddl.GetSchemaName(), ddl.GetTableName(), ddl.GetTableID())
+	binding, err := r.route(ddl.GetSchemaName(), ddl.GetTableName())
 	if err != nil {
 		return nil, err
 	}
 
-	extraBinding, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName(), 0)
+	extraBinding, err := r.route(ddl.GetExtraSchemaName(), ddl.GetExtraTableName())
 	if err != nil {
 		return nil, err
 	}
@@ -236,12 +227,12 @@ func (r Router) ApplyToDDLEvent(ddl *commonEvent.DDLEvent) (*commonEvent.DDLEven
 }
 
 // route returns the target schema/table names and whether routing changed them.
-func (r Router) route(originSchema, originTable string, tableID int64) (binding routeBinding, err error) {
+func (r Router) route(originSchema, originTable string) (binding routeBinding, err error) {
 	// In CDC runtime, table names should always carry schema.
 	// Empty schema means this name pair is absent, so keep it unchanged.
 	// This also prevents wildcard rules like *.* from matching it.
 	if originSchema == "" {
-		return newRouteBinding(tableID, originSchema, originTable, originSchema, originTable), nil
+		return newRouteBinding(originSchema, originTable, originSchema, originTable), nil
 	}
 
 	rule, err := r.matchRule(originSchema, originTable)
@@ -249,16 +240,16 @@ func (r Router) route(originSchema, originTable string, tableID int64) (binding 
 		return routeBinding{}, err
 	}
 	if rule == nil {
-		return newRouteBinding(tableID, originSchema, originTable, originSchema, originTable), nil
+		return newRouteBinding(originSchema, originTable, originSchema, originTable), nil
 	}
 
 	targetSchema := substituteExpression(rule.targetSchemaExpr, originSchema, originTable, originSchema)
 	if originTable == "" {
-		return newRouteBinding(tableID, originSchema, originTable, targetSchema, originTable), nil
+		return newRouteBinding(originSchema, originTable, targetSchema, originTable), nil
 	}
 
 	targetTable := substituteExpression(rule.targetTableExpr, originSchema, originTable, originTable)
-	return newRouteBinding(tableID, originSchema, originTable, targetSchema, targetTable), nil
+	return newRouteBinding(originSchema, originTable, targetSchema, targetTable), nil
 }
 
 // matchRule finds the first rule that matches the given schema/table.
@@ -331,7 +322,7 @@ func (r Router) applyToBlockedTableNames(tableNames []commonEvent.SchemaTableNam
 
 	var result []commonEvent.SchemaTableName
 	for i, tableName := range tableNames {
-		binding, err := r.route(tableName.SchemaName, tableName.TableName, 0)
+		binding, err := r.route(tableName.SchemaName, tableName.TableName)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +374,7 @@ func ValidateNoStaticRouteConflict(
 	registry := NewTargetTableRegistry()
 	for _, tableNames := range tableNameGroups {
 		for _, tableName := range tableNames {
-			binding, err := router.route(tableName.Schema, tableName.Table, tableName.TableID)
+			binding, err := router.route(tableName.Schema, tableName.Table)
 			if err != nil {
 				return err
 			}

--- a/downstreamadapter/routing/router_test.go
+++ b/downstreamadapter/routing/router_test.go
@@ -83,20 +83,20 @@ func TestNewRouter(t *testing.T) {
 		router, err := NewRouter(newTestChangefeedID(), true, nil)
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		schema, table, changed, err := router.route("db1", "t1")
+		binding, err := router.route("db1", "t1")
 		require.NoError(t, err)
-		require.Equal(t, "db1", schema)
-		require.Equal(t, "t1", table)
-		require.False(t, changed)
+		require.Equal(t, "db1", binding.Target.Schema)
+		require.Equal(t, "t1", binding.Target.Table)
+		require.False(t, binding.routed())
 
 		router, err = NewRouter(newTestChangefeedID(), true, []*config.DispatchRule{})
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		schema, table, changed, err = router.route("db1", "t1")
+		binding, err = router.route("db1", "t1")
 		require.NoError(t, err)
-		require.Equal(t, "db1", schema)
-		require.Equal(t, "t1", table)
-		require.False(t, changed)
+		require.Equal(t, "db1", binding.Target.Schema)
+		require.Equal(t, "t1", binding.Target.Table)
+		require.False(t, binding.routed())
 	})
 
 	t.Run("rules without routing targets are skipped", func(t *testing.T) {
@@ -148,23 +148,23 @@ func TestNewRouter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, router.rules, 2)
 
-		schema, table, changed, err := router.route("db1", "orders")
+		binding, err := router.route("db1", "orders")
 		require.NoError(t, err)
-		require.Equal(t, "db1", schema)
-		require.Equal(t, "orders", table)
-		require.False(t, changed)
+		require.Equal(t, "db1", binding.Target.Schema)
+		require.Equal(t, "orders", binding.Target.Table)
+		require.False(t, binding.routed())
 
-		schema, table, changed, err = router.route("db2", "orders")
+		binding, err = router.route("db2", "orders")
 		require.NoError(t, err)
-		require.Equal(t, "archive", schema)
-		require.Equal(t, "orders", table)
-		require.True(t, changed)
+		require.Equal(t, "archive", binding.Target.Schema)
+		require.Equal(t, "orders", binding.Target.Table)
+		require.True(t, binding.routed())
 
-		schema, table, changed, err = router.route("db3", "users")
+		binding, err = router.route("db3", "users")
 		require.NoError(t, err)
-		require.Equal(t, "db3", schema)
-		require.Equal(t, "users_bak", table)
-		require.True(t, changed)
+		require.Equal(t, "db3", binding.Target.Schema)
+		require.Equal(t, "users_bak", binding.Target.Table)
+		require.True(t, binding.routed())
 	})
 }
 
@@ -172,11 +172,11 @@ func TestRouterRoute(t *testing.T) {
 	t.Parallel()
 
 	var zeroRouter Router
-	schema, table, changed, err := zeroRouter.route("source_db", "source_table")
+	binding, err := zeroRouter.route("source_db", "source_table")
 	require.NoError(t, err)
-	require.Equal(t, "source_db", schema)
-	require.Equal(t, "source_table", table)
-	require.False(t, changed)
+	require.Equal(t, "source_db", binding.Target.Schema)
+	require.Equal(t, "source_table", binding.Target.Table)
+	require.False(t, binding.routed())
 
 	router, err := NewRouter(newTestChangefeedID(), true, []*config.DispatchRule{
 		{Matcher: []string{"db1.specific"}, TargetSchema: "specific_db", TargetTable: "specific_table"},
@@ -247,11 +247,11 @@ func TestRouterRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotTable, gotChanged, err := router.route(tc.sourceSchema, tc.sourceTable)
+			binding, err := router.route(tc.sourceSchema, tc.sourceTable)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedSchema, gotSchema)
-			require.Equal(t, tc.expectedTable, gotTable)
-			require.Equal(t, tc.expectedChanged, gotChanged)
+			require.Equal(t, tc.expectedSchema, binding.Target.Schema)
+			require.Equal(t, tc.expectedTable, binding.Target.Table)
+			require.Equal(t, tc.expectedChanged, binding.routed())
 		})
 	}
 
@@ -261,11 +261,11 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("db1", "")
+		binding, err := router.route("db1", "")
 		require.NoError(t, err)
-		require.Equal(t, "db1_archive", schema)
-		require.Empty(t, table)
-		require.True(t, changed)
+		require.Equal(t, "db1_archive", binding.Target.Schema)
+		require.Empty(t, binding.Target.Table)
+		require.True(t, binding.routed())
 	})
 
 	t.Run("schema only routing allows table rules with same target schema", func(t *testing.T) {
@@ -275,11 +275,11 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("db1", "")
+		binding, err := router.route("db1", "")
 		require.NoError(t, err)
-		require.Equal(t, "db1_archive", schema)
-		require.Empty(t, table)
-		require.True(t, changed)
+		require.Equal(t, "db1_archive", binding.Target.Schema)
+		require.Empty(t, binding.Target.Table)
+		require.True(t, binding.routed())
 	})
 
 	t.Run("schema only routing rejects table rules with different target schemas", func(t *testing.T) {
@@ -289,7 +289,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, _, _, err = router.route("db1", "")
+		_, err = router.route("db1", "")
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRoutingFailed.Equal(err))
 		require.Contains(t, err.Error(), "ambiguous schema routing")
@@ -301,11 +301,11 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("", "")
+		binding, err := router.route("", "")
 		require.NoError(t, err)
-		require.Empty(t, schema)
-		require.Empty(t, table)
-		require.False(t, changed)
+		require.Empty(t, binding.Target.Schema)
+		require.Empty(t, binding.Target.Table)
+		require.False(t, binding.routed())
 	})
 }
 
@@ -320,11 +320,11 @@ func TestRouterFirstMatchWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, router.rules, 3)
 
-	schema, table, changed, err := router.route("db1", "users")
+	binding, err := router.route("db1", "users")
 	require.NoError(t, err)
-	require.Equal(t, "catch_all", schema)
-	require.Equal(t, "users", table)
-	require.True(t, changed)
+	require.Equal(t, "catch_all", binding.Target.Schema)
+	require.Equal(t, "users", binding.Target.Table)
+	require.True(t, binding.routed())
 }
 
 func TestRouterCaseSensitivity(t *testing.T) {
@@ -338,17 +338,17 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("MyDB", "MyTable")
+		binding, err := router.route("MyDB", "MyTable")
 		require.NoError(t, err)
-		require.Equal(t, "target_db", schema)
-		require.Equal(t, "target_table", table)
-		require.True(t, changed)
+		require.Equal(t, "target_db", binding.Target.Schema)
+		require.Equal(t, "target_table", binding.Target.Table)
+		require.True(t, binding.routed())
 
-		schema, table, changed, err = router.route("mydb", "mytable")
+		binding, err = router.route("mydb", "mytable")
 		require.NoError(t, err)
-		require.Equal(t, "mydb", schema)
-		require.Equal(t, "mytable", table)
-		require.False(t, changed)
+		require.Equal(t, "mydb", binding.Target.Schema)
+		require.Equal(t, "mytable", binding.Target.Table)
+		require.False(t, binding.routed())
 	})
 
 	t.Run("case insensitive router preserves source case in placeholders", func(t *testing.T) {
@@ -359,10 +359,10 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("mydb", "MyTable")
+		binding, err := router.route("mydb", "MyTable")
 		require.NoError(t, err)
-		require.Equal(t, "backup_mydb", schema)
-		require.Equal(t, "MyTable", table)
-		require.True(t, changed)
+		require.Equal(t, "backup_mydb", binding.Target.Schema)
+		require.Equal(t, "MyTable", binding.Target.Table)
+		require.True(t, binding.routed())
 	})
 }

--- a/downstreamadapter/routing/router_test.go
+++ b/downstreamadapter/routing/router_test.go
@@ -83,7 +83,7 @@ func TestNewRouter(t *testing.T) {
 		router, err := NewRouter(newTestChangefeedID(), true, nil)
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		binding, err := router.route("db1", "t1")
+		binding, err := router.route("db1", "t1", 0)
 		require.NoError(t, err)
 		require.Equal(t, "db1", binding.Target.Schema)
 		require.Equal(t, "t1", binding.Target.Table)
@@ -92,7 +92,7 @@ func TestNewRouter(t *testing.T) {
 		router, err = NewRouter(newTestChangefeedID(), true, []*config.DispatchRule{})
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		binding, err = router.route("db1", "t1")
+		binding, err = router.route("db1", "t1", 0)
 		require.NoError(t, err)
 		require.Equal(t, "db1", binding.Target.Schema)
 		require.Equal(t, "t1", binding.Target.Table)
@@ -148,19 +148,19 @@ func TestNewRouter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, router.rules, 2)
 
-		binding, err := router.route("db1", "orders")
+		binding, err := router.route("db1", "orders", 0)
 		require.NoError(t, err)
 		require.Equal(t, "db1", binding.Target.Schema)
 		require.Equal(t, "orders", binding.Target.Table)
 		require.False(t, binding.routed())
 
-		binding, err = router.route("db2", "orders")
+		binding, err = router.route("db2", "orders", 0)
 		require.NoError(t, err)
 		require.Equal(t, "archive", binding.Target.Schema)
 		require.Equal(t, "orders", binding.Target.Table)
 		require.True(t, binding.routed())
 
-		binding, err = router.route("db3", "users")
+		binding, err = router.route("db3", "users", 0)
 		require.NoError(t, err)
 		require.Equal(t, "db3", binding.Target.Schema)
 		require.Equal(t, "users_bak", binding.Target.Table)
@@ -172,7 +172,7 @@ func TestRouterRoute(t *testing.T) {
 	t.Parallel()
 
 	var zeroRouter Router
-	binding, err := zeroRouter.route("source_db", "source_table")
+	binding, err := zeroRouter.route("source_db", "source_table", 0)
 	require.NoError(t, err)
 	require.Equal(t, "source_db", binding.Target.Schema)
 	require.Equal(t, "source_table", binding.Target.Table)
@@ -247,7 +247,7 @@ func TestRouterRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			binding, err := router.route(tc.sourceSchema, tc.sourceTable)
+			binding, err := router.route(tc.sourceSchema, tc.sourceTable, 0)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSchema, binding.Target.Schema)
 			require.Equal(t, tc.expectedTable, binding.Target.Table)
@@ -261,7 +261,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("db1", "")
+		binding, err := router.route("db1", "", 0)
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", binding.Target.Schema)
 		require.Empty(t, binding.Target.Table)
@@ -275,7 +275,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("db1", "")
+		binding, err := router.route("db1", "", 0)
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", binding.Target.Schema)
 		require.Empty(t, binding.Target.Table)
@@ -289,7 +289,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = router.route("db1", "")
+		_, err = router.route("db1", "", 0)
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRoutingFailed.Equal(err))
 		require.Contains(t, err.Error(), "ambiguous schema routing")
@@ -301,7 +301,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("", "")
+		binding, err := router.route("", "", 0)
 		require.NoError(t, err)
 		require.Empty(t, binding.Target.Schema)
 		require.Empty(t, binding.Target.Table)
@@ -320,7 +320,7 @@ func TestRouterFirstMatchWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, router.rules, 3)
 
-	binding, err := router.route("db1", "users")
+	binding, err := router.route("db1", "users", 0)
 	require.NoError(t, err)
 	require.Equal(t, "catch_all", binding.Target.Schema)
 	require.Equal(t, "users", binding.Target.Table)
@@ -338,13 +338,13 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("MyDB", "MyTable")
+		binding, err := router.route("MyDB", "MyTable", 0)
 		require.NoError(t, err)
 		require.Equal(t, "target_db", binding.Target.Schema)
 		require.Equal(t, "target_table", binding.Target.Table)
 		require.True(t, binding.routed())
 
-		binding, err = router.route("mydb", "mytable")
+		binding, err = router.route("mydb", "mytable", 0)
 		require.NoError(t, err)
 		require.Equal(t, "mydb", binding.Target.Schema)
 		require.Equal(t, "mytable", binding.Target.Table)
@@ -359,7 +359,7 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("mydb", "MyTable")
+		binding, err := router.route("mydb", "MyTable", 0)
 		require.NoError(t, err)
 		require.Equal(t, "backup_mydb", binding.Target.Schema)
 		require.Equal(t, "MyTable", binding.Target.Table)

--- a/downstreamadapter/routing/router_test.go
+++ b/downstreamadapter/routing/router_test.go
@@ -83,7 +83,7 @@ func TestNewRouter(t *testing.T) {
 		router, err := NewRouter(newTestChangefeedID(), true, nil)
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		schema, table, changed, err := router.route("db1", "t1")
+		schema, table, changed, _, _, err := router.route("db1", "t1")
 		require.NoError(t, err)
 		require.Equal(t, "db1", schema)
 		require.Equal(t, "t1", table)
@@ -92,7 +92,7 @@ func TestNewRouter(t *testing.T) {
 		router, err = NewRouter(newTestChangefeedID(), true, []*config.DispatchRule{})
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		schema, table, changed, err = router.route("db1", "t1")
+		schema, table, changed, _, _, err = router.route("db1", "t1")
 		require.NoError(t, err)
 		require.Equal(t, "db1", schema)
 		require.Equal(t, "t1", table)
@@ -148,19 +148,19 @@ func TestNewRouter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, router.rules, 2)
 
-		schema, table, changed, err := router.route("db1", "orders")
+		schema, table, changed, _, _, err := router.route("db1", "orders")
 		require.NoError(t, err)
 		require.Equal(t, "db1", schema)
 		require.Equal(t, "orders", table)
 		require.False(t, changed)
 
-		schema, table, changed, err = router.route("db2", "orders")
+		schema, table, changed, _, _, err = router.route("db2", "orders")
 		require.NoError(t, err)
 		require.Equal(t, "archive", schema)
 		require.Equal(t, "orders", table)
 		require.True(t, changed)
 
-		schema, table, changed, err = router.route("db3", "users")
+		schema, table, changed, _, _, err = router.route("db3", "users")
 		require.NoError(t, err)
 		require.Equal(t, "db3", schema)
 		require.Equal(t, "users_bak", table)
@@ -172,7 +172,7 @@ func TestRouterRoute(t *testing.T) {
 	t.Parallel()
 
 	var zeroRouter Router
-	schema, table, changed, err := zeroRouter.route("source_db", "source_table")
+	schema, table, changed, _, _, err := zeroRouter.route("source_db", "source_table")
 	require.NoError(t, err)
 	require.Equal(t, "source_db", schema)
 	require.Equal(t, "source_table", table)
@@ -247,7 +247,7 @@ func TestRouterRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotTable, gotChanged, err := router.route(tc.sourceSchema, tc.sourceTable)
+			gotSchema, gotTable, gotChanged, _, _, err := router.route(tc.sourceSchema, tc.sourceTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSchema, gotSchema)
 			require.Equal(t, tc.expectedTable, gotTable)
@@ -261,7 +261,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("db1", "")
+		schema, table, changed, _, _, err := router.route("db1", "")
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", schema)
 		require.Empty(t, table)
@@ -275,7 +275,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("db1", "")
+		schema, table, changed, _, _, err := router.route("db1", "")
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", schema)
 		require.Empty(t, table)
@@ -289,7 +289,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, _, _, err = router.route("db1", "")
+		_, _, _, _, _, err = router.route("db1", "")
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRoutingFailed.Equal(err))
 		require.Contains(t, err.Error(), "ambiguous schema routing")
@@ -301,7 +301,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("", "")
+		schema, table, changed, _, _, err := router.route("", "")
 		require.NoError(t, err)
 		require.Empty(t, schema)
 		require.Empty(t, table)
@@ -320,7 +320,7 @@ func TestRouterFirstMatchWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, router.rules, 3)
 
-	schema, table, changed, err := router.route("db1", "users")
+	schema, table, changed, _, _, err := router.route("db1", "users")
 	require.NoError(t, err)
 	require.Equal(t, "catch_all", schema)
 	require.Equal(t, "users", table)
@@ -338,13 +338,13 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("MyDB", "MyTable")
+		schema, table, changed, _, _, err := router.route("MyDB", "MyTable")
 		require.NoError(t, err)
 		require.Equal(t, "target_db", schema)
 		require.Equal(t, "target_table", table)
 		require.True(t, changed)
 
-		schema, table, changed, err = router.route("mydb", "mytable")
+		schema, table, changed, _, _, err = router.route("mydb", "mytable")
 		require.NoError(t, err)
 		require.Equal(t, "mydb", schema)
 		require.Equal(t, "mytable", table)
@@ -359,7 +359,7 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, err := router.route("mydb", "MyTable")
+		schema, table, changed, _, _, err := router.route("mydb", "MyTable")
 		require.NoError(t, err)
 		require.Equal(t, "backup_mydb", schema)
 		require.Equal(t, "MyTable", table)

--- a/downstreamadapter/routing/router_test.go
+++ b/downstreamadapter/routing/router_test.go
@@ -83,7 +83,7 @@ func TestNewRouter(t *testing.T) {
 		router, err := NewRouter(newTestChangefeedID(), true, nil)
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		binding, err := router.route("db1", "t1", 0)
+		binding, err := router.route("db1", "t1")
 		require.NoError(t, err)
 		require.Equal(t, "db1", binding.Target.Schema)
 		require.Equal(t, "t1", binding.Target.Table)
@@ -92,7 +92,7 @@ func TestNewRouter(t *testing.T) {
 		router, err = NewRouter(newTestChangefeedID(), true, []*config.DispatchRule{})
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		binding, err = router.route("db1", "t1", 0)
+		binding, err = router.route("db1", "t1")
 		require.NoError(t, err)
 		require.Equal(t, "db1", binding.Target.Schema)
 		require.Equal(t, "t1", binding.Target.Table)
@@ -148,19 +148,19 @@ func TestNewRouter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, router.rules, 2)
 
-		binding, err := router.route("db1", "orders", 0)
+		binding, err := router.route("db1", "orders")
 		require.NoError(t, err)
 		require.Equal(t, "db1", binding.Target.Schema)
 		require.Equal(t, "orders", binding.Target.Table)
 		require.False(t, binding.routed())
 
-		binding, err = router.route("db2", "orders", 0)
+		binding, err = router.route("db2", "orders")
 		require.NoError(t, err)
 		require.Equal(t, "archive", binding.Target.Schema)
 		require.Equal(t, "orders", binding.Target.Table)
 		require.True(t, binding.routed())
 
-		binding, err = router.route("db3", "users", 0)
+		binding, err = router.route("db3", "users")
 		require.NoError(t, err)
 		require.Equal(t, "db3", binding.Target.Schema)
 		require.Equal(t, "users_bak", binding.Target.Table)
@@ -172,7 +172,7 @@ func TestRouterRoute(t *testing.T) {
 	t.Parallel()
 
 	var zeroRouter Router
-	binding, err := zeroRouter.route("source_db", "source_table", 0)
+	binding, err := zeroRouter.route("source_db", "source_table")
 	require.NoError(t, err)
 	require.Equal(t, "source_db", binding.Target.Schema)
 	require.Equal(t, "source_table", binding.Target.Table)
@@ -247,7 +247,7 @@ func TestRouterRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			binding, err := router.route(tc.sourceSchema, tc.sourceTable, 0)
+			binding, err := router.route(tc.sourceSchema, tc.sourceTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSchema, binding.Target.Schema)
 			require.Equal(t, tc.expectedTable, binding.Target.Table)
@@ -261,7 +261,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("db1", "", 0)
+		binding, err := router.route("db1", "")
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", binding.Target.Schema)
 		require.Empty(t, binding.Target.Table)
@@ -275,7 +275,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("db1", "", 0)
+		binding, err := router.route("db1", "")
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", binding.Target.Schema)
 		require.Empty(t, binding.Target.Table)
@@ -289,7 +289,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = router.route("db1", "", 0)
+		_, err = router.route("db1", "")
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRoutingFailed.Equal(err))
 		require.Contains(t, err.Error(), "ambiguous schema routing")
@@ -301,7 +301,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("", "", 0)
+		binding, err := router.route("", "")
 		require.NoError(t, err)
 		require.Empty(t, binding.Target.Schema)
 		require.Empty(t, binding.Target.Table)
@@ -320,7 +320,7 @@ func TestRouterFirstMatchWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, router.rules, 3)
 
-	binding, err := router.route("db1", "users", 0)
+	binding, err := router.route("db1", "users")
 	require.NoError(t, err)
 	require.Equal(t, "catch_all", binding.Target.Schema)
 	require.Equal(t, "users", binding.Target.Table)
@@ -338,13 +338,13 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("MyDB", "MyTable", 0)
+		binding, err := router.route("MyDB", "MyTable")
 		require.NoError(t, err)
 		require.Equal(t, "target_db", binding.Target.Schema)
 		require.Equal(t, "target_table", binding.Target.Table)
 		require.True(t, binding.routed())
 
-		binding, err = router.route("mydb", "mytable", 0)
+		binding, err = router.route("mydb", "mytable")
 		require.NoError(t, err)
 		require.Equal(t, "mydb", binding.Target.Schema)
 		require.Equal(t, "mytable", binding.Target.Table)
@@ -359,7 +359,7 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		binding, err := router.route("mydb", "MyTable", 0)
+		binding, err := router.route("mydb", "MyTable")
 		require.NoError(t, err)
 		require.Equal(t, "backup_mydb", binding.Target.Schema)
 		require.Equal(t, "MyTable", binding.Target.Table)

--- a/downstreamadapter/routing/router_test.go
+++ b/downstreamadapter/routing/router_test.go
@@ -83,7 +83,7 @@ func TestNewRouter(t *testing.T) {
 		router, err := NewRouter(newTestChangefeedID(), true, nil)
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		schema, table, changed, _, _, err := router.route("db1", "t1")
+		schema, table, changed, err := router.route("db1", "t1")
 		require.NoError(t, err)
 		require.Equal(t, "db1", schema)
 		require.Equal(t, "t1", table)
@@ -92,7 +92,7 @@ func TestNewRouter(t *testing.T) {
 		router, err = NewRouter(newTestChangefeedID(), true, []*config.DispatchRule{})
 		require.NoError(t, err)
 		require.Empty(t, router.rules)
-		schema, table, changed, _, _, err = router.route("db1", "t1")
+		schema, table, changed, err = router.route("db1", "t1")
 		require.NoError(t, err)
 		require.Equal(t, "db1", schema)
 		require.Equal(t, "t1", table)
@@ -148,19 +148,19 @@ func TestNewRouter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, router.rules, 2)
 
-		schema, table, changed, _, _, err := router.route("db1", "orders")
+		schema, table, changed, err := router.route("db1", "orders")
 		require.NoError(t, err)
 		require.Equal(t, "db1", schema)
 		require.Equal(t, "orders", table)
 		require.False(t, changed)
 
-		schema, table, changed, _, _, err = router.route("db2", "orders")
+		schema, table, changed, err = router.route("db2", "orders")
 		require.NoError(t, err)
 		require.Equal(t, "archive", schema)
 		require.Equal(t, "orders", table)
 		require.True(t, changed)
 
-		schema, table, changed, _, _, err = router.route("db3", "users")
+		schema, table, changed, err = router.route("db3", "users")
 		require.NoError(t, err)
 		require.Equal(t, "db3", schema)
 		require.Equal(t, "users_bak", table)
@@ -172,7 +172,7 @@ func TestRouterRoute(t *testing.T) {
 	t.Parallel()
 
 	var zeroRouter Router
-	schema, table, changed, _, _, err := zeroRouter.route("source_db", "source_table")
+	schema, table, changed, err := zeroRouter.route("source_db", "source_table")
 	require.NoError(t, err)
 	require.Equal(t, "source_db", schema)
 	require.Equal(t, "source_table", table)
@@ -247,7 +247,7 @@ func TestRouterRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotTable, gotChanged, _, _, err := router.route(tc.sourceSchema, tc.sourceTable)
+			gotSchema, gotTable, gotChanged, err := router.route(tc.sourceSchema, tc.sourceTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSchema, gotSchema)
 			require.Equal(t, tc.expectedTable, gotTable)
@@ -261,7 +261,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, _, _, err := router.route("db1", "")
+		schema, table, changed, err := router.route("db1", "")
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", schema)
 		require.Empty(t, table)
@@ -275,7 +275,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, _, _, err := router.route("db1", "")
+		schema, table, changed, err := router.route("db1", "")
 		require.NoError(t, err)
 		require.Equal(t, "db1_archive", schema)
 		require.Empty(t, table)
@@ -289,7 +289,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, _, _, _, _, err = router.route("db1", "")
+		_, _, _, err = router.route("db1", "")
 		require.Error(t, err)
 		require.True(t, errors.ErrTableRoutingFailed.Equal(err))
 		require.Contains(t, err.Error(), "ambiguous schema routing")
@@ -301,7 +301,7 @@ func TestRouterRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, _, _, err := router.route("", "")
+		schema, table, changed, err := router.route("", "")
 		require.NoError(t, err)
 		require.Empty(t, schema)
 		require.Empty(t, table)
@@ -320,7 +320,7 @@ func TestRouterFirstMatchWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, router.rules, 3)
 
-	schema, table, changed, _, _, err := router.route("db1", "users")
+	schema, table, changed, err := router.route("db1", "users")
 	require.NoError(t, err)
 	require.Equal(t, "catch_all", schema)
 	require.Equal(t, "users", table)
@@ -338,13 +338,13 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, _, _, err := router.route("MyDB", "MyTable")
+		schema, table, changed, err := router.route("MyDB", "MyTable")
 		require.NoError(t, err)
 		require.Equal(t, "target_db", schema)
 		require.Equal(t, "target_table", table)
 		require.True(t, changed)
 
-		schema, table, changed, _, _, err = router.route("mydb", "mytable")
+		schema, table, changed, err = router.route("mydb", "mytable")
 		require.NoError(t, err)
 		require.Equal(t, "mydb", schema)
 		require.Equal(t, "mytable", table)
@@ -359,7 +359,7 @@ func TestRouterCaseSensitivity(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		schema, table, changed, _, _, err := router.route("mydb", "MyTable")
+		schema, table, changed, err := router.route("mydb", "MyTable")
 		require.NoError(t, err)
 		require.Equal(t, "backup_mydb", schema)
 		require.Equal(t, "MyTable", table)

--- a/logservice/schemastore/validator.go
+++ b/logservice/schemastore/validator.go
@@ -223,6 +223,8 @@ dbLoop:
 
 	verifier.closeAndWait()
 
+	log.Info("verifyTables completed", zap.Int("tableCount", len(verifier.tableInfos)), zap.Uint64("startTs", startTs))
+
 	if verifier.firstErr != nil {
 		return nil, nil, nil, nil, verifier.firstErr
 	}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -270,7 +270,7 @@ var (
 		errors.RFCCodeText("CDC:ErrTableRoutingFailed"),
 	)
 	ErrTableRouteConflict = errors.Normalize(
-		"table route conflict",
+		"table route conflict: target `%s`.`%s` is mapped by both source `%s`.`%s` and source `%s`.`%s`",
 		errors.RFCCodeText("CDC:ErrTableRouteConflict"),
 	)
 	ErrMessageTooLarge = errors.Normalize(

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -269,6 +269,10 @@ var (
 		"table routing failed",
 		errors.RFCCodeText("CDC:ErrTableRoutingFailed"),
 	)
+	ErrTableRouteConflict = errors.Normalize(
+		"table route conflict",
+		errors.RFCCodeText("CDC:ErrTableRouteConflict"),
+	)
 	ErrMessageTooLarge = errors.Normalize(
 		"message is too large. table:%s, length:%d, maxMessageBytes:%d",
 		errors.RFCCodeText("CDC:ErrMessageTooLarge"),

--- a/pkg/errors/helper.go
+++ b/pkg/errors/helper.go
@@ -117,6 +117,7 @@ var changefeedUnRetryableErrors = []*errors.Error{
 	ErrStorageSinkInvalidConfig,
 	ErrInvalidTableRoutingRule,
 	ErrTableRoutingFailed,
+	ErrTableRouteConflict,
 
 	// gc related errors
 	ErrGCTTLExceeded,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5109 

### What is changed and how it works?

add `TargetTableRegistry`, it tracks the route relationship of all replicated tables.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changefeed verification now detects static routing conflicts and rejects conflicting mappings with a clear "table route conflict" error; routing enforces target ownership.
* **Bug Fixes**
  * Schema-only routing ambiguity is reported as an error to prevent unexpected mappings.
* **Tests**
  * Added unit tests for routing registry, conflict detection, and routing behavior.
* **Chores**
  * Verification emits an informational log after table checks complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->