### PR TITLE
Storage: per table flush by age to reduce small file sizes

### DIFF
--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	defaultBufferManagerChannelSize = 64
-	maxIntervalFlushCheckPeriod     = time.Second
 
 	flushReasonSize     = "size"
 	flushReasonInterval = "interval"
@@ -70,21 +69,31 @@ func newBufferManager(
 }
 
 func (c *bufferManager) run(ctx context.Context) error {
-	ticker := time.NewTicker(intervalFlushCheckPeriod(c.config.FlushInterval))
-	defer ticker.Stop()
+	var intervalFlushTimer *time.Timer
+	var intervalFlushC <-chan time.Time
+	defer stopIntervalFlushTimer(intervalFlushTimer)
 
 	for {
+		var injectedErr error
 		failpoint.Inject("passTickerOnce", func() {
-			<-ticker.C
+			if intervalFlushC != nil {
+				now := <-intervalFlushC
+				injectedErr = c.emitExpiredBatch(ctx, now)
+				intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
+			}
 		})
+		if injectedErr != nil {
+			return injectedErr
+		}
 
 		select {
 		case <-ctx.Done():
 			return errors.Trace(context.Cause(ctx))
-		case <-ticker.C:
-			if err := c.emitExpiredBatch(ctx, c.now()); err != nil {
+		case now := <-intervalFlushC:
+			if err := c.emitExpiredBatch(ctx, now); err != nil {
 				return err
 			}
+			intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
 		case task := <-c.inputCh:
 			if task.isFlushTask() {
 				dispatcherBatch := c.buffer.detachByDispatcher(task.dispatcherID)
@@ -96,11 +105,13 @@ func (c *bufferManager) run(ctx context.Context) error {
 				if err := c.enqueueFlushTask(ctx, flushTask{marker: task.marker}); err != nil {
 					return err
 				}
+				intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
 				continue
 			}
 			if err := c.handleDMLTask(ctx, task); err != nil {
 				return err
 			}
+			intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
 		}
 	}
 }
@@ -273,18 +284,50 @@ func (t *tableBatches) detachExpired(now time.Time, maxAge time.Duration) tableB
 	return detached
 }
 
-func intervalFlushCheckPeriod(flushInterval time.Duration) time.Duration {
-	if flushInterval <= 0 {
-		return maxIntervalFlushCheckPeriod
+func (t *tableBatches) nextIntervalFlushDeadline(maxAge time.Duration) (time.Time, bool) {
+	var deadline time.Time
+	for _, tableTask := range t.tables {
+		next := tableTask.firstEntryAt
+		if maxAge > 0 {
+			next = next.Add(maxAge)
+		}
+		if deadline.IsZero() || next.Before(deadline) {
+			deadline = next
+		}
 	}
-	checkPeriod := flushInterval / 10
-	if checkPeriod <= 0 {
-		return flushInterval
+	return deadline, !deadline.IsZero()
+}
+
+func (c *bufferManager) resetIntervalFlushTimer(timer *time.Timer) (*time.Timer, <-chan time.Time) {
+	deadline, ok := c.buffer.nextIntervalFlushDeadline(c.config.FlushInterval)
+	if !ok {
+		stopIntervalFlushTimer(timer)
+		return timer, nil
 	}
-	if checkPeriod > maxIntervalFlushCheckPeriod {
-		return maxIntervalFlushCheckPeriod
+
+	delay := deadline.Sub(c.now())
+	if delay < 0 {
+		delay = 0
 	}
-	return checkPeriod
+	if timer == nil {
+		timer = time.NewTimer(delay)
+	} else {
+		stopIntervalFlushTimer(timer)
+		timer.Reset(delay)
+	}
+	return timer, timer.C
+}
+
+func stopIntervalFlushTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }
 
 func (c *bufferManager) emitFlushTask(ctx context.Context, batch tableBatches, reason string) error {

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -71,7 +71,9 @@ func newBufferManager(
 func (c *bufferManager) run(ctx context.Context) error {
 	var intervalFlushTimer *time.Timer
 	var intervalFlushC <-chan time.Time
-	defer stopIntervalFlushTimer(intervalFlushTimer)
+	defer func() {
+		stopIntervalFlushTimer(intervalFlushTimer)
+	}()
 
 	for {
 		var injectedErr error
@@ -108,42 +110,50 @@ func (c *bufferManager) run(ctx context.Context) error {
 				intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
 				continue
 			}
-			if err := c.handleDMLTask(ctx, task); err != nil {
+			timerDirty, err := c.handleDMLTask(ctx, task)
+			if err != nil {
 				return err
 			}
-			intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
+			if timerDirty {
+				intervalFlushTimer, intervalFlushC = c.resetIntervalFlushTimer(intervalFlushTimer)
+			}
 		}
 	}
 }
 
-func (c *bufferManager) handleDMLTask(ctx context.Context, task *task) error {
+func (c *bufferManager) handleDMLTask(ctx context.Context, task *task) (bool, error) {
 	if len(task.encodedMsgs) == 0 {
 		task.event.PostEnqueue()
-		return nil
+		return false, nil
 	}
 
+	timerDirty := false
 	for {
 		action, entry, err := c.spool.TryEnqueue(task.encodedMsgs, task.event.PostEnqueue)
 		if err != nil {
-			return err
+			return false, err
 		}
 		switch action {
 		case spool.EnqueueActionAcceptedOversized:
 			c.addEntry(task, entry)
-			return c.emitTableBatch(ctx, task.versionedTable, flushReasonOversize)
+			return true, c.emitTableBatch(ctx, task.versionedTable, flushReasonOversize)
 		case spool.EnqueueActionWaitDiskQuota:
 			if err := c.emitBatch(ctx, flushReasonQuota); err != nil {
-				return err
+				return false, err
 			}
+			timerDirty = true
 			if err := c.spool.WaitForDiskQuota(ctx, task.encodedMsgs); err != nil {
-				return err
+				return false, err
 			}
 			continue
 		default:
-			c.addEntry(task, entry)
+			if c.addEntry(task, entry) {
+				timerDirty = true
+			}
 		}
 
-		return c.emitTableBatchIfSizeReached(ctx, task.versionedTable)
+		flushed, err := c.emitTableBatchIfSizeReached(ctx, task.versionedTable)
+		return timerDirty || flushed, err
 	}
 }
 
@@ -171,11 +181,11 @@ func (c *bufferManager) emitExpiredBatch(ctx context.Context, now time.Time) err
 func (c *bufferManager) emitTableBatchIfSizeReached(
 	ctx context.Context,
 	table cloudstorage.VersionedTableName,
-) error {
+) (bool, error) {
 	if c.buffer.tableSize(table) < uint64(c.config.FileSize) {
-		return nil
+		return false, nil
 	}
-	return c.emitTableBatch(ctx, table, flushReasonSize)
+	return true, c.emitTableBatch(ctx, table, flushReasonSize)
 }
 
 func (c *bufferManager) emitTableBatch(
@@ -232,24 +242,27 @@ func (t *tableBatches) tableSize(table cloudstorage.VersionedTableName) uint64 {
 	return tableTask.size
 }
 
-func (t *tableBatches) addEntry(event *task, entry *spool.Entry, now time.Time) {
+func (t *tableBatches) addEntry(event *task, entry *spool.Entry, now time.Time) bool {
 	table := event.versionedTable
+	created := false
 	if _, ok := t.tables[table]; !ok {
 		t.tables[table] = &tableBatch{
 			size:         0,
 			firstEntryAt: now,
 			tableInfo:    event.event.TableInfo,
 		}
+		created = true
 	}
 
 	tableTask := t.tables[table]
 	tableTask.size += entry.FileBytes()
 	tableTask.entries = append(tableTask.entries, entry)
 	t.nBytes += entry.FileBytes()
+	return created
 }
 
-func (c *bufferManager) addEntry(event *task, entry *spool.Entry) {
-	c.buffer.addEntry(event, entry, c.now())
+func (c *bufferManager) addEntry(event *task, entry *spool.Entry) bool {
+	return c.buffer.addEntry(event, entry, c.now())
 }
 
 func (t *tableBatches) detachByTable(version cloudstorage.VersionedTableName) (tableBatches, error) {

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	defaultBufferManagerChannelSize = 64
+	maxIntervalFlushCheckPeriod     = time.Second
 
 	flushReasonSize     = "size"
 	flushReasonInterval = "interval"
@@ -48,6 +49,7 @@ type bufferManager struct {
 	inputCh          chan *task
 	enqueueFlushTask func(context.Context, flushTask) error
 	buffer           tableBatches
+	now              func() time.Time
 }
 
 func newBufferManager(
@@ -63,11 +65,12 @@ func newBufferManager(
 		inputCh:          make(chan *task, defaultBufferManagerChannelSize),
 		enqueueFlushTask: enqueueFlushTask,
 		buffer:           newTableBatches(),
+		now:              time.Now,
 	}
 }
 
 func (c *bufferManager) run(ctx context.Context) error {
-	ticker := time.NewTicker(c.config.FlushInterval)
+	ticker := time.NewTicker(intervalFlushCheckPeriod(c.config.FlushInterval))
 	defer ticker.Stop()
 
 	for {
@@ -79,7 +82,7 @@ func (c *bufferManager) run(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Trace(context.Cause(ctx))
 		case <-ticker.C:
-			if err := c.emitBatch(ctx, flushReasonInterval); err != nil {
+			if err := c.emitExpiredBatch(ctx, c.now()); err != nil {
 				return err
 			}
 		case task := <-c.inputCh:
@@ -150,6 +153,14 @@ func (c *bufferManager) emitBatch(ctx context.Context, reason string) error {
 	return nil
 }
 
+func (c *bufferManager) emitExpiredBatch(ctx context.Context, now time.Time) error {
+	batch := c.buffer.detachExpired(now, c.config.FlushInterval)
+	if batch.isEmpty() {
+		return nil
+	}
+	return c.emitFlushTask(ctx, batch, flushReasonInterval)
+}
+
 func (c *bufferManager) emitTableBatch(
 	ctx context.Context,
 	table cloudstorage.VersionedTableName,
@@ -180,9 +191,10 @@ type tableBatches struct {
 }
 
 type tableBatch struct {
-	size      uint64
-	tableInfo *common.TableInfo
-	entries   []*spool.Entry
+	size         uint64
+	firstEntryAt time.Time
+	tableInfo    *common.TableInfo
+	entries      []*spool.Entry
 }
 
 func newTableBatches() tableBatches {
@@ -195,12 +207,13 @@ func (t *tableBatches) isEmpty() bool {
 	return len(t.tables) == 0
 }
 
-func (t *tableBatches) addEntry(event *task, entry *spool.Entry) {
+func (t *tableBatches) addEntry(event *task, entry *spool.Entry, now time.Time) {
 	table := event.versionedTable
 	if _, ok := t.tables[table]; !ok {
 		t.tables[table] = &tableBatch{
-			size:      0,
-			tableInfo: event.event.TableInfo,
+			size:         0,
+			firstEntryAt: now,
+			tableInfo:    event.event.TableInfo,
 		}
 	}
 
@@ -211,7 +224,7 @@ func (t *tableBatches) addEntry(event *task, entry *spool.Entry) {
 }
 
 func (c *bufferManager) addEntry(event *task, entry *spool.Entry) {
-	c.buffer.addEntry(event, entry)
+	c.buffer.addEntry(event, entry, c.now())
 }
 
 func (t *tableBatches) detachByTable(version cloudstorage.VersionedTableName) (tableBatches, error) {
@@ -243,6 +256,35 @@ func (t *tableBatches) detachByDispatcher(dispatcherID common.DispatcherID) tabl
 		delete(t.tables, version)
 	}
 	return detached
+}
+
+func (t *tableBatches) detachExpired(now time.Time, maxAge time.Duration) tableBatches {
+	detached := newTableBatches()
+	for version, tableTask := range t.tables {
+		if maxAge > 0 && !tableTask.firstEntryAt.IsZero() &&
+			now.Sub(tableTask.firstEntryAt) < maxAge {
+			continue
+		}
+		detached.tables[version] = tableTask
+		detached.nBytes += tableTask.size
+		t.nBytes -= tableTask.size
+		delete(t.tables, version)
+	}
+	return detached
+}
+
+func intervalFlushCheckPeriod(flushInterval time.Duration) time.Duration {
+	if flushInterval <= 0 {
+		return maxIntervalFlushCheckPeriod
+	}
+	checkPeriod := flushInterval / 10
+	if checkPeriod <= 0 {
+		return flushInterval
+	}
+	if checkPeriod > maxIntervalFlushCheckPeriod {
+		return maxIntervalFlushCheckPeriod
+	}
+	return checkPeriod
 }
 
 func (c *bufferManager) emitFlushTask(ctx context.Context, batch tableBatches, reason string) error {

--- a/downstreamadapter/sink/cloudstorage/buffer_manager.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager.go
@@ -143,11 +143,7 @@ func (c *bufferManager) handleDMLTask(ctx context.Context, task *task) error {
 			c.addEntry(task, entry)
 		}
 
-		version := task.versionedTable
-		if c.buffer.tables[version].size < uint64(c.config.FileSize) {
-			return nil
-		}
-		return c.emitTableBatch(ctx, version, flushReasonSize)
+		return c.emitTableBatchIfSizeReached(ctx, task.versionedTable)
 	}
 }
 
@@ -170,6 +166,16 @@ func (c *bufferManager) emitExpiredBatch(ctx context.Context, now time.Time) err
 		return nil
 	}
 	return c.emitFlushTask(ctx, batch, flushReasonInterval)
+}
+
+func (c *bufferManager) emitTableBatchIfSizeReached(
+	ctx context.Context,
+	table cloudstorage.VersionedTableName,
+) error {
+	if c.buffer.tableSize(table) < uint64(c.config.FileSize) {
+		return nil
+	}
+	return c.emitTableBatch(ctx, table, flushReasonSize)
 }
 
 func (c *bufferManager) emitTableBatch(
@@ -216,6 +222,14 @@ func newTableBatches() tableBatches {
 
 func (t *tableBatches) isEmpty() bool {
 	return len(t.tables) == 0
+}
+
+func (t *tableBatches) tableSize(table cloudstorage.VersionedTableName) uint64 {
+	tableTask := t.tables[table]
+	if tableTask == nil {
+		return 0
+	}
+	return tableTask.size
 }
 
 func (t *tableBatches) addEntry(event *task, entry *spool.Entry, now time.Time) {

--- a/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
@@ -148,6 +148,56 @@ func TestBufferManagerOversizedBatchFlushesImmediatelyFromMemory(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
+func TestBufferManagerIntervalFlushesOnlyBatchesReachingMaxAge(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := commonType.NewChangefeedID4Test("test", "buffer-interval")
+	flushSink := newTestFlushTaskSink(16)
+	spoolBuffer, err := spool.New(
+		changefeedID,
+		spool.WithRootDir(t.TempDir()),
+		spool.WithDiskQuotaBytes(1<<20),
+		spool.WithMemoryRatio(0.5),
+	)
+	require.NoError(t, err)
+	defer spoolBuffer.Close()
+
+	controller := newBufferManager(changefeedID, &cloudstorage.Config{
+		FlushInterval:    10 * time.Second,
+		FileSize:         1 << 20,
+		SpoolDiskQuota:   1 << 20,
+		FileIndexWidth:   6,
+		UseTableIDAsPath: false,
+	}, spoolBuffer, flushSink.enqueueFlushTask)
+
+	now := time.Unix(100, 0)
+	firstTask := newBufferedTask("table1", commonType.NewDispatcherID(), `{"id":1}`)
+	secondTask := newBufferedTask("table2", commonType.NewDispatcherID(), `{"id":2}`)
+
+	firstEntry := newBufferedEntry(t, spoolBuffer, firstTask)
+	secondEntry := newBufferedEntry(t, spoolBuffer, secondTask)
+	controller.buffer.addEntry(firstTask, firstEntry, now)
+	controller.buffer.addEntry(secondTask, secondEntry, now.Add(time.Second))
+
+	require.NoError(t, controller.emitExpiredBatch(context.Background(), now.Add(9*time.Second)))
+	require.Len(t, controller.buffer.tables, 2)
+	require.Empty(t, flushSink.ch)
+
+	require.NoError(t, controller.emitExpiredBatch(context.Background(), now.Add(10*time.Second)))
+
+	select {
+	case flushed := <-flushSink.ch:
+		require.Nil(t, flushed.marker)
+		require.Len(t, flushed.batch.tables, 1)
+		require.Contains(t, flushed.batch.tables, firstTask.versionedTable)
+		require.NotContains(t, flushed.batch.tables, secondTask.versionedTable)
+	case <-time.After(3 * time.Second):
+		t.Fatal("buffer controller did not flush expired batch")
+	}
+	require.Len(t, controller.buffer.tables, 1)
+	require.Contains(t, controller.buffer.tables, secondTask.versionedTable)
+}
+
 func newBufferedTask(table string, dispatcherID commonType.DispatcherID, payload string) *task {
 	tableInfo := &commonType.TableInfo{
 		TableName: commonType.TableName{
@@ -178,4 +228,13 @@ func newBufferedTask(table string, dispatcherID commonType.DispatcherID, payload
 	msg.SetRowsCount(1)
 	t.encodedMsgs = []*common.Message{msg}
 	return t
+}
+
+func newBufferedEntry(t *testing.T, spoolBuffer *spool.Spool, task *task) *spool.Entry {
+	t.Helper()
+
+	_, entry, err := spoolBuffer.TryEnqueue(task.encodedMsgs, task.callbacks.postEnqueue)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	return entry
 }

--- a/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
@@ -148,6 +148,44 @@ func TestBufferManagerOversizedBatchFlushesImmediatelyFromMemory(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
+func TestBufferManagerSizeFlushesWithoutWaitingForMaxAge(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := commonType.NewChangefeedID4Test("test", "buffer-size")
+	flushSink := newTestFlushTaskSink(16)
+	spoolBuffer, err := spool.New(
+		changefeedID,
+		spool.WithRootDir(t.TempDir()),
+		spool.WithDiskQuotaBytes(1<<20),
+		spool.WithMemoryRatio(0.5),
+	)
+	require.NoError(t, err)
+	defer spoolBuffer.Close()
+
+	controller := newBufferManager(changefeedID, &cloudstorage.Config{
+		FlushInterval:    time.Hour,
+		FileSize:         1,
+		SpoolDiskQuota:   1 << 20,
+		FileIndexWidth:   6,
+		UseTableIDAsPath: false,
+	}, spoolBuffer, flushSink.enqueueFlushTask)
+
+	task := newBufferedTask("table1", commonType.NewDispatcherID(), `{"id":1}`)
+	require.NoError(t, controller.handleDMLTask(context.Background(), task))
+
+	select {
+	case flushed := <-flushSink.ch:
+		require.Nil(t, flushed.marker)
+		require.Len(t, flushed.batches, 1)
+		require.Equal(t, task.versionedTable, flushed.batches[0].table)
+		require.NotEmpty(t, flushed.batches[0].payload.data)
+		require.Len(t, flushed.batches[0].payload.entries, 1)
+	case <-time.After(3 * time.Second):
+		t.Fatal("buffer controller did not flush size-reached batch immediately")
+	}
+	require.Empty(t, controller.buffer.tables)
+}
+
 func TestBufferManagerIntervalFlushesOnlyBatchesReachingMaxAge(t *testing.T) {
 	t.Parallel()
 
@@ -188,9 +226,9 @@ func TestBufferManagerIntervalFlushesOnlyBatchesReachingMaxAge(t *testing.T) {
 	select {
 	case flushed := <-flushSink.ch:
 		require.Nil(t, flushed.marker)
-		require.Len(t, flushed.batch.tables, 1)
-		require.Contains(t, flushed.batch.tables, firstTask.versionedTable)
-		require.NotContains(t, flushed.batch.tables, secondTask.versionedTable)
+		require.Len(t, flushed.batches, 1)
+		require.Equal(t, firstTask.versionedTable, flushed.batches[0].table)
+		require.NotEmpty(t, flushed.batches[0].payload.data)
 	case <-time.After(3 * time.Second):
 		t.Fatal("buffer controller did not flush expired batch")
 	}
@@ -259,7 +297,7 @@ func newBufferedTask(table string, dispatcherID commonType.DispatcherID, payload
 func newBufferedEntry(t *testing.T, spoolBuffer *spool.Spool, task *task) *spool.Entry {
 	t.Helper()
 
-	_, entry, err := spoolBuffer.TryEnqueue(task.encodedMsgs, task.callbacks.postEnqueue)
+	_, entry, err := spoolBuffer.TryEnqueue(task.encodedMsgs, task.event.PostEnqueue)
 	require.NoError(t, err)
 	require.NotNil(t, entry)
 	return entry

--- a/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
@@ -198,6 +198,32 @@ func TestBufferManagerIntervalFlushesOnlyBatchesReachingMaxAge(t *testing.T) {
 	require.Contains(t, controller.buffer.tables, secondTask.versionedTable)
 }
 
+func TestTableBatchesNextIntervalFlushDeadline(t *testing.T) {
+	t.Parallel()
+
+	var empty tableBatches
+	_, ok := empty.nextIntervalFlushDeadline(5 * time.Second)
+	require.False(t, ok)
+
+	base := time.Unix(100, 0)
+	firstTask := newBufferedTask("table1", commonType.NewDispatcherID(), `{"id":1}`)
+	secondTask := newBufferedTask("table2", commonType.NewDispatcherID(), `{"id":2}`)
+
+	batches := newTableBatches()
+	batches.tables[firstTask.versionedTable] = &tableBatch{
+		size:         1,
+		firstEntryAt: base.Add(2 * time.Second),
+	}
+	batches.tables[secondTask.versionedTable] = &tableBatch{
+		size:         1,
+		firstEntryAt: base,
+	}
+
+	deadline, ok := batches.nextIntervalFlushDeadline(5 * time.Second)
+	require.True(t, ok)
+	require.Equal(t, base.Add(5*time.Second), deadline)
+}
+
 func newBufferedTask(table string, dispatcherID commonType.DispatcherID, payload string) *task {
 	tableInfo := &commonType.TableInfo{
 		TableName: commonType.TableName{

--- a/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
+++ b/downstreamadapter/sink/cloudstorage/buffer_manager_test.go
@@ -171,7 +171,9 @@ func TestBufferManagerSizeFlushesWithoutWaitingForMaxAge(t *testing.T) {
 	}, spoolBuffer, flushSink.enqueueFlushTask)
 
 	task := newBufferedTask("table1", commonType.NewDispatcherID(), `{"id":1}`)
-	require.NoError(t, controller.handleDMLTask(context.Background(), task))
+	timerDirty, err := controller.handleDMLTask(context.Background(), task)
+	require.NoError(t, err)
+	require.True(t, timerDirty)
 
 	select {
 	case flushed := <-flushSink.ch:
@@ -184,6 +186,46 @@ func TestBufferManagerSizeFlushesWithoutWaitingForMaxAge(t *testing.T) {
 		t.Fatal("buffer controller did not flush size-reached batch immediately")
 	}
 	require.Empty(t, controller.buffer.tables)
+}
+
+func TestBufferManagerDMLTaskMarksTimerDirtyOnlyWhenBatchDeadlineCanChange(t *testing.T) {
+	t.Parallel()
+
+	changefeedID := commonType.NewChangefeedID4Test("test", "buffer-timer-dirty")
+	flushSink := newTestFlushTaskSink(16)
+	spoolBuffer, err := spool.New(
+		changefeedID,
+		spool.WithRootDir(t.TempDir()),
+		spool.WithDiskQuotaBytes(1<<20),
+		spool.WithMemoryRatio(0.5),
+	)
+	require.NoError(t, err)
+	defer spoolBuffer.Close()
+
+	controller := newBufferManager(changefeedID, &cloudstorage.Config{
+		FlushInterval:    time.Hour,
+		FileSize:         1 << 20,
+		SpoolDiskQuota:   1 << 20,
+		FileIndexWidth:   6,
+		UseTableIDAsPath: false,
+	}, spoolBuffer, flushSink.enqueueFlushTask)
+
+	dispatcherID := commonType.NewDispatcherID()
+	firstTask := newBufferedTask("table1", dispatcherID, `{"id":1}`)
+	timerDirty, err := controller.handleDMLTask(context.Background(), firstTask)
+	require.NoError(t, err)
+	require.True(t, timerDirty)
+
+	secondTask := newBufferedTask("table1", dispatcherID, `{"id":2}`)
+	timerDirty, err = controller.handleDMLTask(context.Background(), secondTask)
+	require.NoError(t, err)
+	require.False(t, timerDirty)
+
+	thirdTask := newBufferedTask("table2", commonType.NewDispatcherID(), `{"id":3}`)
+	timerDirty, err = controller.handleDMLTask(context.Background(), thirdTask)
+	require.NoError(t, err)
+	require.True(t, timerDirty)
+	require.Empty(t, flushSink.ch)
 }
 
 func TestBufferManagerIntervalFlushesOnlyBatchesReachingMaxAge(t *testing.T) {

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/ticdc/pkg/pdutil"
 	putil "github.com/pingcap/ticdc/pkg/util"
 	"github.com/pingcap/ticdc/utils/chann"
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,11 +146,49 @@ func TestCloudStoragePostEnqueueBeforeFlush(t *testing.T) {
 	require.ErrorIs(t, <-runDone, context.Canceled)
 }
 
-func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
+func TestCloudStorageWriteEvents(t *testing.T) {
 	t.Run("add dml does not call post enqueue before run", verifyAddDMLEventDoesNotCallPostEnqueueBeforePipelineRun)
+
+	helper, job, dmls, batch := newCloudStorageWriteEventsFixture(t)
+	t.Run("without date separator", func(t *testing.T) {
+		verifyCloudStorageWriteEventsWithoutDateSeparator(t, helper, job, dmls, batch)
+	})
+	t.Run("with date separator", func(t *testing.T) {
+		verifyCloudStorageWriteEventsWithDateSeparator(t, helper, job, dmls, batch)
+	})
+}
+
+func newCloudStorageWriteEventsFixture(
+	t *testing.T,
+) (*commonEvent.EventTestHelper, *timodel.Job, []string, int) {
+	t.Helper()
+
+	helper := commonEvent.NewEventTestHelper(t)
+	t.Cleanup(helper.Close)
+
+	helper.Tk().MustExec("use test")
+	job := helper.DDL2Job("create table table1(c1 int, c2 varchar(255))")
+	require.NotNil(t, job)
+	helper.ApplyJob(job)
+
+	batch := 100
+	dmls := make([]string, 0, batch)
+	for j := 0; j < batch; j++ {
+		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
+	}
+	return helper, job, dmls, batch
+}
+
+func verifyCloudStorageWriteEventsWithoutDateSeparator(
+	t *testing.T,
+	helper *commonEvent.EventTestHelper,
+	job *timodel.Job,
+	dmls []string,
+	batch int,
+) {
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=3600s&file-size=1024", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -171,20 +210,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 	defer cancelAndWaitSink(t, cancel, runDone)
 
-	var cnt uint64 = 0
-	batch := 100
-
-	helper := commonEvent.NewEventTestHelper(t)
-	defer helper.Close()
-
-	helper.Tk().MustExec("use test")
-	job := helper.DDL2Job("create table table1(c1 int, c2 varchar(255))")
-	require.NotNil(t, job)
-	helper.ApplyJob(job)
-	dmls := make([]string, 0, batch)
-	for j := 0; j < batch; j++ {
-		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
-	}
+	var cnt uint64
 	dispatcherID := common.NewDispatcherID()
 	event := helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -214,7 +240,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(100), atomic.LoadUint64(&cnt))
+	require.Equal(t, uint64(batch), atomic.LoadUint64(&cnt))
 
 	// generating another dml file.
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
@@ -241,7 +267,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
+	require.Equal(t, 2*uint64(batch), atomic.LoadUint64(&cnt))
 
 }
 
@@ -267,10 +293,16 @@ func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
 	}
 }
 
-func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
+func verifyCloudStorageWriteEventsWithDateSeparator(
+	t *testing.T,
+	helper *commonEvent.EventTestHelper,
+	job *timodel.Job,
+	dmls []string,
+	batch int,
+) {
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=3600s&file-size=1024", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -292,20 +324,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 
 	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 
-	var cnt uint64 = 0
-	batch := 100
-
-	helper := commonEvent.NewEventTestHelper(t)
-	defer helper.Close()
-
-	helper.Tk().MustExec("use test")
-	job := helper.DDL2Job("create table table1(c1 int, c2 varchar(255))")
-	require.NotNil(t, job)
-	helper.ApplyJob(job)
-	dmls := make([]string, 0, batch)
-	for j := 0; j < batch; j++ {
-		dmls = append(dmls, fmt.Sprintf("insert into table1 values (%d, 'hello world')", j))
-	}
+	var cnt uint64
 
 	dispatcherID := common.NewDispatcherID()
 	event := helper.DML2Event(job.SchemaName, job.TableName, dmls...)
@@ -405,7 +424,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
-	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
+	require.Equal(t, 3*uint64(batch), atomic.LoadUint64(&cnt))
 	cancelAndWaitSink(t, cancel, runDone)
 
 	// test table is scheduled from one node to another

--- a/downstreamadapter/sink/cloudstorage/dml_writers_test.go
+++ b/downstreamadapter/sink/cloudstorage/dml_writers_test.go
@@ -23,10 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/failpoint"
 	pclock "github.com/pingcap/ticdc/pkg/clock"
 	"github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/pdutil"
@@ -65,8 +63,7 @@ func verifyAddDMLEventDoesNotCallPostEnqueueBeforePipelineRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -106,8 +103,7 @@ func TestCloudStoragePostEnqueueBeforeFlush(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -153,7 +149,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	t.Run("add dml does not call post enqueue before run", verifyAddDMLEventDoesNotCallPostEnqueueBeforePipelineRun)
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=%ds", parentDir, 2)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -167,13 +163,13 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	var cnt uint64 = 0
 	batch := 100
@@ -198,7 +194,9 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	event.DispatcherID = dispatcherID
 
 	cloudStorageSink.AddDMLEvent(event)
-	time.Sleep(3 * time.Second)
+	require.Eventually(t, func() bool {
+		return atomic.LoadUint64(&cnt) == uint64(batch)
+	}, testEventuallyTimeout, testEventuallyTick, "wait for first event consumed")
 	metaDir := path.Join(parentDir, "test/table1/meta")
 	files, err := os.ReadDir(metaDir)
 	require.NoError(t, err)
@@ -227,7 +225,9 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	event.DispatcherID = dispatcherID
 
 	cloudStorageSink.AddDMLEvent(event)
-	time.Sleep(3 * time.Second)
+	require.Eventually(t, func() bool {
+		return atomic.LoadUint64(&cnt) == 2*uint64(batch)
+	}, testEventuallyTimeout, testEventuallyTick, "wait for second event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
 	require.Len(t, fileNames, 3)
@@ -243,7 +243,6 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(200), atomic.LoadUint64(&cnt))
 
-	cloudStorageSink.Close()
 }
 
 func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
@@ -271,7 +270,7 @@ func TestSubmitTaskToEncoderExitOnContextCancel(t *testing.T) {
 func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	parentDir := t.TempDir()
 
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=%ds", parentDir, 4)
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", parentDir)
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -285,16 +284,13 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	mockClock := pclock.NewMock()
 	mockClock.Set(time.Date(2023, 3, 8, 23, 59, 58, 0, time.UTC))
 	clock := pdutil.NewMonotonicClock(mockClock)
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	setPDClock := setPDClockForTest(t, clock)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
 
 	var cnt uint64 = 0
 	batch := 100
@@ -322,7 +318,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	tableDir := path.Join(parentDir, fmt.Sprintf("%s/%s/%d/2023-03-08", job.SchemaName, job.TableName, event.TableInfoVersion))
 	fileNames := getTableFiles(t, tableDir)
@@ -336,23 +332,19 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 
-	cancel()
-	time.Sleep(5 * time.Second)
+	cancelAndWaitSink(t, cancel, runDone)
 
 	// test date (day) is NOT changed.
 	mockClock.Set(time.Date(2023, 3, 8, 23, 59, 59, 0, time.UTC))
 	clock = pdutil.NewMonotonicClock(mockClock)
 
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	setPDClock(clock)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cloudStorageSink, err = newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone = runSinkInBackground(t, ctx, cloudStorageSink)
 
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -364,7 +356,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == 2*uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
 	require.Len(t, fileNames, 3)
@@ -376,29 +368,19 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	content, err = os.ReadFile(path.Join(tableDir, fmt.Sprintf("meta/CDC_%s.index", dispatcherID.String())))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
-	cancel()
-
-	time.Sleep(5 * time.Second)
+	cancelAndWaitSink(t, cancel, runDone)
 
 	// test date (day) is changed.
 	mockClock.Set(time.Date(2023, 3, 9, 0, 0, 10, 0, time.UTC))
 	clock = pdutil.NewMonotonicClock(mockClock)
 
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	setPDClock(clock)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cloudStorageSink, err = newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	failpoint.Enable("github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/passTickerOnce", "1*return")
-	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/passTickerOnce")
-	}()
-
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone = runSinkInBackground(t, ctx, cloudStorageSink)
 
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -410,7 +392,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == 3*uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	tableDir = path.Join(parentDir, fmt.Sprintf("test/table1/%d/2023-03-09", event.TableInfoVersion))
 	fileNames = getTableFiles(t, tableDir)
@@ -424,25 +406,20 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000001.csv\n", dispatcherID.String()), string(content))
 	require.Equal(t, uint64(300), atomic.LoadUint64(&cnt))
-	cloudStorageSink.Close()
-
-	cancel()
-	time.Sleep(5 * time.Second)
+	cancelAndWaitSink(t, cancel, runDone)
 
 	// test table is scheduled from one node to another
 	cnt = 0
 	mockClock = pclock.NewMock()
 	mockClock.Set(time.Date(2023, 3, 9, 0, 1, 10, 0, time.UTC))
-	appcontext.SetService(appcontext.DefaultPDClock, clock)
+	clock = pdutil.NewMonotonicClock(mockClock)
+	setPDClock(clock)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cloudStorageSink, err = newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go func() {
-		err = cloudStorageSink.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	}()
+	runDone = runSinkInBackground(t, ctx, cloudStorageSink)
 
 	event = helper.DML2Event(job.SchemaName, job.TableName, dmls...)
 	event.TableInfoVersion = job.BinlogInfo.FinishedTS
@@ -454,7 +431,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	cloudStorageSink.AddDMLEvent(event)
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(&cnt) == uint64(batch)
-	}, 30*time.Second, time.Second, "wait for event consumed")
+	}, testEventuallyTimeout, testEventuallyTick, "wait for event consumed")
 
 	fileNames = getTableFiles(t, tableDir)
 	require.Len(t, fileNames, 3)
@@ -467,5 +444,5 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("CDC_%s_000002.csv\n", dispatcherID.String()), string(content))
 
-	cancel()
+	cancelAndWaitSink(t, cancel, runDone)
 }

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/pdutil"
@@ -54,7 +53,7 @@ func newSinkForTest(
 }
 
 func TestBasicFunctionality(t *testing.T) {
-	uri := fmt.Sprintf("file:///%s?protocol=csv", t.TempDir())
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", t.TempDir())
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -65,12 +64,12 @@ func TestBasicFunctionality(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	var count atomic.Int64
 
@@ -132,7 +131,7 @@ func TestBasicFunctionality(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return count.Load() == 2
-	}, 10*time.Second, 100*time.Millisecond)
+	}, testEventuallyTimeout, testEventuallyTick)
 
 	ddlEvent2.PostFlush()
 
@@ -151,8 +150,7 @@ func TestIgnoreCallsAfterRunError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -223,13 +221,13 @@ func TestWriteDDLEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -297,13 +295,13 @@ func verifyWriteDDLEventFlushDMLBeforeBlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	helper := commonEvent.NewEventTestHelper(t)
 	defer helper.Close()
@@ -360,13 +358,13 @@ func TestWriteDDLEventWithTableIDAsPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -413,13 +411,13 @@ func TestSkipDatabaseSchemaWithTableIDAsPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
 	ddlEvent := &commonEvent.DDLEvent{
 		Query:      "create database test_db",
@@ -478,8 +476,7 @@ func TestWriteDDLEventWithInvalidExchangePartitionEvent(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			mockPDClock := pdutil.NewClock4Test()
-			appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+			setPDClockForTest(t, pdutil.NewClock4Test())
 
 			cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 			require.NoError(t, err)
@@ -530,8 +527,7 @@ func TestWriteExchangePartitionDDLEventUsesTargetNames(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
@@ -621,20 +617,18 @@ func TestWriteCheckpointEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
 
-	go cloudStorageSink.Run(ctx)
-	time.Sleep(3 * time.Second)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
+	cloudStorageSink.lastSendCheckpointTsTime = time.Now().Add(-2 * time.Second)
 	cloudStorageSink.AddCheckpointTs(100)
 
-	time.Sleep(2 * time.Second)
-	metadata, err := os.ReadFile(path.Join(parentDir, "metadata"))
-	require.NoError(t, err)
+	metadata := readFileEventually(t, path.Join(parentDir, "metadata"))
 	require.JSONEq(t, `{"checkpoint-ts":100}`, string(metadata))
 }
 
@@ -651,8 +645,7 @@ func TestCloseBeforeRunDoesNotPanicAndCleansSpool(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	changefeedID := common.NewChangefeedID4Test("test", "close-before-run")
 	cloudStorageSink, err := New(ctx, changefeedID, sinkURI, replicaConfig.Sink, true, nil)
@@ -686,23 +679,32 @@ func TestCleanupExpiredFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	var count atomic.Int64
+	cleanupDone := make(chan struct{}, 1)
 	cleanupJobs := []func(){
 		func() {
 			count.Add(1)
+			select {
+			case cleanupDone <- struct{}{}:
+			default:
+			}
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, cleanupJobs)
-	go cloudStorageSink.Run(ctx)
 	require.NoError(t, err)
+	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
+	defer cancelAndWaitSink(t, cancel, runDone)
 
-	time.Sleep(5 * time.Second)
+	select {
+	case <-cleanupDone:
+	case <-time.After(testEventuallyTimeout):
+		t.Fatal("cleanup job did not run")
+	}
 	require.LessOrEqual(t, int64(1), count.Load())
 }
 

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -53,7 +54,7 @@ func newSinkForTest(
 }
 
 func TestBasicFunctionality(t *testing.T) {
-	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=100ms", t.TempDir())
+	uri := fmt.Sprintf("file:///%s?protocol=csv&flush-interval=3600s&file-size=1024", t.TempDir())
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 
@@ -77,7 +78,7 @@ func TestBasicFunctionality(t *testing.T) {
 	defer helper.Close()
 
 	helper.Tk().MustExec("use test")
-	createTableSQL := "create table t (id int primary key, name varchar(32));"
+	createTableSQL := "create table t (id int primary key, name varchar(2048));"
 	job := helper.DDL2Job(createTableSQL)
 	require.NotNil(t, job)
 	helper.ApplyJob(job)
@@ -116,7 +117,12 @@ func TestBasicFunctionality(t *testing.T) {
 		},
 	}
 
-	dmlEvent := helper.DML2Event("test", "t", "insert into t values (1, 'test')", "insert into t values (2, 'test2');")
+	dmlEvent := helper.DML2Event(
+		"test",
+		"t",
+		fmt.Sprintf("insert into t values (1, '%s')", strings.Repeat("x", 1024)),
+		fmt.Sprintf("insert into t values (2, '%s')", strings.Repeat("y", 1024)),
+	)
 	dmlEvent.TableInfoVersion = job.BinlogInfo.FinishedTS
 	dmlEvent.PostTxnFlushed = []func(){
 		func() {
@@ -225,9 +231,7 @@ func TestWriteDDLEvent(t *testing.T) {
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
-
-	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
-	defer cancelAndWaitSink(t, cancel, runDone)
+	defer cloudStorageSink.Close()
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -362,9 +366,7 @@ func TestWriteDDLEventWithTableIDAsPath(t *testing.T) {
 
 	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, nil)
 	require.NoError(t, err)
-
-	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
-	defer cancelAndWaitSink(t, cancel, runDone)
+	defer cloudStorageSink.Close()
 
 	tableInfo := common.WrapTableInfo("test", &timodel.TableInfo{
 		ID:   20,
@@ -673,7 +675,7 @@ func TestCleanupExpiredFiles(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Sink.CloudStorageConfig = &config.CloudStorageConfig{
 		FileExpirationDays:  util.AddressOf(1),
-		FileCleanupCronSpec: util.AddressOf("* * * * * *"),
+		FileCleanupCronSpec: util.AddressOf("@every 1ms"),
 	}
 	err = replicaConfig.ValidateAndAdjust(sinkURI)
 	require.NoError(t, err)
@@ -693,12 +695,20 @@ func TestCleanupExpiredFiles(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	setPDClockForTest(t, pdutil.NewClock4Test())
-
-	cloudStorageSink, err := newSinkForTest(ctx, replicaConfig, sinkURI, cleanupJobs)
-	require.NoError(t, err)
-	runDone := runSinkInBackground(t, ctx, cloudStorageSink)
-	defer cancelAndWaitSink(t, cancel, runDone)
+	cloudStorageSink := &sink{
+		changefeedID: common.NewChangefeedID4Test("test", "test"),
+		cfg: &pkgcloudstorage.Config{
+			DateSeparator:       config.DateSeparatorDay.String(),
+			FileExpirationDays:  1,
+			FileCleanupCronSpec: util.GetOrZero(replicaConfig.Sink.CloudStorageConfig.FileCleanupCronSpec),
+		},
+	}
+	require.NoError(t, cloudStorageSink.initCron(ctx, sinkURI, cleanupJobs))
+	cleanupDoneCh := make(chan struct{}, 1)
+	go func() {
+		cloudStorageSink.bgCleanup(ctx)
+		cleanupDoneCh <- struct{}{}
+	}()
 
 	select {
 	case <-cleanupDone:
@@ -706,6 +716,12 @@ func TestCleanupExpiredFiles(t *testing.T) {
 		t.Fatal("cleanup job did not run")
 	}
 	require.LessOrEqual(t, int64(1), count.Load())
+	cancel()
+	select {
+	case <-cleanupDoneCh:
+	case <-time.After(testEventuallyTimeout):
+		t.Fatal("background cleanup did not exit after context cancel")
+	}
 }
 
 func TestRemoveEmptyDirsCleanupJobCanRunMultipleTimes(t *testing.T) {

--- a/downstreamadapter/sink/cloudstorage/sink_test.go
+++ b/downstreamadapter/sink/cloudstorage/sink_test.go
@@ -130,7 +130,9 @@ func TestBasicFunctionality(t *testing.T) {
 
 	cloudStorageSink.AddDMLEvent(dmlEvent)
 
-	time.Sleep(5 * time.Second)
+	require.Eventually(t, func() bool {
+		return count.Load() == 2
+	}, 10*time.Second, 100*time.Millisecond)
 
 	ddlEvent2.PostFlush()
 

--- a/downstreamadapter/sink/cloudstorage/test_helpers_test.go
+++ b/downstreamadapter/sink/cloudstorage/test_helpers_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudstorage
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	appcontext "github.com/pingcap/ticdc/pkg/common/context"
+	"github.com/pingcap/ticdc/pkg/pdutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testEventuallyTimeout = 5 * time.Second
+	testEventuallyTick    = 10 * time.Millisecond
+)
+
+func setPDClockForTest(t *testing.T, clock pdutil.Clock) func(pdutil.Clock) {
+	t.Helper()
+
+	previous, hasPrevious := appcontext.TryGetService[pdutil.Clock](appcontext.DefaultPDClock)
+
+	setClock := func(clock pdutil.Clock) {
+		appcontext.SetService(appcontext.DefaultPDClock, clock)
+	}
+	setClock(clock)
+
+	t.Cleanup(func() {
+		if hasPrevious {
+			appcontext.SetService(appcontext.DefaultPDClock, previous)
+		}
+	})
+	return setClock
+}
+
+func runSinkInBackground(t *testing.T, ctx context.Context, s *sink) <-chan error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run(ctx)
+	}()
+	return done
+}
+
+func cancelAndWaitSink(t *testing.T, cancel context.CancelFunc, done <-chan error) {
+	t.Helper()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(testEventuallyTimeout):
+		t.Fatal("sink.Run did not exit after context cancel")
+	}
+}
+
+func readFileEventually(t *testing.T, filePath string) []byte {
+	t.Helper()
+
+	var content []byte
+	require.Eventually(t, func() bool {
+		var err error
+		content, err = os.ReadFile(filePath)
+		return err == nil
+	}, testEventuallyTimeout, testEventuallyTick)
+	return content
+}

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -27,9 +27,7 @@ import (
 	"time"
 
 	"github.com/pingcap/ticdc/downstreamadapter/sink/cloudstorage/spool"
-	"github.com/pingcap/ticdc/pkg/clock"
 	commonType "github.com/pingcap/ticdc/pkg/common"
-	appcontext "github.com/pingcap/ticdc/pkg/common/context"
 	commonEvent "github.com/pingcap/ticdc/pkg/common/event"
 	"github.com/pingcap/ticdc/pkg/config"
 	"github.com/pingcap/ticdc/pkg/metrics"
@@ -47,7 +45,7 @@ import (
 )
 
 func testWriter(ctx context.Context, t *testing.T, dir string) *writer {
-	uri := fmt.Sprintf("file:///%s?flush-interval=2s", dir)
+	uri := fmt.Sprintf("file:///%s?flush-interval=100ms", dir)
 	storage, err := util.GetExternalStorageWithDefaultTimeout(ctx, uri)
 	require.NoError(t, err)
 	sinkURI, err := url.Parse(uri)
@@ -61,10 +59,7 @@ func testWriter(ctx context.Context, t *testing.T, dir string) *writer {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", t.Name())
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage,
 		cfg, ".json", statistics, spoolBuffer)
@@ -100,8 +95,6 @@ func hasSpoolLogFile(spoolDir string) bool {
 }
 
 func TestWriterRun(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	parentDir := t.TempDir()
 	d := testWriter(ctx, t, parentDir)
@@ -165,8 +158,6 @@ func TestWriterRun(t *testing.T) {
 }
 
 func TestWriterFlushMarker(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -229,8 +220,6 @@ func TestWriterFlushMarker(t *testing.T) {
 }
 
 func TestWriterFlushMarkerOnlyFlushesTargetDispatcher(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -326,8 +315,6 @@ func TestWriterFlushMarkerOnlyFlushesTargetDispatcher(t *testing.T) {
 }
 
 func TestWriterPostEnqueueAfterConsume(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	parentDir := t.TempDir()
@@ -422,10 +409,7 @@ func TestWriterStoresPendingMessagesInSpoolBeforeFlush(t *testing.T) {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", "spool-pending")
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
@@ -517,8 +501,6 @@ func TestDiscardPayloadDoesNotLoadSpilledPayload(t *testing.T) {
 }
 
 func TestWriterRunExitAfterContextCancel(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancelCause(context.Background())
 	parentDir := t.TempDir()
 	d := testWriter(ctx, t, parentDir)
@@ -593,10 +575,7 @@ func TestWriterIndexWriteError(t *testing.T) {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", "writer-error-metric")
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
 
@@ -659,10 +638,7 @@ func TestWriterDataFileCloseError(t *testing.T) {
 
 	changefeedID := commonType.NewChangefeedID4Test("test", "writer-close-error")
 	statistics := metrics.NewStatistics(changefeedID, t.Name())
-	pdlock := pdutil.NewMonotonicClock(clock.New())
-	appcontext.SetService(appcontext.DefaultPDClock, pdlock)
-	mockPDClock := pdutil.NewClock4Test()
-	appcontext.SetService(appcontext.DefaultPDClock, mockPDClock)
+	setPDClockForTest(t, pdutil.NewClock4Test())
 	spoolBuffer := newTestSpool(t, changefeedID, cfg)
 	d := newWriter(1, changefeedID, storage, cfg, ".json", statistics, spoolBuffer)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5276

Cloud storage sink previously used a periodic sweep for interval flushes. When many tables are active, one table reaching the flush interval can cause all buffered table batches in the shard to be flushed, creating small files for low-traffic tables. Some cloudstorage unit tests also relied on fixed sleeps and took longer than needed.

### What is changed and how it works?

- Track the first entry time for each table batch in the buffer manager.
- Use a dynamic interval timer based on the earliest per-table deadline.
- Flush a table batch when either size or age reaches the configured threshold, whichever happens first.
- Keep barrier and disk quota flush behavior unchanged.
- Avoid resetting the interval timer for every DML append when the batch deadline cannot change.
- Replace fixed sleeps in cloudstorage tests with deterministic polling and shared lifecycle helpers.

### Check List

#### Tests

- Unit test
  - `GOTOOLCHAIN=go1.25.10 go test --tags=intest ./downstreamadapter/sink/cloudstorage -run 'TestBufferManager|TestTableBatches' -count=1`
  - `GOTOOLCHAIN=go1.25.10 go test --tags=intest ./downstreamadapter/sink/cloudstorage -count=1`

#### Questions

##### Will it cause performance regression or break compatibility?

No compatibility impact. Public APIs, config names, and storage formats are unchanged. The runtime behavior is intended to reduce unnecessary small-file flushes; interval timer resets are limited to cases where buffered deadlines may change.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. The change preserves the existing `FlushInterval` and `FileSize` semantics.

### Release note

```release-note
Reduce small cloud storage sink files by using per-table age-based flush scheduling.
```