### PR TITLE
storage: improve cloud storage sink reliability

### DIFF
--- a/api/v2/model.go
+++ b/api/v2/model.go
@@ -507,6 +507,8 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				WorkerCount:          c.Sink.CloudStorageConfig.WorkerCount,
 				FlushInterval:        c.Sink.CloudStorageConfig.FlushInterval,
 				FileSize:             c.Sink.CloudStorageConfig.FileSize,
+				SpoolDiskQuota:       c.Sink.CloudStorageConfig.SpoolDiskQuota,
+				SpoolBaseDir:         c.Sink.CloudStorageConfig.SpoolBaseDir,
 				OutputColumnID:       c.Sink.CloudStorageConfig.OutputColumnID,
 				FileExpirationDays:   c.Sink.CloudStorageConfig.FileExpirationDays,
 				FileCleanupCronSpec:  c.Sink.CloudStorageConfig.FileCleanupCronSpec,
@@ -868,6 +870,8 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				WorkerCount:          cloned.Sink.CloudStorageConfig.WorkerCount,
 				FlushInterval:        cloned.Sink.CloudStorageConfig.FlushInterval,
 				FileSize:             cloned.Sink.CloudStorageConfig.FileSize,
+				SpoolDiskQuota:       cloned.Sink.CloudStorageConfig.SpoolDiskQuota,
+				SpoolBaseDir:         cloned.Sink.CloudStorageConfig.SpoolBaseDir,
 				OutputColumnID:       cloned.Sink.CloudStorageConfig.OutputColumnID,
 				FileExpirationDays:   cloned.Sink.CloudStorageConfig.FileExpirationDays,
 				FileCleanupCronSpec:  cloned.Sink.CloudStorageConfig.FileCleanupCronSpec,
