### PR TITLE
consumer: add subscription-name option for pulsar consumer

### DIFF
--- a/cmd/pulsar-consumer/consumer.go
+++ b/cmd/pulsar-consumer/consumer.go
@@ -41,7 +41,6 @@ func newConsumer(ctx context.Context, option *option) *consumer {
 		pulsarURL = "pulsar" + "://" + strings.Join(option.address, ",")
 	}
 	topicName := option.topic
-	subscriptionName := "pulsar-test-subscription"
 
 	clientOption := pulsar.ClientOptions{
 		URL:    pulsarURL,
@@ -82,7 +81,7 @@ func newConsumer(ctx context.Context, option *option) *consumer {
 
 	consumerConfig := pulsar.ConsumerOptions{
 		Topic:                       topicName,
-		SubscriptionName:            subscriptionName,
+		SubscriptionName:            option.subscriptionName,
 		Type:                        pulsar.Exclusive,
 		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
 	}

--- a/cmd/pulsar-consumer/main.go
+++ b/cmd/pulsar-consumer/main.go
@@ -48,6 +48,7 @@ func main() {
 	cmd.Flags().StringVar(&configFile, "config", "", "config file for changefeed")
 	cmd.Flags().StringVar(&upstreamURIStr, "upstream-uri", "", "pulsar uri")
 	cmd.Flags().StringVar(&consumerOption.downstreamURI, "downstream-uri", "", "downstream sink uri")
+	cmd.Flags().StringVar(&consumerOption.subscriptionName, "subscription-name", consumerOption.subscriptionName, "pulsar subscription name")
 	cmd.Flags().StringVar(&consumerOption.timezone, "tz", "System", "Specify time zone of pulsar consumer")
 	cmd.Flags().StringVar(&consumerOption.ca, "ca", "", "CA certificate path for pulsar SSL connection")
 	cmd.Flags().StringVar(&consumerOption.cert, "cert", "", "Certificate path for pulsar SSL connection")

--- a/cmd/pulsar-consumer/options.go
+++ b/cmd/pulsar-consumer/options.go
@@ -26,8 +26,9 @@ import (
 
 // option represents the options of the pulsar consumer
 type option struct {
-	address []string
-	topic   string
+	address          []string
+	topic            string
+	subscriptionName string
 
 	protocol            config.Protocol
 	enableTiDBExtension bool
@@ -56,6 +57,9 @@ type option struct {
 func newConsumerOption() *option {
 	return &option{
 		protocol: config.ProtocolCanalJSON,
+		// Keep the historical default so existing users continue from the same
+		// durable subscription unless overridden.
+		subscriptionName: "pulsar-test-subscription",
 		// the default value of partitionNum is 1
 		partitionNum: 1,
 	}

--- a/cmd/pulsar-consumer/writer.go
+++ b/cmd/pulsar-consumer/writer.go
@@ -445,8 +445,20 @@ func (w *writer) onDDL(ddl *commonEvent.DDLEvent) {
 		if err != nil {
 			log.Panic("parse ddl query failed", zap.String("query", ddl.Query), zap.Error(err))
 		}
-		if v, ok := stmt.(*ast.CreateTableStmt); ok && v.Partition != nil {
-			w.addPartitionTable(ddl.GetSchemaName(), ddl.GetTableName())
+		if v, ok := stmt.(*ast.CreateTableStmt); ok {
+			if v.Partition != nil {
+				w.addPartitionTable(ddl.GetSchemaName(), ddl.GetTableName())
+				return
+			}
+			if v.ReferTable != nil {
+				referSchema := v.ReferTable.Schema.O
+				if referSchema == "" {
+					referSchema = ddl.GetSchemaName()
+				}
+				if w.partitionTableAccessor.IsPartitionTable(referSchema, v.ReferTable.Name.O) {
+					w.addPartitionTable(ddl.GetSchemaName(), ddl.GetTableName())
+				}
+			}
 		}
 	case timodel.ActionRenameTable:
 		if w.partitionTableAccessor.IsPartitionTable(ddl.ExtraSchemaName, ddl.ExtraTableName) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5508 ref #4051

### What is changed and how it works?
1. Add subscriptionName param
2. Fix data inconsistency when meeting `create xx like partition table`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable subscription name for the Pulsar consumer, with a new command-line flag and preserved default value.

* **Bug Fixes**
  * Improved detection of partitioned tables during DDL handling, including cases where a new table references an existing partitioned table, so related tables are recognized more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->