### PR TITLE
api: return 400 instead of 500 on duplicate changefeed creation

### DIFF
--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	cerrors "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/node"
 	"github.com/pingcap/ticdc/pkg/pdutil"
 	"github.com/pingcap/ticdc/pkg/server"
@@ -201,6 +202,57 @@ func TestForwardToCoordinator(t *testing.T) {
 			if tt.ts != nil {
 				tt.ts.Close()
 			}
+		})
+	}
+}
+
+func TestErrorHandleMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{
+			name:       "no error returns 200",
+			err:        nil,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "registered bad-request error returns 400",
+			err:        cerrors.ErrAPIInvalidParam.GenWithStackByArgs("bad input"),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "duplicate changefeed returns 400",
+			err:        cerrors.ErrChangeFeedAlreadyExists.GenWithStackByArgs("foo"),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "unclassified error returns 500",
+			err:        errors.New("boom"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(ErrorHandleMiddleware())
+			router.GET("/test", func(c *gin.Context) {
+				if tc.err != nil {
+					_ = c.Error(tc.err)
+					return
+				}
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tc.wantStatus, w.Code)
 		})
 	}
 }

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -67,7 +67,8 @@ func NewHTTPError(err error) HTTPError {
 // httpBadRequestError is some errors that will cause a BadRequestError in http handler
 var httpBadRequestError = []*errors.Error{
 	cerror.ErrAPIInvalidParam, cerror.ErrSinkURIInvalid, cerror.ErrStartTsBeforeGC,
-	cerror.ErrChangeFeedNotExists, cerror.ErrTargetTsBeforeStartTs, cerror.ErrTableIneligible,
+	cerror.ErrChangeFeedNotExists, cerror.ErrChangeFeedAlreadyExists,
+	cerror.ErrTargetTsBeforeStartTs, cerror.ErrTableIneligible,
 	cerror.ErrFilterRuleInvalid, cerror.ErrChangefeedUpdateRefused, cerror.ErrMySQLConnectionError,
 	cerror.ErrMySQLInvalidConfig, cerror.ErrCaptureNotExist, cerror.ErrSchedulerRequestFailed,
 	cerror.ErrActiveActiveTSOIndexIncompatible,


### PR DESCRIPTION
ErrChangeFeedAlreadyExists was not in the httpBadRequestError registry, so the v2 CreateChangefeed handler returned HTTP 500 when a client posted a changefeed ID that already existed. A duplicate-create is a client-side condition and should be a 4xx.

Adds the error to the existing bad-request registry, mirroring how ErrChangeFeedNotExists is already classified, and adds a TestErrorHandleMiddleware regression test.

close #5427

<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

  Issue Number: close #5427

  The v2 `POST /api/v2/changefeeds` endpoint returned HTTP 500 when the requested changefeed ID already existed, because
  `ErrChangeFeedAlreadyExists` was not registered in the middleware's bad-request error list. Clients could not distinguish
  this duplicate condition from a real server fault.

  ### What is changed and how it works?

  - `pkg/api/util.go`: add `ErrChangeFeedAlreadyExists` to `httpBadRequestError`, grouped next to `ErrChangeFeedNotExists`. The
  existing `IsHTTPBadRequestError` matcher already handles direct equality, RFC code, and wrapped errors, so no other plumbing
  is needed.
  - `api/middleware/middleware_test.go`: add `TestErrorHandleMiddleware` pinning the 200 / 400 / 500 buckets, including the
  duplicate-changefeed → 400 case as a regression guard.

  ### Check List

  #### Tests

  - Unit test

  #### Questions

  ##### Will it cause performance regression or break compatibility?

  Changes the HTTP response code for one error case from 500 to 400. Clients that previously treated the 500 as a transient
  server fault and retried will now see a 4xx and (correctly) stop retrying. No wire-format or API-shape changes.

  ##### Do you need to update user documentation, design documentation or monitoring documentation?

  No.

  ### Release note

  ```release-note
  Fix `POST /api/v2/changefeeds` returning HTTP 500 instead of 400 when the changefeed ID already exists.
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to return appropriate HTTP 400 status codes for invalid requests, including scenarios involving duplicate changefeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->