@@ -1510,6 +1514,8 @@ type CloudStorageConfig struct {
 	WorkerCount          *int    `json:"worker_count,omitempty"`
 	FlushInterval        *string `json:"flush_interval,omitempty"`
 	FileSize             *int    `json:"file_size,omitempty"`
+	SpoolDiskQuota       *int64  `json:"spool_disk_quota,omitempty"`
+	SpoolBaseDir         *string `json:"spool_base_dir,omitempty"`
 	OutputColumnID       *bool   `json:"output_column_id,omitempty"`
 	FileExpirationDays   *int    `json:"file_expiration_days,omitempty"`
 	FileCleanupCronSpec  *string `json:"file_cleanup_cron_spec,omitempty"`

--- a/api/v2/model_test.go
+++ b/api/v2/model_test.go
@@ -38,6 +38,8 @@ func TestReplicaConfigConversion(t *testing.T) {
 		Sink: &SinkConfig{
 			CloudStorageConfig: &CloudStorageConfig{
 				UseTableIDAsPath: util.AddressOf(true),
+				SpoolDiskQuota:   util.AddressOf(int64(1024)),
+				SpoolBaseDir:     util.AddressOf("/tmp/ticdc-spool"),
 			},
 		},
 		Mounter: &MounterConfig{
@@ -69,6 +71,8 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.True(t, util.GetOrZero(internalCfg.EnableTableMonitor))
 	require.True(t, util.GetOrZero(internalCfg.BDRMode))
 	require.True(t, util.GetOrZero(internalCfg.Sink.CloudStorageConfig.UseTableIDAsPath))
+	require.Equal(t, int64(1024), util.GetOrZero(internalCfg.Sink.CloudStorageConfig.SpoolDiskQuota))
+	require.Equal(t, "/tmp/ticdc-spool", util.GetOrZero(internalCfg.Sink.CloudStorageConfig.SpoolBaseDir))
 	require.Equal(t, internalCfg.Mounter.WorkerNum, *apiCfg.Mounter.WorkerNum)
 	require.True(t, util.GetOrZero(internalCfg.Scheduler.EnableTableAcrossNodes))
 	require.Equal(t, 1000, util.GetOrZero(internalCfg.Scheduler.RegionThreshold))
@@ -94,6 +98,8 @@ func TestReplicaConfigConversion(t *testing.T) {
 	require.True(t, *apiCfgBack.ForceReplicate)
 	require.True(t, *apiCfgBack.IgnoreIneligibleTable)
 	require.True(t, *apiCfgBack.Sink.CloudStorageConfig.UseTableIDAsPath)
+	require.Equal(t, int64(1024), *apiCfgBack.Sink.CloudStorageConfig.SpoolDiskQuota)
+	require.Equal(t, "/tmp/ticdc-spool", *apiCfgBack.Sink.CloudStorageConfig.SpoolBaseDir)
 	require.Equal(t, 16, *apiCfgBack.Mounter.WorkerNum)
 	require.True(t, *apiCfgBack.Scheduler.EnableTableAcrossNodes)
 	require.Equal(t, "correctness", *apiCfgBack.Integrity.IntegrityCheckLevel)

--- a/downstreamadapter/sink/cloudstorage/spool/spool.go
+++ b/downstreamadapter/sink/cloudstorage/spool/spool.go
@@ -753,10 +753,15 @@ func (s *Spool) rotateLocked() error {
 }
 
 func (s *Spool) removeSegmentLocked(seg *segment) {
-	if err := seg.file.Close(); err != nil {
-		log.Warn("close spool segment file failed",
-			zap.String("keyspace", s.keyspace), zap.String("changefeed", s.changefeed),
-			zap.Error(err))
+	if seg == nil {
+		return
+	}
+	if seg.file != nil {
+		if err := seg.file.Close(); err != nil {
+			log.Warn("close spool segment file failed",
+				zap.String("keyspace", s.keyspace), zap.String("changefeed", s.changefeed),
+				zap.Error(err))
+		}
 	}
 	if err := os.Remove(seg.path); err != nil {
 		log.Warn(

--- a/downstreamadapter/sink/cloudstorage/spool/spool.go
+++ b/downstreamadapter/sink/cloudstorage/spool/spool.go
@@ -625,18 +625,7 @@ func (s *Spool) Release(entry *Entry) {
 		if seg != nil {
 			seg.refCnt--
 			if seg.refCnt == 0 && s.activeSegment != seg {
-				if err := seg.file.Close(); err != nil {
-					log.Warn("close spool segment file failed",
-						zap.String("keyspace", s.keyspace), zap.String("changefeed", s.changefeed),
-						zap.Error(err))
-				}
-				if err := os.Remove(seg.path); err != nil {
-					log.Warn(
-						"remove spool segment file failed",
-						zap.String("keyspace", s.keyspace), zap.String("changefeed", s.changefeed),
-						zap.String("path", seg.path), zap.Error(err))
-				}
-				delete(s.segments, seg.id)
+				s.removeSegmentLocked(seg)
 				s.metricSegmentCount.Set(float64(len(s.segments)))
 			}
 		}
@@ -734,6 +723,7 @@ func (s *Spool) getWritableSegmentLocked(needBytes int64) (*segment, error) {
 }
 
 func (s *Spool) rotateLocked() error {
+	oldSegment := s.activeSegment
 	s.nextSegmentID++
 	segmentID := s.nextSegmentID
 	path := filepath.Join(
@@ -754,9 +744,27 @@ func (s *Spool) rotateLocked() error {
 	}
 	s.segments[segmentID] = seg
 	s.activeSegment = seg
+	if oldSegment != nil && oldSegment.refCnt == 0 {
+		s.removeSegmentLocked(oldSegment)
+	}
 	s.metricRotatedCount.Inc()
 	s.metricSegmentCount.Set(float64(len(s.segments)))
 	return nil
+}
+
+func (s *Spool) removeSegmentLocked(seg *segment) {
+	if err := seg.file.Close(); err != nil {
+		log.Warn("close spool segment file failed",
+			zap.String("keyspace", s.keyspace), zap.String("changefeed", s.changefeed),
+			zap.Error(err))
+	}
+	if err := os.Remove(seg.path); err != nil {
+		log.Warn(
+			"remove spool segment file failed",
+			zap.String("keyspace", s.keyspace), zap.String("changefeed", s.changefeed),
+			zap.String("path", seg.path), zap.Error(err))
+	}
+	delete(s.segments, seg.id)
 }
 
 func takePostFlushCallbacks(entry *Entry) []func() {

--- a/downstreamadapter/sink/cloudstorage/spool/spool_test.go
+++ b/downstreamadapter/sink/cloudstorage/spool/spool_test.go
@@ -366,6 +366,41 @@ func TestCloseRemovesOwnedChangefeedDir(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRotateRemovesReleasedActiveSegment(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := commonType.NewChangefeedID4Test("test", "spool")
+	manager, err := New(
+		changefeedID,
+		WithDiskQuotaBytes(1024),
+		WithRootDir(t.TempDir()),
+		WithSegmentBytes(40),
+		WithMemoryRatio(0.01),
+	)
+	require.NoError(t, err)
+	defer manager.Close()
+
+	firstEntry, err := manager.Enqueue([]*common.Message{newTestMessage("first-entry", 1)}, nil)
+	require.NoError(t, err)
+	require.True(t, firstEntry.IsSpilled())
+
+	firstSegmentPath := filepath.Join(manager.workDir, "segment-000001.log")
+	_, err = os.Stat(firstSegmentPath)
+	require.NoError(t, err)
+
+	manager.Release(firstEntry)
+
+	secondEntry, err := manager.Enqueue([]*common.Message{newTestMessage("second-entry", 1)}, nil)
+	require.NoError(t, err)
+	require.True(t, secondEntry.IsSpilled())
+	defer manager.Release(secondEntry)
+
+	_, err = os.Stat(firstSegmentPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(manager.workDir, "segment-000002.log"))
+	require.NoError(t, err)
+}
+
 func TestEnqueueSpillsWhenSerializedBatchExceedsMemoryQuota(t *testing.T) {
 	t.Parallel()
 

--- a/downstreamadapter/sink/cloudstorage/writer.go
+++ b/downstreamadapter/sink/cloudstorage/writer.go
@@ -246,7 +246,8 @@ func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath 
 		if inErr != nil {
 			return 0, 0, inErr
 		}
-		defer func() {
+
+		closeWriter := func() error {
 			closeErr := writer.Close(ctx)
 			if closeErr != nil {
 				log.Warn("failed to close writer",
@@ -256,8 +257,13 @@ func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath 
 					zap.Int("shardID", d.shardID),
 					zap.Error(closeErr))
 			}
-		}()
+			return closeErr
+		}
 		if _, retErr = writer.Write(ctx, payload.data); retErr != nil {
+			_ = closeWriter()
+			return 0, 0, retErr
+		}
+		if retErr = closeWriter(); retErr != nil {
 			return 0, 0, retErr
 		}
 		return payload.rowsCount, payload.nBytes, nil

--- a/downstreamadapter/sink/cloudstorage/writer.go
+++ b/downstreamadapter/sink/cloudstorage/writer.go
@@ -229,9 +229,9 @@ func (d *writer) discardPayload(payload *payload) {
 func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath string, payload *payload) error {
 	keyspace := d.changeFeedID.Keyspace()
 	changefeed := d.changeFeedID.Name()
-
 	start := time.Now()
-	if err := d.statistics.RecordBatchExecution(func() (_ int, _ int64, retErr error) {
+
+	err := d.statistics.RecordBatchExecution(func() (int, int64, error) {
 		if d.config.FlushConcurrency <= 1 {
 			err := d.storage.WriteFile(ctx, dataFilePath, payload.data)
 			if err != nil {
@@ -240,38 +240,38 @@ func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath 
 			return payload.rowsCount, payload.nBytes, nil
 		}
 
-		writer, inErr := d.storage.Create(ctx, dataFilePath, &storage.WriterOption{
+		writer, err := d.storage.Create(ctx, dataFilePath, &storage.WriterOption{
 			Concurrency: d.config.FlushConcurrency,
 		})
-		if inErr != nil {
-			return 0, 0, inErr
+		if err != nil {
+			return 0, 0, err
 		}
 
-		closeWriter := func() error {
+		_, err = writer.Write(ctx, payload.data)
+		if err != nil {
 			closeErr := writer.Close(ctx)
 			if closeErr != nil {
-				log.Warn("failed to close writer",
-					zap.String("keyspace", keyspace),
-					zap.String("changefeed", changefeed),
-					zap.Any("table", payload.tableInfo.TableName),
-					zap.Int("shardID", d.shardID),
-					zap.Error(closeErr))
+				log.Warn("failed to close writer after write failure",
+					zap.String("keyspace", keyspace), zap.String("changefeed", changefeed),
+					zap.String("path", dataFilePath), zap.Error(closeErr))
 			}
-			return closeErr
+			return 0, 0, err
 		}
-		if _, retErr = writer.Write(ctx, payload.data); retErr != nil {
-			_ = closeWriter()
-			return 0, 0, retErr
-		}
-		if retErr = closeWriter(); retErr != nil {
-			return 0, 0, retErr
+
+		if err = writer.Close(ctx); err != nil {
+			log.Error("failed to close concurrency writer",
+				zap.String("keyspace", keyspace), zap.String("changefeed", changefeed),
+				zap.String("path", dataFilePath), zap.Error(err))
+			return 0, 0, err
 		}
 		return payload.rowsCount, payload.nBytes, nil
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 
-	if err := d.storage.WriteFile(ctx, indexFilePath, []byte(path.Base(dataFilePath)+"\n")); err != nil {
+	err = d.storage.WriteFile(ctx, indexFilePath, []byte(path.Base(dataFilePath)+"\n"))
+	if err != nil {
 		log.Error("failed to write index file to external storage",
 			zap.String("keyspace", keyspace),
 			zap.String("changefeed", changefeed),

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -543,11 +543,34 @@ type failOnIndexStorage struct {
 	storage.ExternalStorage
 }
 
+type failOnCloseStorage struct {
+	storage.ExternalStorage
+}
+
+type failOnCloseWriter struct {
+	storage.ExternalFileWriter
+}
+
 func (s *failOnIndexStorage) WriteFile(ctx context.Context, name string, data []byte) error {
 	if strings.HasSuffix(name, ".index") {
 		return errors.New("index write failed")
 	}
 	return s.ExternalStorage.WriteFile(ctx, name, data)
+}
+
+func (s *failOnCloseStorage) Create(
+	ctx context.Context, name string, option *storage.WriterOption,
+) (storage.ExternalFileWriter, error) {
+	writer, err := s.ExternalStorage.Create(ctx, name, option)
+	if err != nil {
+		return nil, err
+	}
+	return &failOnCloseWriter{ExternalFileWriter: writer}, nil
+}
+
+func (w *failOnCloseWriter) Close(ctx context.Context) error {
+	_ = w.ExternalFileWriter.Close(ctx)
+	return errors.New("writer close failed")
 }
 
 func TestWriterIndexWriteError(t *testing.T) {
@@ -613,4 +636,80 @@ func TestWriterIndexWriteError(t *testing.T) {
 
 	err = <-done
 	require.ErrorContains(t, err, "index write failed")
+}
+
+func TestWriterDataFileCloseError(t *testing.T) {
+	ctx := context.Background()
+	parentDir := t.TempDir()
+	uri := fmt.Sprintf("file:///%s?flush-interval=2s", parentDir)
+	baseStorage, err := util.GetExternalStorageWithDefaultTimeout(ctx, uri)
+	require.NoError(t, err)
+	storage := &failOnCloseStorage{ExternalStorage: baseStorage}
+
+	sinkURI, err := url.Parse(uri)
+	require.NoError(t, err)
+	cfg := cloudstorage.NewConfig()
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.DateSeparator = util.AddressOf(config.DateSeparatorNone.String())
+	err = cfg.Apply(context.TODO(), sinkURI, replicaConfig.Sink, true)
+	require.NoError(t, err)
+	cfg.FileIndexWidth = 6
+	cfg.FlushConcurrency = 2
+	cfg.FlushInterval = time.Hour
+
+	changefeedID := commonType.NewChangefeedID4Test("test", "writer-close-error")
+	statistics := metrics.NewStatistics(changefeedID, t.Name())
+	pdlock := pdutil.NewMonotonicClock(clock.New())
+	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
+	mockPDClock := pdutil.NewClock4Test()
+	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	spoolBuffer := newTestSpool(t, changefeedID, cfg)
+	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
+
+	tableInfo := commonType.WrapTableInfo("test", &model.TableInfo{
+		ID:   100,
+		Name: ast.NewCIStr("table1"),
+		Columns: []*model.ColumnInfo{
+			{ID: 1, Name: ast.NewCIStr("c1"), FieldType: *types.NewFieldType(mysql.TypeLong)},
+		},
+	})
+	dispatcherID := commonType.NewDispatcherID()
+	task := newDMLTask(
+		cloudstorage.VersionedTableName{
+			TableNameWithPhysicTableID: commonType.TableName{
+				Schema:  "test",
+				Table:   "table1",
+				TableID: 100,
+			},
+			TableInfoVersion: 99,
+			DispatcherID:     dispatcherID,
+		},
+		&commonEvent.DMLEvent{
+			PhysicalTableID: 100,
+			TableInfo:       tableInfo,
+		},
+	)
+
+	var callbackCount atomic.Int64
+	msg := common.NewMsg(nil, []byte(`{"id":1}`))
+	msg.SetRowsCount(1)
+	msg.Callback = func() {
+		callbackCount.Add(1)
+	}
+	task.encodedMsgs = []*common.Message{msg}
+	require.NoError(t, d.enqueueTask(ctx, task))
+	require.NoError(t, d.enqueueTask(ctx, newFlushTask(dispatcherID, 100)))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.run(ctx)
+	}()
+
+	err = <-done
+	require.ErrorContains(t, err, "writer close failed")
+	require.Equal(t, int64(0), callbackCount.Load())
+
+	indexFilePath := path.Join(parentDir, "test/table1/99/meta", fmt.Sprintf("CDC_%s.index", dispatcherID.String()))
+	_, err = os.Stat(indexFilePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -409,6 +409,9 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 		f.fileIndex[tbl].prevDate = f.fileIndex[tbl].currDate
 		f.fileIndex[tbl].index = 0
 	}
+	// A local file index can lag behind existing data files after sink restart or
+	// dispatcher ownership transfer. Probe consecutive file names from the index
+	// until the first missing one.
 	for {
 		f.fileIndex[tbl].index++
 		name := generateDataFileName(f.config.EnableTableAcrossNodes, tbl.DispatcherID.String(), f.fileIndex[tbl].index, f.extension, f.config.FileIndexWidth)
@@ -428,9 +431,6 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 				zap.String("dataFile", dataFile))
 			newIndexFile = false
 		}
-		// Avoid listing the whole object directory. In the normal partial-success
-		// case only the next candidate exists, so one more existence probe moves
-		// us past the orphan data file.
 	}
 }
 

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -409,27 +409,29 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 		f.fileIndex[tbl].prevDate = f.fileIndex[tbl].currDate
 		f.fileIndex[tbl].index = 0
 	}
-	f.fileIndex[tbl].index++
-	name := generateDataFileName(f.config.EnableTableAcrossNodes, tbl.DispatcherID.String(), f.fileIndex[tbl].index, f.extension, f.config.FileIndexWidth)
-	dataFile := path.Join(dir, name)
-	exist, err := f.storage.FileExists(ctx, dataFile)
-	if err != nil {
-		return "", err
+	for {
+		f.fileIndex[tbl].index++
+		name := generateDataFileName(f.config.EnableTableAcrossNodes, tbl.DispatcherID.String(), f.fileIndex[tbl].index, f.extension, f.config.FileIndexWidth)
+		dataFile := path.Join(dir, name)
+		exist, err := f.storage.FileExists(ctx, dataFile)
+		if err != nil {
+			return "", err
+		}
+		if !exist {
+			return dataFile, nil
+		}
+		if newIndexFile {
+			log.Warn("the data file exists and the index file is stale",
+				zap.String("keyspace", f.changefeedID.Keyspace()),
+				zap.String("changefeedID", f.changefeedID.Name()),
+				zap.Any("versionedTableName", tbl),
+				zap.String("dataFile", dataFile))
+			newIndexFile = false
+		}
+		// Avoid listing the whole object directory. In the normal partial-success
+		// case only the next candidate exists, so one more existence probe moves
+		// us past the orphan data file.
 	}
-	if !exist {
-		return dataFile, nil
-	}
-	if newIndexFile {
-		log.Warn("the data file exists and the index file is stale",
-			zap.String("keyspace", f.changefeedID.Keyspace()),
-			zap.String("changefeedID", f.changefeedID.Name()),
-			zap.Any("versionedTableName", tbl),
-			zap.String("dataFile", dataFile))
-	}
-	// if the file already exists, which means the fileIndex is stale,
-	// we need to delete the file index in memory and re-generate the file path with the updated file index until we find a non-existing file path.
-	delete(f.fileIndex, tbl)
-	return f.GenerateDataFilePath(ctx, tbl, date)
 }
 
 func (f *FilePathGenerator) generateDataDirPath(tbl VersionedTableName, date string) (string, error) {

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -389,7 +389,7 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 	if err != nil {
 		return "", err
 	}
-	newIndexFile := false
+	loadedIndexFile := false
 	if idx, ok := f.fileIndex[tbl]; !ok {
 		fileIdx, err := f.getFileIdxFromIndexFile(ctx, tbl, date)
 		if err != nil {
@@ -400,7 +400,7 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 			currDate: date,
 			index:    fileIdx,
 		}
-		newIndexFile = true
+		loadedIndexFile = true
 	} else {
 		idx.currDate = date
 	}
@@ -409,9 +409,11 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 		f.fileIndex[tbl].prevDate = f.fileIndex[tbl].currDate
 		f.fileIndex[tbl].index = 0
 	}
+	triedIndexResync := loadedIndexFile
 	// A local file index can lag behind existing data files after sink restart or
-	// dispatcher ownership transfer. Probe consecutive file names from the index
-	// until the first missing one.
+	// dispatcher ownership transfer. If the local cache collides with an existing
+	// data file, reload the index file once before falling back to consecutive
+	// probes for the index-stale recovery path.
 	for {
 		f.fileIndex[tbl].index++
 		name := generateDataFileName(f.config.EnableTableAcrossNodes, tbl.DispatcherID.String(), f.fileIndex[tbl].index, f.extension, f.config.FileIndexWidth)
@@ -423,13 +425,24 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 		if !exist {
 			return dataFile, nil
 		}
-		if newIndexFile {
+		if !triedIndexResync {
+			fileIdx, err := f.getFileIdxFromIndexFile(ctx, tbl, date)
+			if err != nil {
+				return "", err
+			}
+			triedIndexResync = true
+			if fileIdx >= f.fileIndex[tbl].index {
+				f.fileIndex[tbl].index = fileIdx
+				continue
+			}
+		}
+		if loadedIndexFile {
 			log.Warn("the data file exists and the index file is stale",
 				zap.String("keyspace", f.changefeedID.Keyspace()),
 				zap.String("changefeedID", f.changefeedID.Name()),
 				zap.Any("versionedTableName", tbl),
 				zap.String("dataFile", dataFile))
-			newIndexFile = false
+			loadedIndexFile = false
 		}
 	}
 }

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/pdutil"
 	"github.com/pingcap/ticdc/pkg/util"
+	"github.com/pingcap/tidb/br/pkg/storage"
 	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -36,6 +37,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
 )
+
+type countFileExistsStorage struct {
+	storage.ExternalStorage
+	fileExistsCount int
+}
+
+func (s *countFileExistsStorage) FileExists(ctx context.Context, name string) (bool, error) {
+	s.fileExistsCount++
+	return s.ExternalStorage.FileExists(ctx, name)
+}
 
 func testFilePathGenerator(ctx context.Context, t *testing.T, dir string) *FilePathGenerator {
 	uri := fmt.Sprintf("file:///%s?flush-interval=2s", dir)
@@ -250,8 +261,7 @@ func TestGenerateDataFilePathWithIndexFile(t *testing.T) {
 func TestGenerateDataFilePathResyncIndexFile(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+	ctx := t.Context()
 
 	dir := t.TempDir()
 	f1 := testFilePathGenerator(ctx, t, dir)
@@ -280,23 +290,29 @@ func TestGenerateDataFilePathResyncIndexFile(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_000001.json", dispatcherID.String()), dataFilePath)
 	err = f1.storage.WriteFile(ctx, dataFilePath, []byte("test1"))
 	require.NoError(t, err)
-	err = f1.storage.WriteFile(ctx, indexFilePath, []byte(fmt.Sprintf("CDC_%s_000001.json\n", dispatcherID.String())))
+	err = f1.storage.WriteFile(ctx, indexFilePath, fmt.Appendf(nil, "CDC_%s_000001.json\n", dispatcherID.String()))
 	require.NoError(t, err)
 
-	// 2) f2 continues from index file and generates CDC_..._000002, then updates index file.
-	dataFilePath, err = f2.GenerateDataFilePath(ctx, table, date)
-	require.NoError(t, err)
-	err = f2.storage.WriteFile(ctx, dataFilePath, []byte("test2"))
-	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_000002.json", dispatcherID.String()), dataFilePath)
-	err = f2.storage.WriteFile(ctx, indexFilePath, []byte(fmt.Sprintf("CDC_%s_000002.json\n", dispatcherID.String())))
-	require.NoError(t, err)
+	// 2) f2 continues from index file and generates CDC_..._000002 to CDC_..._000005,
+	// then updates index file.
+	for i := 2; i <= 5; i++ {
+		dataFilePath, err = f2.GenerateDataFilePath(ctx, table, date)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_%06d.json", dispatcherID.String(), i), dataFilePath)
+		err = f2.storage.WriteFile(ctx, dataFilePath, []byte("test"))
+		require.NoError(t, err)
+		err = f2.storage.WriteFile(ctx, indexFilePath, fmt.Appendf(nil, "CDC_%s_%06d.json\n", dispatcherID.String(), i))
+		require.NoError(t, err)
+	}
 
 	// 3) f1 generates again after being scheduled back. It must reconcile with index file and
-	//    generate CDC_..._000003 instead of overwriting CDC_..._000002.
+	//    generate CDC_..._000006 instead of probing every existing data file one by one.
+	countStorage := &countFileExistsStorage{ExternalStorage: f1.storage}
+	f1.storage = countStorage
 	dataFilePath, err = f1.GenerateDataFilePath(ctx, table, date)
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_000003.json", dispatcherID.String()), dataFilePath)
+	require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_000006.json", dispatcherID.String()), dataFilePath)
+	require.LessOrEqual(t, countStorage.fileExistsCount, 3)
 }
 
 func TestGenerateDataFilePathReconcilesStaleIndexFile(t *testing.T) {

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -299,6 +299,39 @@ func TestGenerateDataFilePathResyncIndexFile(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_000003.json", dispatcherID.String()), dataFilePath)
 }
 
+func TestGenerateDataFilePathReconcilesStaleIndexFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	dir := t.TempDir()
+	f := testFilePathGenerator(ctx, t, dir)
+
+	dispatcherID := commonType.NewDispatcherID()
+	table := VersionedTableName{
+		TableNameWithPhysicTableID: commonType.TableName{
+			Schema: "test",
+			Table:  "table1",
+		},
+		TableInfoVersion: 5,
+		DispatcherID:     dispatcherID,
+	}
+	f.versionMap[table] = table.TableInfoVersion
+
+	date := ""
+	firstDataFile := fmt.Sprintf("test/table1/5/CDC_%s_000001.json", dispatcherID.String())
+	secondDataFile := fmt.Sprintf("test/table1/5/CDC_%s_000002.json", dispatcherID.String())
+	indexFilePath, err := f.GenerateIndexFilePath(table, date)
+	require.NoError(t, err)
+	require.NoError(t, f.storage.WriteFile(ctx, firstDataFile, []byte("test1")))
+	require.NoError(t, f.storage.WriteFile(ctx, secondDataFile, []byte("test2")))
+	require.NoError(t, f.storage.WriteFile(ctx, indexFilePath, fmt.Appendf(nil, "CDC_%s_000001.json\n", dispatcherID.String())))
+
+	dataFilePath, err := f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("test/table1/5/CDC_%s_000003.json", dispatcherID.String()), dataFilePath)
+}
+
 func TestIsSchemaFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5257

This PR fixes several cloud storage sink reliability issues:

- data writer `Close` failures could be logged but not returned, allowing index files and flush callbacks to advance after an incomplete upload;
- local file indexes can become stale after sink restart or dispatcher ownership transfer, which may collide with existing data files or trigger repeated object-store `FileExists` checks;
- released active spool segments could remain on disk after rotation, making real disk usage diverge from spool quota accounting;
- API v2 could not expose or preserve `spool-disk-quota` and `spool-base-dir` in replica config conversion.

### What is changed and how it works?

- Treat data writer `Close` errors as flush failures before writing the index file.
- Reconcile stale data file indexes without listing object directories:
  - if the local cache collides with an existing data file, reload the remote index once;
  - if the remote index itself is stale, probe consecutive file names until the first missing one.
- Remove released old active spool segments after rotating to a new segment.
- Add API v2 `spool_disk_quota` and `spool_base_dir` fields with round-trip conversion.

### Check List

#### Tests

- Unit test
- `go test ./api/v2`
- `go test ./pkg/sink/cloudstorage`
- `go test ./downstreamadapter/sink/cloudstorage/spool`
- `go test ./downstreamadapter/sink/cloudstorage -run 'TestWriter(DataFileCloseError|IndexWriteError)'`
- `tools/bin/golangci-lint run --timeout 10m0s --new-from-rev=upstream/master`

#### Questions

##### Will it cause performance regression or break compatibility?

No. API fields are additive. Stale index recovery avoids directory listing, and ownership-transfer recovery reloads the remote index once instead of linearly probing many existing data files.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix cloud storage sink file handling and spool cleanup reliability.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cloud storage spool configuration parameters.

* **Bug Fixes**
  * Ensure released spool segments are removed after rotation.
  * Improve writer close/error handling to surface close failures.
  * Refine data-file path generation to reconcile stale indexes without overwriting.

* **Tests**
  * Added tests covering segment rotation removal, writer close failure, and path reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->