### PR TITLE
pulsar-consumer: Move DML event append logs from info to debug

### DIFF
--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -495,7 +495,7 @@ func (w *writer) appendRow2Group(dml *commonEvent.DMLEvent, progress *partitionP
 	}
 	if commitTs >= group.HighWatermark {
 		group.Append(dml, false)
-		log.Info("DML event append to the group",
+		log.Debug("DML event append to the group",
 			zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 			zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
 			zap.Stringer("eventType", dml.RowTypes[0]))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5472 

(Apply #5469 again, which is partially reverted by #5438. Also refer to https://tcms.pingcap.net/dashboard/executions/plan/8171490)

The `cdc_kafka_xxx_scenario` case produced extremely high Kafka consumer INFO log volume from per-DML append logging. Under heavy DML workload, this can amplify consumer throughput bottlenecks and watermark lag, delaying queued DDL execution such as the `finishmark` DDL.

### What is changed and how it works?

This PR moves the high-frequency `DML event append to the group` log from INFO to DEBUG in the consumer append path:

- ~~Kafka consumer~~
- Pulsar consumer
- ~~Storage consumer~~

The detailed per-DML diagnostics remain available when DEBUG logging is enabled, while default INFO logging avoids the large log volume and related formatting/file I/O overhead.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
  - `go test ./cmd/kafka-consumer ./cmd/pulsar-consumer ./cmd/storage-consumer`
- Manual test
  - https://tcms.pingcap.net/dashboard/executions/plan/8190821
  - [cdc_kafka_consumer.log.txt.zip](https://github.com/user-attachments/files/29186077/cdc_kafka_consumer.log.txt.zip)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No performance regression or compatibility break is expected. This reduces default INFO log volume and preserves the log at DEBUG level for troubleshooting.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
pulsar-consumer: Move DML event append logs from info to debug
```
