### PR TITLE
metrics: correct the datasource of various panels

### DIFF
--- a/metrics/grafana/ticdc_new_arch.json
+++ b/metrics/grafana/ticdc_new_arch.json
@@ -15944,7 +15944,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16048,7 +16048,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16152,7 +16152,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16255,7 +16255,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16358,7 +16358,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16461,7 +16461,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -19271,7 +19271,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of flush data to the external storage system",
           "fieldConfig": {
             "defaults": {},
@@ -19570,7 +19570,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of flush DMLs by the DDL",
           "fieldConfig": {
             "defaults": {},
@@ -20361,7 +20361,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of waiting for the spool disk quota",
           "fieldConfig": {
             "defaults": {},

--- a/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_next_gen.json
@@ -15944,7 +15944,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16048,7 +16048,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16152,7 +16152,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16255,7 +16255,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16358,7 +16358,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -16461,7 +16461,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -19271,7 +19271,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of flush data to the external storage system",
           "fieldConfig": {
             "defaults": {},
@@ -19570,7 +19570,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of flush DMLs by the DDL",
           "fieldConfig": {
             "defaults": {},
@@ -20361,7 +20361,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of waiting for the spool disk quota",
           "fieldConfig": {
             "defaults": {},

--- a/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
+++ b/metrics/nextgengrafana/ticdc_new_arch_with_keyspace_name.json
@@ -7909,7 +7909,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of flush data to the external storage system",
           "fieldConfig": {
             "defaults": {},
@@ -8208,7 +8208,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of flush DMLs by the DDL",
           "fieldConfig": {
             "defaults": {},
@@ -8999,7 +8999,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The time duration of waiting for the spool disk quota",
           "fieldConfig": {
             "defaults": {},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5429

### What is changed and how it works?

Change the `null` datasource into `"${DS_TEST-CLUSTER}"`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Grafana dashboard panels that lacked proper datasource configuration, ensuring flush-related metrics and spool quota metrics now correctly display data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->