### PR TITLE
event: add string to table info and do not use zap.Any for logging

### DIFF
--- a/downstreamadapter/dispatcher/basic_dispatcher.go
+++ b/downstreamadapter/dispatcher/basic_dispatcher.go
@@ -355,7 +355,7 @@ func (d *BasicDispatcher) AddBlockEventToSink(event commonEvent.BlockEvent) erro
 		// If NotSync is true, it means the DDL should not be sent to downstream.
 		// So we just call PassBlockEventToSink to update the table progress and call the postFlush func.
 		if ddl.NotSync {
-			log.Info("ignore DDL by NotSync", zap.Stringer("dispatcher", d.id), zap.Any("ddl", ddl))
+			log.Info("ignore DDL by NotSync", zap.Stringer("dispatcher", d.id), zap.String("ddl", ddl.GetDDLQuery()))
 			d.PassBlockEventToSink(event)
 			return nil
 		}
@@ -697,7 +697,7 @@ func (d *BasicDispatcher) handleEvents(dispatcherEvents []DispatcherEvent, wakeC
 				cost := time.Since(now)
 				d.sharedInfo.metricHandleDDLHis.Observe(cost.Seconds())
 				log.Debug("dispatcher handle ddl event finish",
-					zap.Duration("cost", cost), zap.Any("ddl", ddl))
+					zap.Duration("cost", cost), zap.String("query", ddl.Query))
 			})
 			d.DealWithBlockEvent(ddl)
 		case commonEvent.TypeSyncPointEvent:

--- a/downstreamadapter/eventcollector/dispatcher_stat.go
+++ b/downstreamadapter/eventcollector/dispatcher_stat.go
@@ -261,7 +261,6 @@ func (d *dispatcherStat) shouldForwardEventByCommitTs(event dispatcher.Dispatche
 			zap.Stringer("changefeedID", d.target.GetChangefeedID()),
 			zap.Int64("tableID", d.target.GetTableSpan().TableID),
 			zap.Stringer("dispatcher", d.getDispatcherID()),
-			zap.Any("event", event.Event),
 			zap.Uint64("eventCommitTs", event.GetCommitTs()),
 			zap.Uint64("sentCommitTs", d.lastEventCommitTs.Load()))
 		return false
