### PR TITLE
chore: update Go to 1.25.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ TiCDC can be built on the following operating systems:
 * Linux
 * MacOS
 
-Install GoLang 1.25.8
+Install GoLang 1.25.10
 
 ```bash
 # Linux
-wget https://go.dev/dl/go1.25.8.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.25.10.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.25.10.linux-amd64.tar.gz
 
 # MacOS
-curl -O https://go.dev/dl/go1.25.8.darwin-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.8.darwin-amd64.tar.gz
+curl -O https://go.dev/dl/go1.25.10.darwin-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.25.10.darwin-amd64.tar.gz
 
 
 export PATH=$PATH:/usr/local/go/bin

--- a/deployments/integration-test.Dockerfile
+++ b/deployments/integration-test.Dockerfile
@@ -29,7 +29,7 @@ RUN ./download-integration-test-binaries.sh $BRANCH $COMMUNITY $VERSION $OS $ARC
 RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.8
+ENV GOLANG_VERSION 1.25.10
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/deployments/next-gen-local-integration-test.Dockerfile
+++ b/deployments/next-gen-local-integration-test.Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /root/download
 #RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.8
+ENV GOLANG_VERSION 1.25.10
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/ticdc
 
-go 1.25.8
+go 1.25.10
 
 require (
 	cloud.google.com/go/kms v1.15.8

--- a/tests/integration_tests/debezium01/go.mod
+++ b/tests/integration_tests/debezium01/go.mod
@@ -1,6 +1,6 @@
 module github.com/breezewish/checker
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-cdc/_tools
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0

--- a/tools/workload/go.mod
+++ b/tools/workload/go.mod
@@ -1,6 +1,6 @@
 module workload
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
### What problem does this PR solve?

Update the Go version used by TiCDC master, and align TiCDC's TiFlow dependency
with the TiFlow master update from pingcap/tiflow#12683.

Issue Number: close #5191

### What is changed and how it works?

- Update Go version declarations and build instructions from 1.25.8 to 1.25.10.
- 
### Check List

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

README Go installation instructions are updated.

### Release note

```release-note
None
```
