### PR TITLE
etcd: update etcd cluster member correctly

### DIFF
--- a/maintainer/maintainer_controller_test.go
+++ b/maintainer/maintainer_controller_test.go
@@ -125,7 +125,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableMoreThanNodeNum(t *testing.T) {
 	}, ddlSpan, nil, 1000, 0, refresher, common.DefaultKeyspace, false, testBalanceMoveBatchSize)
 
 	nodeID := node.ID("node1")
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		// generate 100 groups
 		totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		for j := 0; j < 4; j++ {
@@ -259,7 +259,7 @@ func TestBalanceGroupsNewNodeAdd_SplitsTableLessThanNodeNum(t *testing.T) {
 	regionCache := appcontext.GetService[*testutil.MockCache](appcontext.RegionCache)
 
 	nodeIDList := []node.ID{"node1", "node2"}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		// generate 100 groups
 		totalSpan := common.TableIDToComparableSpan(common.DefaultKeyspaceID, int64(i))
 		for j := 0; j < 2; j++ {

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -564,7 +564,7 @@ func (checker *healthyChecker) update(eps []string) {
 			lastHealthy := client.lastHealth
 			if time.Since(lastHealthy) > etcdServerOfflineTimeout {
 				log.Info("some etcd server maybe offline", zap.String("endpoint", ep))
-				client.Close()
+				_ = client.Close()
 				checker.Delete(ep)
 			}
 			if time.Since(lastHealthy) > etcdServerDisconnectedTimeout {
@@ -580,7 +580,7 @@ func (checker *healthyChecker) update(eps []string) {
 		ep := key.(string)
 		if _, exist := updateEps[ep]; !exist {
 			if client, ok := value.(*healthyClient); ok {
-				client.Close()
+				_ = client.Close()
 			}
 			checker.Delete(key)
 		}

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -455,7 +455,7 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 			select {
 			case <-client.Ctx().Done():
 				log.Info("etcd client is closed, exit health check goroutine")
-				checker.Range(func(key, value interface{}) bool {
+				checker.Range(func(key, value any) bool {
 					client := value.(*healthyClient)
 					client.Close()
 					return true
@@ -523,15 +523,15 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 	// See https://github.com/etcd-io/etcd/blob/85b640cee793e25f3837c47200089d14a8392dc7/etcdctl/ctlv3/command/ep_command.go#L105-L145
 	var wg sync.WaitGroup
 	count := 0
-	checker.Range(func(key, value interface{}) bool {
+	checker.Range(func(key, value any) bool {
 		count++
 		return true
 	})
 	hch := make(chan string, count)
 	healthyList := make([]string, 0, count)
-	checker.Range(func(key, value interface{}) bool {
+	checker.Range(func(key, value any) bool {
 		wg.Add(1)
-		go func(key, value interface{}) {
+		go func(key, value any) {
 			defer wg.Done()
 			ep := key.(string)
 			client := value.(*healthyClient)
@@ -576,7 +576,7 @@ func (checker *healthyChecker) update(eps []string) {
 		}
 		checker.addClient(ep, time.Now())
 	}
-	checker.Range(func(key, value interface{}) bool {
+	checker.Range(func(key, value any) bool {
 		ep := key.(string)
 		if _, exist := updateEps[ep]; !exist {
 			if client, ok := value.(*healthyClient); ok {

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -455,7 +455,7 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 			select {
 			case <-client.Ctx().Done():
 				log.Info("etcd client is closed, exit health check goroutine")
-				checker.Range(func(key, value any) bool {
+				checker.Range(func(_, value any) bool {
 					client := value.(*healthyClient)
 					client.Close()
 					return true
@@ -523,7 +523,7 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 	// See https://github.com/etcd-io/etcd/blob/85b640cee793e25f3837c47200089d14a8392dc7/etcdctl/ctlv3/command/ep_command.go#L105-L145
 	var wg sync.WaitGroup
 	count := 0
-	checker.Range(func(_, value any) bool {
+	checker.Range(func(_, _ any) bool {
 		count++
 		return true
 	})

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -523,7 +523,7 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 	// See https://github.com/etcd-io/etcd/blob/85b640cee793e25f3837c47200089d14a8392dc7/etcdctl/ctlv3/command/ep_command.go#L105-L145
 	var wg sync.WaitGroup
 	count := 0
-	checker.Range(func(key, value any) bool {
+	checker.Range(func(_, value any) bool {
 		count++
 		return true
 	})

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -535,7 +535,7 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 			defer wg.Done()
 			ep := key.(string)
 			client := value.(*healthyClient)
-			if IsHealthy(ctx, client.Client) {
+			if isHealthy(ctx, client.Client) {
 				hch <- ep
 				checker.Store(ep, &healthyClient{
 					Client:     client.Client,
@@ -555,23 +555,37 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 }
 
 func (checker *healthyChecker) update(eps []string) {
+	updateEps := make(map[string]struct{}, len(eps))
 	for _, ep := range eps {
+		updateEps[ep] = struct{}{}
 		// check if client exists, if not, create one, if exists, check if it's offline or disconnected.
-		if client, ok := checker.Load(ep); ok {
-			lastHealthy := client.(*healthyClient).lastHealth
+		if value, ok := checker.Load(ep); ok {
+			client := value.(*healthyClient)
+			lastHealthy := client.lastHealth
 			if time.Since(lastHealthy) > etcdServerOfflineTimeout {
 				log.Info("some etcd server maybe offline", zap.String("endpoint", ep))
+				client.Close()
 				checker.Delete(ep)
 			}
 			if time.Since(lastHealthy) > etcdServerDisconnectedTimeout {
 				// try to reset client endpoint to trigger reconnect
-				client.(*healthyClient).SetEndpoints([]string{}...)
-				client.(*healthyClient).SetEndpoints(ep)
+				client.SetEndpoints([]string{}...)
+				client.SetEndpoints(ep)
 			}
 			continue
 		}
 		checker.addClient(ep, time.Now())
 	}
+	checker.Range(func(key, value interface{}) bool {
+		ep := key.(string)
+		if _, exist := updateEps[ep]; !exist {
+			if client, ok := value.(*healthyClient); ok {
+				client.Close()
+			}
+			checker.Delete(key)
+		}
+		return true
+	})
 }
 
 func (checker *healthyChecker) addClient(ep string, lastHealth time.Time) {
@@ -605,8 +619,8 @@ func syncUrls(client *clientv3.Client) []string {
 	return eps
 }
 
-// IsHealthy checks if the etcd is healthy.
-func IsHealthy(ctx context.Context, client *clientv3.Client) bool {
+// isHealthy checks if the etcd is healthy.
+func isHealthy(ctx context.Context, client *clientv3.Client) bool {
 	timeout := etcdClientTimeoutDuration
 	ctx, cancel := context.WithTimeout(clientv3.WithRequireLeader(ctx), timeout)
 	defer cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5137

### What is changed and how it works?
When updating etcd client URLs, remove the client that is not a member of the etcd cluster.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved etcd client health-checking and endpoint reconciliation: more reliable detection of healthy endpoints, automatic addition of new endpoints, and cleanup of stale connections; permission-denied responses treated as healthy to avoid false failures.
* **Tests**
  * Simplified loop constructs in two balancing tests for more concise iteration; no behavioral changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingcap/ticdc/pull/5138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->