@@ -411,7 +410,6 @@ func (d *dispatcherStat) handleSingleDataEvents(events []dispatcher.DispatcherEv
 			zap.Stringer("changefeedID", d.target.GetChangefeedID()),
 			zap.Stringer("dispatcher", d.getDispatcherID()),
 			zap.String("eventType", commonEvent.TypeToString(events[0].GetType())),
-			zap.Any("event", events[0].Event),
 			zap.Uint64("eventEpoch", events[0].GetEpoch()),
 			zap.Uint64("dispatcherEpoch", state.epoch),
 			zap.Stringer("staleEventService", *from),

--- a/downstreamadapter/sink/blackhole/sink.go
+++ b/downstreamadapter/sink/blackhole/sink.go
@@ -67,7 +67,7 @@ func (s *Sink) WriteBlockEvent(event commonEvent.BlockEvent) error {
 		e := event.(*commonEvent.DDLEvent)
 		// NOTE: don't change the log, integration test `lossy_ddl` depends on it.
 		// ref: https://github.com/pingcap/ticdc/blob/da834db76e0662ff15ef12645d1f37bfa6506d83/tests/integration_tests/lossy_ddl/run.sh#L17
-		log.Debug("BlackHoleSink: DDL Event", zap.Any("ddl", e))
+		log.Debug("BlackHoleSink: DDL Event", zap.String("ddl", e.GetDDLQuery()))
 		ddlType := e.GetDDLType().String()
 		err := s.statistics.RecordDDLExecution(func() (string, error) {
 			return ddlType, nil

--- a/downstreamadapter/sink/cloudstorage/writer_test.go
+++ b/downstreamadapter/sink/cloudstorage/writer_test.go
@@ -146,15 +146,18 @@ func TestWriterRun(t *testing.T) {
 		_ = d.run(ctx)
 	}()
 
+	dataFileName := fmt.Sprintf("CDC_%s_000001.json", dispatcherID.String())
+	indexFileName := fmt.Sprintf("CDC_%s.index", dispatcherID.String())
 	require.Eventually(t, func() bool {
-		files, err := os.ReadDir(table1Dir)
-		return err == nil && len(files) == 2
+		_, dataErr := os.Stat(path.Join(table1Dir, dataFileName))
+		_, indexErr := os.Stat(path.Join(table1Dir, "meta", indexFileName))
+		return dataErr == nil && indexErr == nil
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// check whether files for table1 has been generated
 	fileNames := getTableFiles(t, table1Dir)
 	require.Len(t, fileNames, 2)
-	require.ElementsMatch(t, []string{fmt.Sprintf("CDC_%s_000001.json", dispatcherID.String()), fmt.Sprintf("CDC_%s.index", dispatcherID.String())}, fileNames)
+	require.ElementsMatch(t, []string{dataFileName, indexFileName}, fileNames)
 	cancel()
 	wg.Wait()
 }

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -238,7 +238,7 @@ func (ra *RedoApplier) applyDDL(
 		if ddl.DDL == nil {
 			// Note this could only happen when using old version of cdc, and the commit ts
 			// of the DDL should be equal to checkpoint ts or resolved ts.
-			log.Warn("ignore DDL without table info", zap.Any("ddl", ddl))
+			log.Warn("ignore DDL without table info", zap.String("ddl", ddl.DDL.Query))
 			return true
 		}
 
@@ -277,12 +277,14 @@ func (ra *RedoApplier) applyDDL(
 				timodel.ActionAlterTablePartitionPlacement, timodel.ActionRecoverSchema:
 				tableDDLTs = ra.getTableDDLTs(commonType.DDLSpanTableID)
 			default:
-				log.Warn("ignore unsupport DDL", zap.Any("ddl", ddl), zap.Any("type", ddl.Type))
+				log.Warn("ignore unsupport DDL", zap.String("ddl", ddl.DDL.Query))
 				return true
 			}
 		}
 		if tableDDLTs.ts >= int64(ddl.DDL.CommitTs) {
-			log.Warn("ignore DDL which commit ts is less than current ts", zap.Any("ddl", ddl), zap.Any("startTs", tableDDLTs.ts))
+			log.Warn("ignore DDL which commit ts is less than current ts",
+				zap.Uint64("commitTs", ddl.DDL.CommitTs), zap.Int64("startTs", tableDDLTs.ts),
+				zap.String("ddl", ddl.DDL.Query))
 			// Ignore the previous dml events, because the drop ddl has replicated the downstream
 			// DML + Drop Table: If the drop table ddl is ignored and the previous dmls should be replicated the downstream in the past.
 			if ddl.DDL.NeedDroppedTables != nil {
@@ -307,7 +309,7 @@ func (ra *RedoApplier) applyDDL(
 		// compatible with old arch
 		if ra.needRecoveryInfo && ddl.DDL.CommitTs == checkpointTs {
 			if _, ok := unsupportedDDL[timodel.ActionType(ddl.Type)]; ok {
-				log.Error("ignore unsupported DDL", zap.Any("ddl", ddl))
+				log.Warn("ignore unsupported DDL", zap.String("ddl", ddl.DDL.Query))
 				return true
 			}
 		}
@@ -316,7 +318,7 @@ func (ra *RedoApplier) applyDDL(
 	if shouldSkip() {
 		return nil
 	}
-	log.Warn("apply DDL", zap.Any("ddl", ddl))
+	log.Warn("apply DDL", zap.String("ddl", ddl.DDL.Query))
 	// Wait block tables to flush data before applying DDL.
 	tableIDs := ra.getBlockTableIDs(ddl.DDL.BlockedTables)
 	for tableID := range tableIDs {

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -238,7 +238,7 @@ func (ra *RedoApplier) applyDDL(
 		if ddl.DDL == nil {
 			// Note this could only happen when using old version of cdc, and the commit ts
 			// of the DDL should be equal to checkpoint ts or resolved ts.
-			log.Warn("ignore DDL without table info", zap.String("ddl", ddl.DDL.Query))
+			log.Warn("ignore DDL without table info", zap.Any("ddl", ddl))
 			return true
 		}
 

--- a/pkg/common/table_info.go
+++ b/pkg/common/table_info.go
@@ -116,6 +116,27 @@ type TableInfo struct {
 	} `json:"-"`
 }
 
+func (ti *TableInfo) String() string {
+	if ti == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"TableInfo{schema:%s, table:%s, tableID:%d, isPartition:%t, targetSchema:%s, targetTable:%s, charset:%s, collate:%s, hasPKOrNotNullUK:%t, activeActiveTable:%t, softDeleteTable:%t, updateTS:%d}",
+		ti.TableName.Schema,
+		ti.TableName.Table,
+		ti.TableName.TableID,
+		ti.TableName.IsPartition,
+		ti.TableName.GetTargetSchema(),
+		ti.TableName.GetTargetTable(),
+		ti.Charset,
+		ti.Collate,
+		ti.HasPKOrNotNullUK,
+		ti.ActiveActiveTable,
+		ti.SoftDeleteTable,
+		ti.UpdateTS,
+	)
+}
+
 func (ti *TableInfo) initPreSQLs() {
 	if ti == nil || ti.columnSchema == nil {
 		return

--- a/pkg/sink/codec/common/ddl.go
+++ b/pkg/sink/codec/common/ddl.go
@@ -163,7 +163,7 @@ func GetBlockedTables(
 	if action == timodel.ActionRenameTable {
 		stmt, err := parser.New().ParseOneStmt(ddl.Query, "", "")
 		if err != nil {
-			log.Panic("parse statement failed", zap.Any("DDL", ddl), zap.Error(err))
+			log.Panic("parse statement failed", zap.String("DDL", ddl.GetDDLQuery()), zap.Error(err))
 		}
 		// The query in job maybe "RENAME TABLE table1 to table2"
 		oldSchemaName := stmt.(*ast.RenameTableStmt).TableToTables[0].OldTable.Schema.O
@@ -180,7 +180,7 @@ func GetBlockedTables(
 	if action == timodel.ActionExchangeTablePartition {
 		stmt, err := parser.New().ParseOneStmt(ddl.Query, "", "")
 		if err != nil {
-			log.Panic("parse statement failed", zap.Any("DDL", ddl), zap.Error(err))
+			log.Panic("parse statement failed", zap.String("DDL", ddl.GetDDLQuery()), zap.Error(err))
 		}
 		sourceSchemaName := stmt.(*ast.AlterTableStmt).Table.Schema.O
 		if sourceSchemaName == "" {

--- a/pkg/sink/mysql/mysql_writer_ddl.go
+++ b/pkg/sink/mysql/mysql_writer_ddl.go
@@ -222,28 +222,27 @@ func (w *Writer) execDDLWithMaxRetries(event *commonEvent.DDLEvent) error {
 			if errors.IsIgnorableMySQLDDLError(err) {
 				// NOTE: don't change the log, some tests depend on it.
 				log.Info("Execute DDL failed, but error can be ignored",
-					zap.String("ddl", event.Query),
 					zap.Uint64("startTs", event.GetStartTs()), zap.Uint64("commitTs", event.GetCommitTs()),
-					zap.Error(err))
+					zap.String("ddl", event.Query), zap.Error(err))
 				// If the error is ignorable, we will ignore the error directly.
 				return nil
 			}
 			if w.cfg.IsTiDB && ddlCreateTime != "" && errors.Is(errors.Cause(err), mysql.ErrInvalidConn) {
-				log.Warn("Wait the asynchronous ddl to synchronize", zap.String("ddl", event.Query), zap.String("ddlCreateTime", ddlCreateTime),
+				log.Warn("Wait the asynchronous ddl to synchronize",
 					zap.Uint64("startTs", event.GetStartTs()), zap.Uint64("commitTs", event.GetCommitTs()),
+					zap.String("ddl", event.Query), zap.String("ddlCreateTime", ddlCreateTime),
 					zap.String("readTimeout", w.cfg.ReadTimeout), zap.Error(err))
 				return w.waitDDLDone(w.ctx, event, ddlCreateTime)
 			}
 			log.Warn("Execute DDL with error, retry later",
-				zap.String("ddl", event.Query),
 				zap.Uint64("startTs", event.GetStartTs()), zap.Uint64("commitTs", event.GetCommitTs()),
-				zap.Error(err))
+				zap.String("ddl", event.Query), zap.Error(err))
 			return errors.WrapError(errors.ErrExecDDLFailed, errors.WithMessage(err, fmt.Sprintf("Execute DDL failed, Query info: %s; ", event.GetDDLQuery())))
 		}
 		log.Info("Execute DDL succeeded",
-			zap.String("changefeed", w.ChangefeedID.String()), zap.String("query", event.GetDDLQuery()),
+			zap.String("changefeed", w.ChangefeedID.String()),
 			zap.Uint64("startTs", event.GetStartTs()), zap.Uint64("commitTs", event.GetCommitTs()),
-			zap.Any("ddl", event))
+			zap.String("query", event.GetDDLQuery()))
 		return nil
 	}, retry.WithBackoffBaseDelay(BackoffBaseDelay.Milliseconds()),
 		retry.WithBackoffMaxDelay(BackoffMaxDelay.Milliseconds()),

--- a/tests/integration_tests/ddl_reentrant/run.sh
+++ b/tests/integration_tests/ddl_reentrant/run.sh
@@ -88,7 +88,12 @@ function ddl_test() {
 
 	echo $restored_sql >${WORK_DIR}/ddl_temp.sql
 	ensure 10 check_ddl_executed "${WORK_DIR}/cdc.log" "${WORK_DIR}/ddl_temp.sql" true
-	ddl_finished_ts=$(grep "Execute DDL succeeded" ${WORK_DIR}/cdc.log | tail -n 1 | grep -oE 'FinishedTs: [0-9]+' | awk '{print $2}')
+	ddl_finished_ts=$(grep "Execute DDL succeeded" "${WORK_DIR}/cdc.log" | tail -n 1 | grep -oE 'commitTs=[0-9]+' | awk -F= '{print $2}')
+	if [[ -z "$ddl_finished_ts" ]]; then
+		echo "failed to parse ddl finished ts from cdc log"
+		grep "Execute DDL succeeded" "${WORK_DIR}/cdc.log" | tail -n 1 || true
+		exit 1
+	fi
 	cdc_cli_changefeed pause --changefeed-id=${changefeedid}
 	cdc_cli_changefeed resume --no-confirm --changefeed-id=${changefeedid} --overwrite-checkpoint-ts=$((ddl_finished_ts - 1))
 	echo "resume changefeed ${changefeedid} from ${ddl_finished_ts}"


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5399 

### What is changed and how it works?

* add string method to the tableInfo
* print the ddl query instead of the whole object

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved diagnostic logging across components by switching from full object dumps to structured fields (including epochs and commitTs/startTs) and DDL query strings.
  * Refreshed DDL apply/retry logging for clearer, more consistent context.

* **New Features**
  * Added a readable string representation for table information to improve log clarity.

* **Tests**
  * Updated a storage writer test to assert exact expected output filenames and wait for them.
  * Improved the DDL reentrancy test script to extract commitTs from success logs more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->