### PR TITLE
logservice: resolve shared locks in stale resolver (#5340)

### DIFF
--- a/logservice/txnutil/lock_resolver.go
+++ b/logservice/txnutil/lock_resolver.go
@@ -53,6 +53,32 @@ var (
 	metricResolveLockOperationDuration = metrics.SubscriptionClientResolveLockOperationDuration.WithLabelValues("resolve")
 )
 
+func resolveScanLockInfos(lockInfos []*kvrpcpb.LockInfo, resolve func([]*txnkv.Lock) (int64, error)) ([]*txnkv.Lock, int64, error) {
+	locks := make([]*txnkv.Lock, 0, len(lockInfos))
+	for _, lockInfo := range lockInfos {
+		sharedLockInfos := lockInfo.GetSharedLockInfos()
+		if len(sharedLockInfos) > 0 {
+			for _, sharedLockInfo := range sharedLockInfos {
+				locks = append(locks, txnkv.NewLock(sharedLockInfo))
+			}
+			continue
+		}
+		locks = append(locks, txnkv.NewLock(lockInfo))
+	}
+	if len(locks) == 0 {
+		return locks, 0, nil
+	}
+	msBeforeTxnExpired, err := resolve(locks)
+	return locks, msBeforeTxnExpired, err
+}
+
+func nextScanLockKey(locEndKey []byte, locks []*txnkv.Lock, msBeforeTxnExpired int64) []byte {
+	if msBeforeTxnExpired > 0 || len(locks) < scanLockLimit {
+		return locEndKey
+	}
+	return locks[len(locks)-1].Key
+}
+
 func (r *resolver) Resolve(ctx context.Context, keyspaceID uint32, regionID uint64, maxVersion uint64) (err error) {
 	var totalLocks []*txnkv.Lock
 
@@ -146,31 +172,28 @@ func (r *resolver) Resolve(ctx context.Context, keyspaceID uint32, regionID uint
 		}
 		metricScanLockOperationDuration.Observe(time.Since(scanLockStart).Seconds())
 		locksInfo := locksResp.GetLocks()
-		locks := make([]*txnkv.Lock, len(locksInfo))
-		for i := range locksInfo {
-			locks[i] = txnkv.NewLock(locksInfo[i])
-		}
+		locks, msBeforeTxnExpired, err1 := resolveScanLockInfos(locksInfo, func(locks []*txnkv.Lock) (int64, error) {
+			resolveLockStart := time.Now()
+			msBeforeTxnExpired, err := kvStorage.GetLockResolver().ResolveLocks(bo, 0, locks)
+			if err == nil {
+				metricResolveLockOperationDuration.Observe(time.Since(resolveLockStart).Seconds())
+			}
+			return msBeforeTxnExpired, err
+		})
 		totalLocks = append(totalLocks, locks...)
 		metricResolveLockFoundCounter.Add(float64(len(locks)))
 
+		if err1 != nil {
+			return errors.Trace(err1)
+		}
 		if len(locks) != 0 {
-			resolveLockStart := time.Now()
-			msBeforeTxnExpired, err := kvStorage.GetLockResolver().ResolveLocks(bo, 0, locks)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			metricResolveLockOperationDuration.Observe(time.Since(resolveLockStart).Seconds())
 			resolvedLockCount := len(locks)
 			if msBeforeTxnExpired > 0 {
 				resolvedLockCount = countExpiredLocks(kvStorage, locks)
 			}
 			metricResolveLockResolvedCounter.Add(float64(resolvedLockCount))
 		}
-		if len(locks) < scanLockLimit {
-			key = loc.EndKey
-		} else {
-			key = locks[len(locks)-1].Key
-		}
+		key = nextScanLockKey(loc.EndKey, locks, msBeforeTxnExpired)
 
 		if len(key) == 0 || (len(loc.EndKey) != 0 && bytes.Compare(key, loc.EndKey) >= 0) {
 			break

--- a/logservice/txnutil/lock_resolver_test.go
+++ b/logservice/txnutil/lock_resolver_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/txnkv"
+	"github.com/tikv/client-go/v2/txnkv/txnlock"
+)
+
+func TestDirectSharedLockWrapperResolveFails(t *testing.T) {
+	wrapper := &kvrpcpb.LockInfo{
+		Key:         []byte("shared-wrapper"),
+		LockVersion: 100,
+		LockType:    kvrpcpb.Op_SharedLock,
+		SharedLockInfos: []*kvrpcpb.LockInfo{
+			{
+				Key:         []byte("shared-wrapper"),
+				PrimaryLock: []byte("primary-1"),
+				LockVersion: 101,
+				LockType:    kvrpcpb.Op_Lock,
+			},
+		},
+	}
+	lock := txnkv.NewLock(wrapper)
+
+	_, err := txnlock.NewLockResolver(nil).ResolveLocks(
+		tikv.NewBackoffer(context.Background(), 1),
+		0,
+		[]*txnkv.Lock{lock},
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "trying to resolve a shared lock directly")
+}
+
+func TestResolveScanLockInfosExpandsSharedLockWrapper(t *testing.T) {
+	sharedLock1 := &kvrpcpb.LockInfo{
+		Key:         []byte("shared-key"),
+		PrimaryLock: []byte("primary-1"),
+		LockVersion: 101,
+		LockType:    kvrpcpb.Op_Lock,
+	}
+	sharedLock2 := &kvrpcpb.LockInfo{
+		Key:         []byte("shared-key"),
+		PrimaryLock: []byte("primary-2"),
+		LockVersion: 102,
+		LockType:    kvrpcpb.Op_PessimisticLock,
+	}
+	ordinaryLock := &kvrpcpb.LockInfo{
+		Key:         []byte("ordinary-key"),
+		PrimaryLock: []byte("ordinary-primary"),
+		LockVersion: 103,
+		LockType:    kvrpcpb.Op_Lock,
+	}
+	wrapper := &kvrpcpb.LockInfo{
+		Key:             []byte("shared-key"),
+		LockVersion:     100,
+		LockType:        kvrpcpb.Op_SharedLock,
+		SharedLockInfos: []*kvrpcpb.LockInfo{sharedLock1, sharedLock2},
+	}
+	var resolvedLocks []*txnkv.Lock
+
+	locks, ttl, err := resolveScanLockInfos([]*kvrpcpb.LockInfo{wrapper, ordinaryLock}, func(locks []*txnkv.Lock) (int64, error) {
+		for _, lock := range locks {
+			if lock.LockType == kvrpcpb.Op_SharedLock {
+				return 0, fmt.Errorf("unexpected shared lock wrapper")
+			}
+		}
+		resolvedLocks = append(resolvedLocks, locks...)
+		return 42, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(42), ttl)
+	require.Len(t, locks, 3)
+	require.Equal(t, locks, resolvedLocks)
+	require.Equal(t, []uint64{101, 102, 103}, []uint64{locks[0].TxnID, locks[1].TxnID, locks[2].TxnID})
+	require.Equal(t, []kvrpcpb.Op{kvrpcpb.Op_Lock, kvrpcpb.Op_PessimisticLock, kvrpcpb.Op_Lock},
+		[]kvrpcpb.Op{locks[0].LockType, locks[1].LockType, locks[2].LockType})
+	require.Equal(t, [][]byte{[]byte("shared-key"), []byte("shared-key"), []byte("ordinary-key")},
+		[][]byte{locks[0].Key, locks[1].Key, locks[2].Key})
+}
+
+func TestResolveScanLockInfosKeepsOrdinaryLocks(t *testing.T) {
+	ordinaryLock := &kvrpcpb.LockInfo{
+		Key:         []byte("ordinary-key"),
+		PrimaryLock: []byte("ordinary-primary"),
+		LockVersion: 103,
+		LockType:    kvrpcpb.Op_Lock,
+	}
+	var resolvedLocks []*txnkv.Lock
+
+	locks, ttl, err := resolveScanLockInfos([]*kvrpcpb.LockInfo{ordinaryLock}, func(locks []*txnkv.Lock) (int64, error) {
+		resolvedLocks = append(resolvedLocks, locks...)
+		return 0, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(0), ttl)
+	require.Len(t, locks, 1)
+	require.Equal(t, locks, resolvedLocks)
+	require.Equal(t, uint64(103), locks[0].TxnID)
+	require.Equal(t, []byte("ordinary-key"), locks[0].Key)
+	require.Equal(t, kvrpcpb.Op_Lock, locks[0].LockType)
+}
+
+func TestNextScanLockKeyStopsAtRegionEndWhenFullPageHasLiveLocks(t *testing.T) {
+	locks := make([]*txnkv.Lock, scanLockLimit)
+	for i := range locks {
+		locks[i] = &txnkv.Lock{Key: []byte("shared-key")}
+	}
+
+	key := nextScanLockKey([]byte("region-end"), locks, 1)
+
+	require.Equal(t, []byte("region-end"), key)
+}
+
+func TestNextScanLockKeyContinuesFromLastLockWhenFullPageHasNoLiveLocks(t *testing.T) {
+	locks := make([]*txnkv.Lock, scanLockLimit)
+	for i := range locks {
+		locks[i] = &txnkv.Lock{Key: []byte("shared-key")}
+	}
+	locks[len(locks)-1].Key = []byte("last-lock")
+
+	key := nextScanLockKey([]byte("region-end"), locks, 0)
+
+	require.Equal(t, []byte("last-lock"), key)
+}
+
+func TestNextScanLockKeyStopsAtRegionEndWhenPageIsNotFull(t *testing.T) {
+	locks := []*txnkv.Lock{{Key: []byte("last-lock")}}
+
+	key := nextScanLockKey([]byte("region-end"), locks, 0)
+
+	require.Equal(t, []byte("region-end"), key)
+}
+
+func TestSharedLockFullPageUsesResolveTTLForNextScanKey(t *testing.T) {
+	sharedLockInfos := make([]*kvrpcpb.LockInfo, scanLockLimit)
+	for i := range sharedLockInfos {
+		sharedLockInfos[i] = &kvrpcpb.LockInfo{
+			Key:         []byte("shared-key"),
+			PrimaryLock: fmt.Appendf(nil, "primary-%d", i),
+			LockVersion: uint64(i + 1),
+			LockType:    kvrpcpb.Op_Lock,
+		}
+	}
+	wrapper := &kvrpcpb.LockInfo{
+		Key:             []byte("shared-key"),
+		LockType:        kvrpcpb.Op_SharedLock,
+		SharedLockInfos: sharedLockInfos,
+	}
+
+	locks, ttl, err := resolveScanLockInfos([]*kvrpcpb.LockInfo{wrapper}, func(locks []*txnkv.Lock) (int64, error) {
+		require.Len(t, locks, scanLockLimit)
+		return 1, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), ttl)
+	require.Equal(t, []byte("region-end"), nextScanLockKey([]byte("region-end"), locks, ttl))
+	require.Equal(t, []byte("shared-key"), nextScanLockKey([]byte("region-end"), locks, 0))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Cherry-pick of #5340

Close #5206

`ScanLock` can return a shared lock wrapper for nextgen shared locks. Passing that wrapper directly to client-go `ResolveLocks` fails because shared lock wrappers must be expanded before resolving. The stale lock resolver can then leave locks unresolved.

### What is changed and how it works?

- Expand shared lock wrappers returned by `ScanLock` into their inner locks
  before calling `ResolveLocks`.

### Check List

#### Tests

- Unit test

```bash
GOCACHE=/tmp/ticdc-gocache go test -count=1 ./logservice/txnutil
git diff --check HEAD
```

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only expands shared lock wrappers before resolving and preserves the existing ordinary-lock path. It also avoids repeated same-key scanning when live locks remain.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved lock scanning and resolution: shared-lock wrappers are expanded into individual locks and scan continuation logic better respects resolved lock TTLs for paging.

* **Tests**
  * Added unit tests covering shared-lock handling (expansion and direct-resolve failure), lock resolution metrics, and scan-key paging/termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
