### PR TITLE
consumer: fix debezium partition fallback

### DIFF
--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -618,7 +618,7 @@ func (w *writer) appendRow2Group(dml *event.DMLEvent, progress *partitionProgres
 		return
 	}
 	switch w.protocol {
-	case config.ProtocolSimple, config.ProtocolDebezium:
+	case config.ProtocolSimple:
 		// simple protocol set the table id for all row message, it can be known which table the row message belongs to,
 		// also consider the table partition.
 		// open protocol set the partition table id if the table is partitioned.
@@ -632,15 +632,15 @@ func (w *writer) appendRow2Group(dml *event.DMLEvent, progress *partitionProgres
 			zap.Stringer("eventType", dml.RowTypes[0]),
 			// zap.Any("columns", row.Columns), zap.Any("preColumns", row.PreColumns),
 			zap.Any("protocol", w.protocol), zap.Bool("IsPartition", dml.TableInfo.TableName.IsPartition))
-	case config.ProtocolCanalJSON, config.ProtocolOpen, config.ProtocolAvro:
-		// for partition table, the canal-json, avro and open-protocol message cannot assign physical table id to each dml message,
+	case config.ProtocolCanalJSON, config.ProtocolOpen, config.ProtocolAvro, config.ProtocolDebezium:
+		// for partition table, these protocols cannot assign physical table id to each dml message,
 		// we cannot distinguish whether it's a real fallback event or not, still append it.
 		if w.partitionTableAccessor.IsPartitionTable(schema, table) {
-			log.Warn("DML events fallback, but it's canal-json, avro or open-protocol and the table is a partition table, still append it",
+			log.Warn("DML events fallback, but the table is a partition table, still append it",
 				zap.Int32("partition", group.Partition), zap.Any("offset", offset),
 				zap.Uint64("commitTs", commitTs), zap.Uint64("highWatermark", group.HighWatermark),
 				zap.String("schema", schema), zap.String("table", table), zap.Int64("tableID", tableID),
-				zap.Stringer("eventType", dml.RowTypes[0]))
+				zap.Stringer("eventType", dml.RowTypes[0]), zap.Any("protocol", w.protocol))
 			group.Append(dml, true)
 			return
 		}

--- a/cmd/kafka-consumer/writer_test.go
+++ b/cmd/kafka-consumer/writer_test.go
@@ -318,3 +318,46 @@ func TestOnDDLMarksRoutedCreateTableLikePartitionTableForAvro(t *testing.T) {
 	require.Len(t, resolved, 1)
 	require.Equal(t, uint64(100), resolved[0].CommitTs)
 }
+
+func TestAppendRow2GroupKeepsDebeziumPartitionTableFallback(t *testing.T) {
+	replicaCfg := config.GetDefaultReplicaConfig()
+	eventRouter, err := eventrouter.NewEventRouter(replicaCfg.Sink, "test-topic", false, false)
+	require.NoError(t, err)
+
+	w := &writer{
+		progresses:             []*partitionProgress{{partition: 0, eventsGroup: make(map[int64]*util.EventsGroup)}},
+		eventRouter:            eventRouter,
+		protocol:               config.ProtocolDebezium,
+		partitionTableAccessor: codeccommon.NewPartitionTableAccessor(),
+	}
+
+	w.partitionTableAccessor.Add("target", "src")
+	ddl := &commonEvent.DDLEvent{
+		Query:      "CREATE TABLE `target`.`dst` LIKE `target`.`src`",
+		SchemaName: "target",
+		TableName:  "dst",
+		Type:       byte(timodel.ActionCreateTable),
+	}
+	w.onDDL(ddl)
+	require.True(t, w.partitionTableAccessor.IsPartitionTable("target", "dst"))
+
+	newDMLEvent := func(commitTs uint64) *commonEvent.DMLEvent {
+		return &commonEvent.DMLEvent{
+			PhysicalTableID: 1,
+			CommitTs:        commitTs,
+			RowTypes:        []common.RowType{common.RowTypeUpdate},
+			Rows:            chunk.NewChunkWithCapacity(nil, 0),
+			TableInfo: &common.TableInfo{
+				TableName: common.TableName{Schema: "target", Table: "dst"},
+			},
+		}
+	}
+
+	progress := w.progresses[0]
+	w.appendRow2Group(newDMLEvent(200), progress, kafka.Offset(10))
+	w.appendRow2Group(newDMLEvent(100), progress, kafka.Offset(11))
+
+	resolved := progress.eventsGroup[1].ResolveInto(150, nil)
+	require.Len(t, resolved, 1)
+	require.Equal(t, uint64(100), resolved[0].CommitTs)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5508

This PR fixes a Debezium Kafka consumer data loss issue exposed by the
`table_route` integration test. For partitioned tables, row events from
different physical partitions can be consumed in Kafka offset order that is not
commitTs order. The consumer grouped Debezium DML events by the logical table
ID, so a later commitTs could advance the group high watermark before an earlier
commitTs event arrived. The earlier valid event was then treated as a fallback
row and ignored, causing downstream to miss data.

### What is changed and how it works?

- Let Debezium use the existing partition-table fallback path in
  `cmd/kafka-consumer/writer.go`.
- Keep the partition watermark protection unchanged: events below the partition
  watermark are still ignored as old/replayed messages.
- When a Debezium DML event is for a known partition table and only falls below
  the event group's high watermark, append it with `force=true` so it is inserted
  back into the group by commitTs instead of being dropped.
- Add a regression test covering `CREATE TABLE ... LIKE ...` partition-table
  routing and out-of-order Debezium DML commitTs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
  - `GOCACHE=$PWD/.cache/go-build go test ./cmd/kafka-consumer -run 'Test(OnDDLMarksRoutedCreateTableLikePartitionTableForAvro|AppendRow2GroupKeepsDebeziumPartitionTableFallback)$' -count=1`
  - `GOCACHE=$PWD/.cache/go-build go test ./cmd/kafka-consumer -count=1`
- Integration test
  - Not run locally. The target integration coverage is `make integration_test_kafka CASE=table_route`.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No expected performance regression or compatibility break. The change only affects
Debezium DML events for tables already recorded as partition tables by the
consumer. Non-partition-table fallback handling and partition watermark replay
protection are unchanged.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a Debezium Kafka consumer issue that could drop out-of-order DML events for partitioned tables.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling for Debezium so partition-table rows continue to be included correctly when earlier events fall below the high watermark.
  * Adjusted fallback behavior across protocol types to keep row delivery consistent for partitioned tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->