### PR TITLE
pkg/eventservice: add scan window switch

### DIFF
--- a/pkg/config/debug.go
+++ b/pkg/config/debug.go
@@ -123,6 +123,8 @@ type EventServiceConfig struct {
 	// DMLEventMaxBytes is the maximum size of a DML event in bytes when split txn is enabled.
 	DMLEventMaxBytes int64 `toml:"dml-event-max-bytes" json:"dml_event_max_bytes"`
 
+	EnableScanWindow bool `toml:"enable-scan-window" json:"enable_scan_window"`
+
 	// FIXME: For now we found cdc may OOM when there is a large amount of events to be sent to event collector from a remote event service.
 	// So we add this config to be able to disable remote event service in such scenario.
 	// TODO: Remove this config after we find a proper way to fix the OOM issue.
@@ -137,6 +139,7 @@ func NewDefaultEventServiceConfig() *EventServiceConfig {
 		ScanLimitInBytes:         1024 * 1024 * 256, // 256MB
 		DMLEventMaxRows:          256,
 		DMLEventMaxBytes:         1024 * 1024 * 1, // 1MB
+		EnableScanWindow:         true,
 		EnableRemoteEventService: true,
 	}
 }

--- a/pkg/eventservice/dispatcher_stat.go
+++ b/pkg/eventservice/dispatcher_stat.go
@@ -431,10 +431,32 @@ type changefeedStatus struct {
 }
 
 func newChangefeedStatus(changefeedID common.ChangeFeedID, syncPointInterval time.Duration) *changefeedStatus {
+	return newChangefeedStatusWithScanWindow(
+		changefeedID,
+		syncPointInterval,
+		isScanWindowEnabled(),
+	)
+}
+
+func isScanWindowEnabled() bool {
+	cfg := config.GetGlobalServerConfig()
+	if cfg == nil || cfg.Debug == nil || cfg.Debug.EventService == nil {
+		return true
+	}
+	return cfg.Debug.EventService.EnableScanWindow
+}
+
+func newChangefeedStatusWithScanWindow(
+	changefeedID common.ChangeFeedID,
+	syncPointInterval time.Duration,
+	enableScanWindow bool,
+) *changefeedStatus {
 	status := &changefeedStatus{
-		changefeedID:         changefeedID,
-		scanWindowController: newAdaptiveScanWindowController(time.Now()),
-		syncPointInterval:    syncPointInterval,
+		changefeedID:      changefeedID,
+		syncPointInterval: syncPointInterval,
+	}
+	if enableScanWindow {
+		status.scanWindowController = newAdaptiveScanWindowController(time.Now())
 	}
 	status.scanInterval.Store(int64(defaultScanInterval))
 

--- a/pkg/eventservice/event_broker.go
+++ b/pkg/eventservice/event_broker.go
@@ -1258,7 +1258,9 @@ func (c *eventBroker) getOrSetChangefeedStatus(info DispatcherInfo) *changefeedS
 		return actual.(*changefeedStatus)
 	}
 	log.Info("new changefeed status", zap.Stringer("changefeedID", changefeedID))
-	initializeScanWindowMetrics(changefeedID.String())
+	if status.scanWindowController != nil {
+		initializeScanWindowMetrics(changefeedID.String())
+	}
 	return status
 }
 

--- a/pkg/eventservice/scan_window.go
+++ b/pkg/eventservice/scan_window.go
@@ -811,6 +811,10 @@ func (c *changefeedStatus) maxScanInterval() time.Duration {
 }
 
 func (c *changefeedStatus) refreshMinSentResolvedTs() {
+	if c.scanWindowController == nil {
+		return
+	}
+
 	now := time.Now()
 	minSentResolvedTs := ^uint64(0)
 	minSentResolvedTsWithStale := ^uint64(0)
@@ -854,6 +858,10 @@ func (c *changefeedStatus) refreshMinSentResolvedTs() {
 }
 
 func (c *changefeedStatus) getScanMaxTs() uint64 {
+	if c.scanWindowController == nil {
+		return 0
+	}
+
 	baseTs := c.minSentTs.Load()
 	if baseTs == 0 {
 		return 0
@@ -872,7 +880,9 @@ func (c *changefeedStatus) storeMinSentTs(value uint64) {
 		return
 	}
 	c.minSentTs.Store(value)
-	metrics.EventServiceScanWindowBaseTsGaugeVec.WithLabelValues(c.changefeedID.String()).Set(float64(value))
+	if c.scanWindowController != nil {
+		metrics.EventServiceScanWindowBaseTsGaugeVec.WithLabelValues(c.changefeedID.String()).Set(float64(value))
+	}
 }
 
 func scaleDuration(d time.Duration, numerator int64, denominator int64) time.Duration {

--- a/pkg/eventservice/scan_window_test.go
+++ b/pkg/eventservice/scan_window_test.go
@@ -466,3 +466,21 @@ func TestGetScanMaxTsFallbackInterval(t *testing.T) {
 	status.minSentTs.Store(0)
 	require.Equal(t, uint64(0), status.getScanMaxTs())
 }
+
+func TestScanWindowDisabledSkipsAdjustmentAndCap(t *testing.T) {
+	t.Parallel()
+
+	status := newChangefeedStatusWithScanWindow(
+		common.NewChangefeedID4Test("default", "test"),
+		1*time.Minute,
+		false,
+	)
+	require.Nil(t, status.scanWindowController)
+
+	status.scanInterval.Store(int64(40 * time.Second))
+	status.updateMemoryUsage(time.Now().Add(memoryUsageWindowDuration), 1, 0)
+	require.Equal(t, int64(40*time.Second), status.scanInterval.Load())
+
+	status.minSentTs.Store(oracle.GoTimeToTS(time.Unix(1234, 0)))
+	require.Equal(t, uint64(0), status.getScanMaxTs())
+}


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #5394

Scan window changes event service scan scheduling and needs a fast rollback switch during rollout or incident mitigation.

### What is changed and how it works?

This PR adds `debug.event-service.enable-scan-window`, defaulting to true to preserve current behavior. When disabled, changefeed status does not create a scan window controller, skips scan window metrics initialization and memory-based interval adjustment, and returns no scan max ts cap.

### Check List

#### Tests
- Unit test
  - `GOFLAGS=-mod=mod make unit_test_pkg PKG=./pkg/eventservice/...`
  - `GOFLAGS=-mod=mod make unit_test_pkg PKG=./pkg/config/...`
- Manual test
  - `GOFLAGS=-mod=mod make cdc`

#### Questions

##### Will it cause performance regression or break compatibility?

No. The new switch defaults to enabled, so existing behavior is unchanged unless it is explicitly disabled.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This is a debug event service configuration switch.

### Release note
```release-note
Add a debug configuration switch to disable event service scan window.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `EnableScanWindow` configuration option to control adaptive scan window feature in the event service. Enabled by default.

* **Tests**
  * Added test to verify scan window behavior when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->