### PR TITLE
stability-test-release-8.5-non-next-gen - 2026-06-20 18:03:51

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,3 +342,4 @@ workload: tools/bin/workload
 
 generate-next-gen-grafana:
 	./scripts/generate-next-gen-metrics.sh
+


### PR DESCRIPTION
Automated stability test PR - adding empty line to Makefile