### PR TITLE
test: fix unstable unit test TestScaleNode

### DIFF
--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -561,7 +561,7 @@ func TestScaleNode(t *testing.T) {
 		},
 	})
 	requireBootstrapNodeRemoved(t, co, waitTime, info3.ID)
-	
+
 	require.Eventually(t, func() bool {
 		return co.controller.changefeedDB.GetReplicatingSize() == changefeedNumber
 	}, waitTime, time.Millisecond*5)

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -542,6 +542,7 @@ func TestScaleNode(t *testing.T) {
 			config.CaptureID(info3.ID): {ID: config.CaptureID(info3.ID), AdvertiseAddr: info3.AdvertiseAddr},
 		},
 	})
+	requireBootstrapReady(t, co, waitTime, info2.ID, info3.ID)
 
 	require.Eventually(t, func() bool {
 		return co.controller.changefeedDB.GetReplicatingSize() == changefeedNumber
@@ -559,7 +560,8 @@ func TestScaleNode(t *testing.T) {
 			config.CaptureID(info2.ID): {ID: config.CaptureID(info2.ID), AdvertiseAddr: info2.AdvertiseAddr},
 		},
 	})
-
+	requireBootstrapNodeRemoved(t, co, waitTime, info3.ID)
+	
 	require.Eventually(t, func() bool {
 		return co.controller.changefeedDB.GetReplicatingSize() == changefeedNumber
 	}, waitTime, time.Millisecond*5)
@@ -569,6 +571,27 @@ func TestScaleNode(t *testing.T) {
 	}, waitTime, time.Millisecond*5)
 
 	log.Info("pass scale node")
+}
+
+func requireBootstrapReady(t *testing.T, co *coordinator, waitTime time.Duration, nodes ...node.ID) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		for _, id := range nodes {
+			if !co.controller.bootstrapper.NodeInitialized(id) {
+				return false
+			}
+		}
+		return true
+	}, waitTime, time.Millisecond*5)
+}
+
+func requireBootstrapNodeRemoved(t *testing.T, co *coordinator, waitTime time.Duration, id node.ID) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return !co.controller.bootstrapper.HasNode(id)
+	}, waitTime, time.Millisecond*5)
 }
 
 func TestBootstrapWithUnStoppedChangefeed(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4837

### What is changed and how it works?
TestScaleNode no longer assumes that a NodeManager.Tick has already completed all coordinator bootstrap side effects. After adding
  nodes, the test now waits until the new nodes are initialized in the coordinator bootstrapper before asserting the 2/2/2 distribution. After removing a node, it waits until that
  node has been removed from bootstrap tracking before asserting the 3/3 distribution

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved node-scaling tests to wait for and assert bootstrapper state changes: verifies nodes become initialized after addition and are removed after deletion, using timed polling to ensure reliable membership checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->