### PR TITLE
storage sink: reduce memory retained by pending work

### DIFF
--- a/downstreamadapter/dispatcher/table_progress.go
+++ b/downstreamadapter/dispatcher/table_progress.go
@@ -113,13 +113,6 @@ func (p *TableProgress) Add(event commonEvent.FlushableEvent) {
 	})
 }
 
-// Remove deletes an event from the TableProgress.
-// Note: Consider implementing batch removal in the future if needed.
-func (p *TableProgress) Remove(event commonEvent.FlushableEvent) {
-	ts := Ts{startTs: event.GetStartTs(), commitTs: event.GetCommitTs()}
-	p.remove(ts, event.GetSize())
-}
-
 func (p *TableProgress) remove(ts Ts, size int64) {
 	p.rwMutex.Lock()
 	defer p.rwMutex.Unlock()

--- a/downstreamadapter/dispatcher/table_progress.go
+++ b/downstreamadapter/dispatcher/table_progress.go
@@ -97,6 +97,7 @@ func NewTableProgress() *TableProgress {
 func (p *TableProgress) Add(event commonEvent.FlushableEvent) {
 	commitTs := event.GetCommitTs()
 	ts := Ts{startTs: event.GetStartTs(), commitTs: commitTs}
+	size := event.GetSize()
 
 	p.rwMutex.Lock()
 	defer p.rwMutex.Unlock()
@@ -108,7 +109,7 @@ func (p *TableProgress) Add(event commonEvent.FlushableEvent) {
 	p.elemMap[ts].Push(elem)
 	p.maxCommitTs = commitTs
 	event.PushFrontFlushFunc(func() {
-		p.Remove(event)
+		p.remove(ts, size)
 	})
 }
 
@@ -116,6 +117,10 @@ func (p *TableProgress) Add(event commonEvent.FlushableEvent) {
 // Note: Consider implementing batch removal in the future if needed.
 func (p *TableProgress) Remove(event commonEvent.FlushableEvent) {
 	ts := Ts{startTs: event.GetStartTs(), commitTs: event.GetCommitTs()}
+	p.remove(ts, event.GetSize())
+}
+
+func (p *TableProgress) remove(ts Ts, size int64) {
 	p.rwMutex.Lock()
 	defer p.rwMutex.Unlock()
 
@@ -133,7 +138,7 @@ func (p *TableProgress) Remove(event commonEvent.FlushableEvent) {
 			p.lastSyncedTs = ts.commitTs
 		}
 	}
-	p.cumulateEventSize += event.GetSize()
+	p.cumulateEventSize += size
 }
 
 // Empty checks if the TableProgress is empty.

--- a/downstreamadapter/dispatcher/table_progress_test.go
+++ b/downstreamadapter/dispatcher/table_progress_test.go
@@ -93,8 +93,11 @@ func TestSyncPointEventCommitTs(t *testing.T) {
 	assert.Equal(t, uint64(39), checkpointTs, "checkpointTs should be largest commitTs - 1")
 	assert.False(t, isEmpty)
 
-	// Test Remove method
-	tp.Remove(syncPointEvent)
+	// Test remove method
+	tp.remove(
+		Ts{startTs: syncPointEvent.GetStartTs(), commitTs: syncPointEvent.GetCommitTs()},
+		syncPointEvent.GetSize(),
+	)
 	assert.True(t, tp.Empty(), "TableProgress should be empty after removing the event")
 
 	// Verify checkpointTs after removal
@@ -115,7 +118,10 @@ func TestSyncPointEventCommitTs(t *testing.T) {
 	assert.Equal(t, uint64(59), checkpointTs, "checkpointTs should be largest commitTs - 1")
 	assert.False(t, isEmpty)
 
-	tp.Remove(syncPointEvent)
+	tp.remove(
+		Ts{startTs: syncPointEvent.GetStartTs(), commitTs: syncPointEvent.GetCommitTs()},
+		syncPointEvent.GetSize(),
+	)
 
 	checkpointTs, isEmpty = tp.GetCheckpointTs()
 	assert.Equal(t, uint64(59), checkpointTs, "checkpointTs should be largest commitTs - 1")

--- a/downstreamadapter/dispatcher/table_progress_test.go
+++ b/downstreamadapter/dispatcher/table_progress_test.go
@@ -93,11 +93,7 @@ func TestSyncPointEventCommitTs(t *testing.T) {
 	assert.Equal(t, uint64(39), checkpointTs, "checkpointTs should be largest commitTs - 1")
 	assert.False(t, isEmpty)
 
-	// Test remove method
-	tp.remove(
-		Ts{startTs: syncPointEvent.GetStartTs(), commitTs: syncPointEvent.GetCommitTs()},
-		syncPointEvent.GetSize(),
-	)
+	syncPointEvent.PostFlush()
 	assert.True(t, tp.Empty(), "TableProgress should be empty after removing the event")
 
 	// Verify checkpointTs after removal
@@ -118,10 +114,7 @@ func TestSyncPointEventCommitTs(t *testing.T) {
 	assert.Equal(t, uint64(59), checkpointTs, "checkpointTs should be largest commitTs - 1")
 	assert.False(t, isEmpty)
 
-	tp.remove(
-		Ts{startTs: syncPointEvent.GetStartTs(), commitTs: syncPointEvent.GetCommitTs()},
-		syncPointEvent.GetSize(),
-	)
+	syncPointEvent.PostFlush()
 
 	checkpointTs, isEmpty = tp.GetCheckpointTs()
 	assert.Equal(t, uint64(59), checkpointTs, "checkpointTs should be largest commitTs - 1")

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -248,29 +248,20 @@ func (t *tableBatches) detachByDispatcher(dispatcherID common.DispatcherID) tabl
 }
 
 func (c *bufferManager) emitFlushTask(ctx context.Context, batch tableBatches, reason string) error {
-	batches := make([]tablePayload, 0, len(batch.tables))
-	for table, tableTask := range batch.tables {
-		payload, err := c.buildPayload(tableTask)
-		if err != nil {
-			return err
-		}
-		batches = append(batches, tablePayload{
-			table:   table,
-			payload: payload,
-		})
+	if batch.isEmpty() {
+		return nil
 	}
-
-	if err := c.enqueueFlushTask(ctx, flushTask{batches: batches}); err != nil {
+	if err := c.enqueueFlushTask(ctx, flushTask{batch: batch}); err != nil {
 		return err
 	}
 	metrics.CloudStorageFlushReasonCounter.WithLabelValues(c.changeFeedID.Keyspace(), c.changeFeedID.Name(), reason).Inc()
 	return nil
 }
 
-func (c *bufferManager) buildPayload(batch *tableBatch) (*payload, error) {
+func buildPayload(spoolBuffer *spool.Spool, batch *tableBatch) (*payload, error) {
 	builder := newPayloadBuilder(batch)
 	for _, entry := range batch.entries {
-		if err := builder.appendEntry(c.spool, entry); err != nil {
+		if err := builder.appendEntry(spoolBuffer, entry); err != nil {
 			return nil, err
 		}
 	}

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -105,11 +105,11 @@ func (c *bufferManager) run(ctx context.Context) error {
 func (c *bufferManager) handleDMLTask(ctx context.Context, task *task) error {
 	if len(task.encodedMsgs) == 0 {
 		task.callbacks.postEnqueue()
-		task.releaseEvent()
+		task.event = nil
 		return nil
 	}
 
-	task.releaseEvent()
+	task.event = nil
 	for {
 		action, entry, err := c.spool.TryEnqueue(task.encodedMsgs, task.callbacks.postEnqueue)
 		if err != nil {

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -104,12 +104,14 @@ func (c *bufferManager) run(ctx context.Context) error {
 
 func (c *bufferManager) handleDMLTask(ctx context.Context, task *task) error {
 	if len(task.encodedMsgs) == 0 {
-		task.event.PostEnqueue()
+		task.callbacks.postEnqueue()
+		task.releaseEvent()
 		return nil
 	}
 
+	task.releaseEvent()
 	for {
-		action, entry, err := c.spool.TryEnqueue(task.encodedMsgs, task.event.PostEnqueue)
+		action, entry, err := c.spool.TryEnqueue(task.encodedMsgs, task.callbacks.postEnqueue)
 		if err != nil {
 			return err
 		}
@@ -200,7 +202,7 @@ func (t *tableBatches) addEntry(event *task, entry *spool.Entry) {
 	if _, ok := t.tables[table]; !ok {
 		t.tables[table] = &tableBatch{
 			size:      0,
-			tableInfo: event.event.TableInfo,
+			tableInfo: event.tableInfo,
 		}
 	}
 

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -105,11 +105,9 @@ func (c *bufferManager) run(ctx context.Context) error {
 func (c *bufferManager) handleDMLTask(ctx context.Context, task *task) error {
 	if len(task.encodedMsgs) == 0 {
 		task.callbacks.postEnqueue()
-		task.event = nil
 		return nil
 	}
 
-	task.event = nil
 	for {
 		action, entry, err := c.spool.TryEnqueue(task.encodedMsgs, task.callbacks.postEnqueue)
 		if err != nil {

--- a/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
@@ -85,10 +85,9 @@ func TestBufferManagerFlushesPendingBatchBeforeWaitingForDiskQuota(t *testing.T)
 	select {
 	case flushed := <-flushSink.ch:
 		require.Nil(t, flushed.marker)
-		require.Len(t, flushed.batches, 1)
-		for _, batch := range flushed.batches {
-			require.NotEmpty(t, batch.payload.data)
-			require.Len(t, batch.payload.entries, 1)
+		require.Len(t, flushed.batch.tables, 1)
+		for _, batch := range flushed.batch.tables {
+			require.Len(t, batch.entries, 1)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("buffer controller did not flush pending batch before waiting for disk quota")
@@ -133,12 +132,11 @@ func TestBufferManagerOversizedBatchFlushesImmediatelyFromMemory(t *testing.T) {
 
 	select {
 	case flushed := <-flushSink.ch:
-		require.Len(t, flushed.batches, 1)
-		for _, batch := range flushed.batches {
-			require.NotEmpty(t, batch.payload.data)
-			require.Len(t, batch.payload.entries, 1)
-			require.True(t, batch.payload.entries[0].InMemory())
-			require.False(t, batch.payload.entries[0].IsSpilled())
+		require.Len(t, flushed.batch.tables, 1)
+		for _, batch := range flushed.batch.tables {
+			require.Len(t, batch.entries, 1)
+			require.True(t, batch.entries[0].InMemory())
+			require.False(t, batch.entries[0].IsSpilled())
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("buffer controller did not flush oversized batch immediately")

--- a/downstreamadapter/sink/cloudstorage/encoder_group.go
+++ b/downstreamadapter/sink/cloudstorage/encoder_group.go
@@ -114,6 +114,7 @@ func (eg *encoderGroup) runEncoder(ctx context.Context, index int) error {
 			}
 			task.encodedMsgs = encoder.Build()
 			task.replacePostFlushCallbacks()
+			task.event = nil
 			future.Done()
 		}
 	}

--- a/downstreamadapter/sink/cloudstorage/encoder_group.go
+++ b/downstreamadapter/sink/cloudstorage/encoder_group.go
@@ -113,6 +113,7 @@ func (eg *encoderGroup) runEncoder(ctx context.Context, index int) error {
 				return err
 			}
 			task.encodedMsgs = encoder.Build()
+			task.replacePostFlushCallbacks()
 			future.Done()
 		}
 	}

--- a/downstreamadapter/sink/cloudstorage/encoder_group_test.go
+++ b/downstreamadapter/sink/cloudstorage/encoder_group_test.go
@@ -201,6 +201,7 @@ func TestEncodingGroupEncodeDMLTask(t *testing.T) {
 				}
 				task := future.task
 				require.Equal(t, taskValue, task)
+				require.Nil(t, task.event)
 				done <- struct{}{}
 				return nil
 			}

--- a/downstreamadapter/sink/cloudstorage/task.go
+++ b/downstreamadapter/sink/cloudstorage/task.go
@@ -52,6 +52,9 @@ func newDMLTask(
 	version cloudstorage.VersionedTableName,
 	event *commonEvent.DMLEvent,
 ) *task {
+	// The dispatcher path registers progress callbacks before calling
+	// Sink.AddDMLEvent, so snapshot callbacks here and release the large event
+	// object after encoding.
 	return &task{
 		kind:           taskKindDML,
 		event:          event,
@@ -92,13 +95,6 @@ func (t *task) replacePostFlushCallbacks() {
 	if !replaced {
 		t.encodedMsgs[len(t.encodedMsgs)-1].Callback = t.callbacks.postFlush
 	}
-}
-
-func (t *task) releaseEvent() {
-	if t == nil {
-		return
-	}
-	t.event = nil
 }
 
 type txnCallbacks struct {

--- a/downstreamadapter/sink/cloudstorage/task.go
+++ b/downstreamadapter/sink/cloudstorage/task.go
@@ -126,6 +126,7 @@ func (c *txnCallbacks) postFlush() {
 			f()
 		}
 	}
+	c.postEnqueue()
 }
 
 func (c *txnCallbacks) postEnqueue() {

--- a/downstreamadapter/sink/cloudstorage/task.go
+++ b/downstreamadapter/sink/cloudstorage/task.go
@@ -81,22 +81,24 @@ func (t *task) isFlushTask() bool {
 }
 
 func (t *task) replacePostFlushCallbacks() {
-	if t == nil || t.callbacks == nil || len(t.encodedMsgs) == 0 {
+	if len(t.encodedMsgs) == 0 {
 		return
 	}
-	replaced := false
+
+	// Txn encoders put event.PostFlush into message.Callback. That method value
+	// keeps the original DMLEvent reachable through the encoded messages, so
+	// replace it with the lightweight callback copy before releasing task.event.
 	for _, msg := range t.encodedMsgs {
-		if msg.Callback == nil {
-			continue
-		}
-		msg.Callback = t.callbacks.postFlush
-		replaced = true
+		msg.Callback = nil
 	}
-	if !replaced {
-		t.encodedMsgs[len(t.encodedMsgs)-1].Callback = t.callbacks.postFlush
-	}
+	// One callback on the last message is enough because all messages in a task
+	// are enqueued and flushed as one spool entry.
+	t.encodedMsgs[len(t.encodedMsgs)-1].Callback = t.callbacks.postFlush
 }
 
+// txnCallbacks is a lightweight copy of a DMLEvent's enqueue and flush
+// callbacks. It lets cloud storage release the full DMLEvent after encoding
+// while preserving the event callback semantics: each stage runs at most once.
 type txnCallbacks struct {
 	flushed  []func()
 	enqueued []func()

--- a/downstreamadapter/sink/cloudstorage/task.go
+++ b/downstreamadapter/sink/cloudstorage/task.go
@@ -15,6 +15,7 @@ package cloudstorage
 
 import (
 	"context"
+	"sync/atomic"
 
 	commonType "github.com/pingcap/ticdc/pkg/common"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
@@ -38,6 +39,8 @@ type task struct {
 
 	// DML-only fields.
 	event          *commonEvent.DMLEvent           // Original DML event to encode and flush.
+	callbacks      *txnCallbacks                   // Lightweight txn callbacks detached from event.
+	tableInfo      *commonType.TableInfo           // Table info used after event is released.
 	versionedTable cloudstorage.VersionedTableName // Versioned output identity for the DML event.
 	encodedMsgs    []*common.Message               // Encoded result built from event.
 
@@ -52,6 +55,8 @@ func newDMLTask(
 	return &task{
 		kind:           taskKindDML,
 		event:          event,
+		callbacks:      newTxnCallbacks(event),
+		tableInfo:      event.TableInfo,
 		versionedTable: version,
 		dispatcherID:   event.GetDispatcherID(),
 	}
@@ -70,6 +75,70 @@ func newFlushTask(
 
 func (t *task) isFlushTask() bool {
 	return t != nil && t.kind == taskKindFlush
+}
+
+func (t *task) replacePostFlushCallbacks() {
+	if t == nil || t.callbacks == nil || len(t.encodedMsgs) == 0 {
+		return
+	}
+	replaced := false
+	for _, msg := range t.encodedMsgs {
+		if msg.Callback == nil {
+			continue
+		}
+		msg.Callback = t.callbacks.postFlush
+		replaced = true
+	}
+	if !replaced {
+		t.encodedMsgs[len(t.encodedMsgs)-1].Callback = t.callbacks.postFlush
+	}
+}
+
+func (t *task) releaseEvent() {
+	if t == nil {
+		return
+	}
+	t.event = nil
+}
+
+type txnCallbacks struct {
+	flushed  []func()
+	enqueued []func()
+
+	flushedCalled  atomic.Bool
+	enqueuedCalled atomic.Bool
+}
+
+func newTxnCallbacks(event *commonEvent.DMLEvent) *txnCallbacks {
+	if event == nil {
+		return &txnCallbacks{}
+	}
+	return &txnCallbacks{
+		flushed:  append([]func(){}, event.PostTxnFlushed...),
+		enqueued: append([]func(){}, event.PostTxnEnqueued...),
+	}
+}
+
+func (c *txnCallbacks) postFlush() {
+	if c == nil || !c.flushedCalled.CompareAndSwap(false, true) {
+		return
+	}
+	for _, f := range c.flushed {
+		if f != nil {
+			f()
+		}
+	}
+}
+
+func (c *txnCallbacks) postEnqueue() {
+	if c == nil || !c.enqueuedCalled.CompareAndSwap(false, true) {
+		return
+	}
+	for _, f := range c.enqueued {
+		if f != nil {
+			f()
+		}
+	}
 }
 
 func (t *task) wait(ctx context.Context) error {

--- a/downstreamadapter/sink/cloudstorage/task_test.go
+++ b/downstreamadapter/sink/cloudstorage/task_test.go
@@ -56,11 +56,17 @@ func TestReplacePostFlushCallbacksDetachesOriginalMessageCallbacks(t *testing.T)
 
 	var originalCallbackCount atomic.Int32
 	var flushCallbackCount atomic.Int32
+	var enqueueCallbackCount atomic.Int32
 	task := &task{
 		callbacks: &txnCallbacks{
 			flushed: []func(){
 				func() {
 					flushCallbackCount.Add(1)
+				},
+			},
+			enqueued: []func(){
+				func() {
+					enqueueCallbackCount.Add(1)
 				},
 			},
 		},
@@ -81,4 +87,5 @@ func TestReplacePostFlushCallbacksDetachesOriginalMessageCallbacks(t *testing.T)
 	task.encodedMsgs[2].Callback()
 	require.Equal(t, int32(0), originalCallbackCount.Load())
 	require.Equal(t, int32(1), flushCallbackCount.Load())
+	require.Equal(t, int32(1), enqueueCallbackCount.Load())
 }

--- a/downstreamadapter/sink/cloudstorage/task_test.go
+++ b/downstreamadapter/sink/cloudstorage/task_test.go
@@ -16,9 +16,11 @@ package cloudstorage
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pingcap/ticdc/pkg/sink/codec/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +49,36 @@ func TestFlushMarkerWaitReturnsContextCause(t *testing.T) {
 	marker := newFlushMarker(100)
 	err := marker.wait(ctx)
 	require.ErrorIs(t, err, cause)
+}
+
+func TestReplacePostFlushCallbacksDetachesOriginalMessageCallbacks(t *testing.T) {
+	t.Parallel()
+
+	var originalCallbackCount atomic.Int32
+	var flushCallbackCount atomic.Int32
+	task := &task{
+		callbacks: &txnCallbacks{
+			flushed: []func(){
+				func() {
+					flushCallbackCount.Add(1)
+				},
+			},
+		},
+		encodedMsgs: []*common.Message{
+			{Callback: func() { originalCallbackCount.Add(1) }},
+			{Callback: func() { originalCallbackCount.Add(1) }},
+			{},
+		},
+	}
+
+	task.replacePostFlushCallbacks()
+
+	require.Nil(t, task.encodedMsgs[0].Callback)
+	require.Nil(t, task.encodedMsgs[1].Callback)
+	require.NotNil(t, task.encodedMsgs[2].Callback)
+
+	task.encodedMsgs[2].Callback()
+	task.encodedMsgs[2].Callback()
+	require.Equal(t, int32(0), originalCallbackCount.Load())
+	require.Equal(t, int32(1), flushCallbackCount.Load())
 }

--- a/downstreamadapter/sink/cloudstorage/writer.go
+++ b/downstreamadapter/sink/cloudstorage/writer.go
@@ -55,13 +55,8 @@ type writer struct {
 // flushTask is internal and never crosses component boundary.
 // marker task and data batch are mutually exclusive in normal flow.
 type flushTask struct {
-	batches []tablePayload
-	marker  *flushMarker
-}
-
-type tablePayload struct {
-	table   cloudstorage.VersionedTableName
-	payload *payload
+	batch  tableBatches
+	marker *flushMarker
 }
 
 type payload struct {
@@ -142,19 +137,17 @@ func (d *writer) flushMessages(ctx context.Context) error {
 				task.marker.finish()
 				continue
 			}
-			if len(task.batches) == 0 {
+			if task.batch.isEmpty() {
 				continue
 			}
 
 			start := time.Now()
-			for _, batch := range task.batches {
-				table := batch.table
-				payload := batch.payload
-				if payload == nil || len(payload.entries) == 0 {
+			for table, tableTask := range task.batch.tables {
+				if tableTask == nil || len(tableTask.entries) == 0 {
 					continue
 				}
 
-				hasNewerSchemaVersion, err := d.filePathGenerator.CheckOrWriteSchema(ctx, table, payload.tableInfo)
+				hasNewerSchemaVersion, err := d.filePathGenerator.CheckOrWriteSchema(ctx, table, tableTask.tableInfo)
 				if err != nil {
 					log.Error("failed to write schema file to external storage",
 						zap.String("keyspace", keyspace),
@@ -164,7 +157,7 @@ func (d *writer) flushMessages(ctx context.Context) error {
 					return err
 				}
 				if hasNewerSchemaVersion {
-					d.discardPayload(payload)
+					d.discardEntries(tableTask.entries)
 					log.Warn("ignore messages belonging to an old schema version",
 						zap.String("keyspace", keyspace),
 						zap.String("changefeed", changefeed),
@@ -195,6 +188,10 @@ func (d *writer) flushMessages(ctx context.Context) error {
 					return err
 				}
 
+				payload, err := buildPayload(d.spool, tableTask)
+				if err != nil {
+					return err
+				}
 				if err := d.writeDataFile(ctx, dataFilePath, indexFilePath, payload); err != nil {
 					log.Error("failed to write data file to external storage",
 						zap.String("keyspace", keyspace),
@@ -220,8 +217,8 @@ func (d *writer) flushMessages(ctx context.Context) error {
 	}
 }
 
-func (d *writer) discardPayload(payload *payload) {
-	for _, entry := range payload.entries {
+func (d *writer) discardEntries(entries []*spool.Entry) {
+	for _, entry := range entries {
 		d.spool.Discard(entry)
 	}
 }
@@ -292,6 +289,9 @@ func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath 
 	for _, entry := range payload.entries {
 		d.spool.Release(entry)
 	}
+	payload.data = nil
+	payload.entries = nil
+	payload.postFlushCallbacks = nil
 	return nil
 }
 

--- a/downstreamadapter/sink/cloudstorage/writer.go
+++ b/downstreamadapter/sink/cloudstorage/writer.go
@@ -158,6 +158,7 @@ func (d *writer) flushMessages(ctx context.Context) error {
 				}
 				if hasNewerSchemaVersion {
 					d.discardEntries(tableTask.entries)
+					tableTask.entries = nil
 					log.Warn("ignore messages belonging to an old schema version",
 						zap.String("keyspace", keyspace),
 						zap.String("changefeed", changefeed),
@@ -201,6 +202,7 @@ func (d *writer) flushMessages(ctx context.Context) error {
 						zap.Error(err))
 					return err
 				}
+				tableTask.entries = nil
 
 				log.Debug("write file to storage success",
 					zap.String("keyspace", keyspace),
@@ -289,9 +291,8 @@ func (d *writer) writeDataFile(ctx context.Context, dataFilePath, indexFilePath 
 	for _, entry := range payload.entries {
 		d.spool.Release(entry)
 	}
+	// Help GC release the potentially large encoded payload buffer before returning.
 	payload.data = nil
-	payload.entries = nil
-	payload.postFlushCallbacks = nil
 	return nil
 }
 

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -479,7 +479,7 @@ func TestWriterStoresPendingMessagesInSpoolBeforeFlush(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
-func TestDiscardPayloadDoesNotLoadSpilledPayload(t *testing.T) {
+func TestDiscardEntriesDoesNotLoadSpilledPayload(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()
 
@@ -510,9 +510,7 @@ func TestDiscardPayloadDoesNotLoadSpilledPayload(t *testing.T) {
 
 	d.spool.Close()
 
-	d.discardPayload(&payload{
-		entries: []*spool.Entry{entry},
-	})
+	d.discardEntries([]*spool.Entry{entry})
 	require.Equal(t, int64(1), callbackCount.Load())
 }
 

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -386,6 +386,70 @@ func TestWriterPostEnqueueAfterConsume(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
+func TestWriterPostFlushRunsPausedPostEnqueueBeforeLowWatermark(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := commonType.NewChangefeedID4Test("test", t.Name())
+	spoolBuffer, err := spool.New(
+		changefeedID,
+		spool.WithDiskQuotaBytes(1000),
+		spool.WithRootDir(t.TempDir()),
+		spool.WithSegmentBytes(1<<20),
+		spool.WithMemoryRatio(0.99),
+		spool.WithHighWatermarkRatio(0.6),
+		spool.WithLowWatermarkRatio(0.3),
+	)
+	require.NoError(t, err)
+	defer spoolBuffer.Close()
+
+	var firstEnqueued atomic.Int64
+	firstMsg := common.NewMsg(nil, []byte(strings.Repeat("a", 500)))
+	firstEntry, err := spoolBuffer.Enqueue([]*common.Message{firstMsg}, func() {
+		firstEnqueued.Add(1)
+	})
+	require.NoError(t, err)
+	defer spoolBuffer.Release(firstEntry)
+	require.Equal(t, int64(1), firstEnqueued.Load())
+
+	var secondFlushed atomic.Int64
+	var secondEnqueued atomic.Int64
+	secondCallbacks := &txnCallbacks{
+		flushed: []func(){
+			func() {
+				secondFlushed.Add(1)
+			},
+		},
+		enqueued: []func(){
+			func() {
+				secondEnqueued.Add(1)
+			},
+		},
+	}
+	secondMsg := common.NewMsg(nil, []byte(strings.Repeat("b", 120)))
+	secondMsg.Callback = secondCallbacks.postFlush
+	secondEntry, err := spoolBuffer.Enqueue([]*common.Message{secondMsg}, secondCallbacks.postEnqueue)
+	require.NoError(t, err)
+	defer spoolBuffer.Release(secondEntry)
+	require.Equal(t, int64(0), secondEnqueued.Load())
+
+	payload, err := buildPayload(spoolBuffer, &tableBatch{entries: []*spool.Entry{secondEntry}})
+	require.NoError(t, err)
+	require.Len(t, payload.postFlushCallbacks, 1)
+
+	for _, postFlushCallback := range payload.postFlushCallbacks {
+		postFlushCallback()
+	}
+	for _, entry := range payload.entries {
+		spoolBuffer.Release(entry)
+	}
+
+	require.Equal(t, int64(1), secondFlushed.Load())
+	require.Equal(t, int64(1), secondEnqueued.Load())
+
+	spoolBuffer.Release(firstEntry)
+	require.Equal(t, int64(1), secondEnqueued.Load())
+}
+
 func TestWriterStoresPendingMessagesInSpoolBeforeFlush(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5274

Before this PR, 1000 tables with huge rows may cause OOM, since allocated events is not released in time and build payload too early.

After this PR, the memory allocation reduced from more then 32GB to around 7 ~ 14GB


This PR reduces memory retained by the cloud storage sink when external storage is slow.

In the two-stage acknowledgement flow, dispatchers can continue scanning after DML events are accepted by the storage sink. The spool is expected to absorb that backlog, but the storage sink should not keep original heavy `DMLEvent` objects or large materialized file payloads alive longer than needed. In stress tests with many tables and slow S3 writes, this retained memory could accumulate and lead to TiCDC OOM.

### What is changed and how it works?

- Update `TableProgress` callback capture to avoid retaining DML events.
  - This is necessary for the memory-retention fix: `TableProgress.Add` used to register a callback that closed over the full event via `p.Remove(event)`.
  - Now it snapshots only `(startTs, commitTs)` and event size when the event is added, and the flush callback calls the internal `remove(ts, size)` helper.
  - The checkpoint/progress behavior is unchanged, but the progress callback no longer prevents the original event from being garbage-collected after encoding.

- Split storage-sink task state from the original `DMLEvent`.
  - `newDMLTask` snapshots the lightweight data still needed after encoding: callback lists, table info, versioned output table, and dispatcher ID.
  - After `encoder.Build()` and callback replacement, the encoder drops `task.event`, so queued buffer/spool/writer work no longer retains the full event object.
- Replace encoded message callbacks with a lightweight transaction callback wrapper.
  - Some txn encoders attach `event.PostFlush` to `message.Callback`. That method value keeps the original `DMLEvent` reachable through encoded messages.
  - The storage sink replaces those callbacks with `txnCallbacks.postFlush`, which preserves post-flush semantics without retaining the event.
  - `txnCallbacks` also preserves post-enqueue semantics and makes both stages idempotent.
- Delay cloud storage payload construction until writer flush time.
  - Flush tasks keep spool entries instead of eagerly materialized payload byte slices.
  - The writer builds payload bytes only when it is ready to write the table data file.
  - After a table is flushed or discarded because of a newer schema version, the writer clears the table batch entries so already-processed spool entries are not kept reachable by the batch map.

The storage file format, schema/data/index write order, callback timing, and spool release semantics are intended to remain unchanged.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test

Commands run locally:

- `go test ./downstreamadapter/sink/cloudstorage -run 'Test(ReplacePostFlushCallbacks|FlushMarker|EncodingGroup|TaskIndexer|BufferManager|Writer|DiscardEntries|AddDMLEventUsesTargetNames|CloudStoragePostEnqueueBeforeFlush|SubmitTaskToEncoderExitOnContextCancel)'`
- `go test ./downstreamadapter/dispatcher -run 'TestTableProgress|TestSyncPointEventCommitTs|TestMultiSameCommitTsStartTsPair'`
- `git diff --check`


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No compatibility impact is expected. This PR does not change public APIs, storage file format, metrics, or sink output semantics.

The expected runtime impact is lower retained heap under slow external storage. Payload construction is moved closer to the actual writer execution, so queued flush tasks retain less memory. The writer still writes the same data files and index files in the same order.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Reduce TiCDC cloud storage sink memory usage when external storage is slow.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved callback and task handling mechanisms for better event processing reliability.
  * Optimized memory management by releasing event references after encoding.
  * Simplified internal flush task structure to enhance maintainability.

* **Tests**
  * Added and updated test coverage for callback handling and flush operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->