### PR TITLE
consumer: Move DML event append logs from info to debug

### DIFF
--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -630,7 +630,7 @@ func (w *writer) appendRow2Group(dml *event.DMLEvent, progress *partitionProgres
 		return
 	}
 	group.Append(dml, false)
-	log.Info("DML event append to the group",
+	log.Debug("DML event append to the group",
 		zap.Int32("partition", group.Partition), zap.Any("offset", offset),
 		zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 		zap.Uint64("appliedWatermark", group.AppliedWatermark),

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -533,7 +533,7 @@ func (w *writer) appendRow2Group(dml *commonEvent.DMLEvent, progress *partitionP
 		return
 	}
 	group.Append(dml, false)
-	log.Info("DML event append to the group",
+	log.Debug("DML event append to the group",
 		zap.Int32("partition", group.Partition),
 		zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 		zap.Uint64("appliedWatermark", group.AppliedWatermark),

--- a/cmd/storage-consumer/consumer.go
+++ b/cmd/storage-consumer/consumer.go
@@ -286,7 +286,7 @@ func (c *consumer) appendRow2Group(dml *event.DMLEvent, enableTableAcrossNodes b
 	}
 	if commitTs >= group.HighWatermark {
 		group.Append(dml, false)
-		log.Info("DML event append to the group",
+		log.Debug("DML event append to the group",
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", dml.RowTypes[0]))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5472 

The `cdc_kafka_xxx_scenario` case produced extremely high Kafka consumer INFO log volume from per-DML append logging. Under heavy DML workload, this can amplify consumer throughput bottlenecks and watermark lag, delaying queued DDL execution such as the `finishmark` DDL.

### What is changed and how it works?

This PR moves the high-frequency `DML event append to the group` log from INFO to DEBUG in the consumer append path:

- Kafka consumer
- Pulsar consumer
- Storage consumer

The detailed per-DML diagnostics remain available when DEBUG logging is enabled, while default INFO logging avoids the large log volume and related formatting/file I/O overhead.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
  - `go test ./cmd/kafka-consumer ./cmd/pulsar-consumer ./cmd/storage-consumer`
- Manual test
  - https://tcms.pingcap.net/dashboard/executions/plan/8190821
  - [cdc_kafka_consumer.log.txt.zip](https://github.com/user-attachments/files/29186077/cdc_kafka_consumer.log.txt.zip)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No performance regression or compatibility break is expected. This reduces default INFO log volume and preserves the log at DEBUG level for troubleshooting.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
consumer: Move DML event append logs from info to debug
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized logging verbosity in consumer services by adjusting log output levels to reduce operational noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->