### PR TITLE
logservice: add baseline scan task logs

### DIFF
--- a/logservice/eventstore/event_store.go
+++ b/logservice/eventstore/event_store.go
@@ -460,7 +460,7 @@ func (e *eventStore) Close(_ context.Context) error {
 }
 
 func (e *eventStore) RegisterDispatcher(
-	_ common.ChangeFeedID,
+	changefeedID common.ChangeFeedID,
 	dispatcherID common.DispatcherID,
 	dispatcherSpan *heartbeatpb.TableSpan,
 	startTs uint64,
@@ -678,7 +678,7 @@ func (e *eventStore) RegisterDispatcher(
 	serverConfig := config.GetGlobalServerConfig()
 	resolvedTsAdvanceInterval := int64(serverConfig.KVClient.AdvanceIntervalInMs)
 	// Note: don't hold any lock when call Subscribe
-	e.subClient.Subscribe(subStat.subID, *dispatcherSpan, startTs, consumeKVEvents, advanceResolvedTs, resolvedTsAdvanceInterval, bdrMode)
+	e.subClient.Subscribe(changefeedID.String(), subStat.subID, *dispatcherSpan, startTs, consumeKVEvents, advanceResolvedTs, resolvedTsAdvanceInterval, bdrMode)
 	log.Info("new subscription created",
 		zap.Stringer("dispatcherID", dispatcherID),
 		zap.Uint64("startTs", startTs),

--- a/logservice/eventstore/event_store_test.go
+++ b/logservice/eventstore/event_store_test.go
@@ -120,6 +120,7 @@ func (s *mockSubscriptionClient) AllocSubscriptionID() logpuller.SubscriptionID 
 }
 
 func (s *mockSubscriptionClient) Subscribe(
+	_ string,
 	subID logpuller.SubscriptionID,
 	span heartbeatpb.TableSpan,
 	startTs uint64,

--- a/logservice/logpuller/subscription_client.go
+++ b/logservice/logpuller/subscription_client.go
@@ -102,14 +102,26 @@ type rangeTask struct {
 	priority       TaskType
 }
 
+func taskTypeLogName(taskType TaskType) string {
+	switch taskType {
+	case TaskHighPrior:
+		return "high"
+	case TaskLowPrior:
+		return "low"
+	default:
+		return taskType.String()
+	}
+}
+
 const kvEventsCacheMaxSize = 32
 
 // subscribedSpan represents a span to subscribe.
 // It contains a sub span of a table(or the total span of a table),
 // the startTs of the table, and the output event channel.
 type subscribedSpan struct {
-	subID   SubscriptionID
-	startTs uint64
+	changefeedID string
+	subID        SubscriptionID
+	startTs      uint64
 	// Whether to filter out the value written by TiCDC itself.
 	// It should be `true` in BDR mode.
 	filterLoop bool
@@ -168,6 +180,7 @@ type SubscriptionClient interface {
 	AllocSubscriptionID() SubscriptionID
 	// subscribe a table span
 	Subscribe(
+		changefeedID string,
 		subID SubscriptionID,
 		span heartbeatpb.TableSpan,
 		startTs uint64,
@@ -349,6 +362,7 @@ func (s *subscriptionClient) updateMetrics(ctx context.Context) error {
 // and send a rangeTask to `s.rangeTaskCh`.
 // The rangeTask will be handled in `handleRangeTasks` goroutine.
 func (s *subscriptionClient) Subscribe(
+	changefeedID string,
 	subID SubscriptionID,
 	span heartbeatpb.TableSpan,
 	startTs uint64,
@@ -362,7 +376,7 @@ func (s *subscriptionClient) Subscribe(
 		return
 	}
 
-	rt := s.newSubscribedSpan(subID, span, startTs, consumeKVEvents, advanceResolvedTs, advanceInterval, bdrMode)
+	rt := s.newSubscribedSpan(changefeedID, subID, span, startTs, consumeKVEvents, advanceResolvedTs, advanceInterval, bdrMode)
 	s.totalSpans.Lock()
 	s.totalSpans.spanMap[subID] = rt
 	s.totalSpans.Unlock()
@@ -374,7 +388,8 @@ func (s *subscriptionClient) Subscribe(
 	case <-s.ctx.Done():
 		log.Warn("subscribes span failed, the subscription client has closed")
 	case s.rangeTaskCh <- rangeTask{span: span, subscribedSpan: rt, filterLoop: rt.filterLoop, priority: TaskLowPrior}:
-		log.Info("subscribes span done", zap.Uint64("subscriptionID", uint64(subID)),
+		log.Info("subscribes span done", zap.String("changefeedID", changefeedID),
+			zap.Uint64("subscriptionID", uint64(subID)),
 			zap.Int64("tableID", span.TableID), zap.Uint64("startTs", startTs),
 			zap.String("startKey", spanz.HexKey(span.StartKey)), zap.String("endKey", spanz.HexKey(span.EndKey)))
 	}
@@ -814,6 +829,16 @@ func (s *subscriptionClient) scheduleRegionRequest(ctx context.Context, region r
 	case regionlock.LockRangeStatusSuccess:
 		region.lockedRangeState = lockRangeResult.LockedRangeState
 		s.regionTaskQueue.Push(NewRegionPriorityTask(priority, region, s.pdClock.CurrentTS()))
+		log.Info("cdc region scan task enqueued",
+			zap.String("changefeedID", region.subscribedSpan.changefeedID),
+			zap.Uint64("subscriptionID", uint64(region.subscribedSpan.subID)),
+			zap.Int64("tableID", region.subscribedSpan.span.TableID),
+			zap.Uint64("startTs", region.subscribedSpan.startTs),
+			zap.Uint64("regionID", region.verID.GetID()),
+			zap.Uint64("regionEpochVersion", region.verID.GetVer()),
+			zap.Uint64("regionEpochConfVer", region.verID.GetConfVer()),
+			zap.String("priority", taskTypeLogName(priority)),
+			zap.String("span", common.FormatTableSpan(&region.span)))
 	case regionlock.LockRangeStatusStale:
 		for _, r := range lockRangeResult.RetryRanges {
 			s.scheduleRangeRequest(ctx, r, region.subscribedSpan, region.filterLoop, priority)
@@ -1077,6 +1102,7 @@ func (s *subscriptionClient) logSlowRegions(ctx context.Context) error {
 }
 
 func (s *subscriptionClient) newSubscribedSpan(
+	changefeedID string,
 	subID SubscriptionID,
 	span heartbeatpb.TableSpan,
 	startTs uint64,
@@ -1088,11 +1114,12 @@ func (s *subscriptionClient) newSubscribedSpan(
 	rangeLock := regionlock.NewRangeLock(uint64(subID), span.StartKey, span.EndKey, startTs)
 
 	rt := &subscribedSpan{
-		subID:      subID,
-		span:       span,
-		startTs:    startTs,
-		filterLoop: filterLoop,
-		rangeLock:  rangeLock,
+		changefeedID: changefeedID,
+		subID:        subID,
+		span:         span,
+		startTs:      startTs,
+		filterLoop:   filterLoop,
+		rangeLock:    rangeLock,
 
 		consumeKVEvents:   consumeKVEvents,
 		advanceResolvedTs: advanceResolvedTs,

--- a/logservice/logpuller/subscription_client_test.go
+++ b/logservice/logpuller/subscription_client_test.go
@@ -66,7 +66,7 @@ func TestGenerateResolveLockTask(t *testing.T) {
 	}
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
-	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, false)
+	span := client.newSubscribedSpan("test/changefeed", SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, false)
 	client.totalSpans.spanMap = make(map[SubscriptionID]*subscribedSpan)
 	client.totalSpans.spanMap[SubscriptionID(1)] = span
 	client.pdClock = pdutil.NewClock4Test()
@@ -136,12 +136,12 @@ func TestResolveLockTaskDeduplicatedAcrossSubscribedSpans(t *testing.T) {
 
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
-	span1 := client.newSubscribedSpan(SubscriptionID(1), heartbeatpb.TableSpan{
+	span1 := client.newSubscribedSpan("test/changefeed", SubscriptionID(1), heartbeatpb.TableSpan{
 		TableID:  1,
 		StartKey: []byte{'a'},
 		EndKey:   []byte{'z'},
 	}, 100, consumeKVEvents, advanceResolvedTs, 0, false)
-	span2 := client.newSubscribedSpan(SubscriptionID(2), heartbeatpb.TableSpan{
+	span2 := client.newSubscribedSpan("test/changefeed", SubscriptionID(2), heartbeatpb.TableSpan{
 		TableID:  2,
 		StartKey: []byte{'a'},
 		EndKey:   []byte{'z'},
@@ -244,7 +244,7 @@ func TestResolveLockTaskDroppedWhenChannelFull(t *testing.T) {
 	}
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
-	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, false)
+	span := client.newSubscribedSpan("test/changefeed", SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, false)
 
 	res := span.rangeLock.LockRange(context.Background(), []byte{'b'}, []byte{'c'}, 1, 100)
 	require.Equal(t, regionlock.LockRangeStatusSuccess, res.Status)
@@ -292,7 +292,7 @@ func TestStopTaskUsesSubscribedSpanFilterLoop(t *testing.T) {
 	}
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
-	span := client.newSubscribedSpan(SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, true)
+	span := client.newSubscribedSpan("test/changefeed", SubscriptionID(1), rawSpan, 100, consumeKVEvents, advanceResolvedTs, 0, true)
 
 	res := span.rangeLock.LockRange(context.Background(), rawSpan.StartKey, rawSpan.EndKey, 1, 1)
 	require.Equal(t, regionlock.LockRangeStatusSuccess, res.Status)
@@ -521,7 +521,7 @@ func TestSubscriptionWithFailedTiKV(t *testing.T) {
 		case tsCh <- ts:
 		}
 	}
-	client.Subscribe(subID, span, 1, consumeKVEvents, advanceResolvedTs, 0, false)
+	client.Subscribe("test/changefeed", subID, span, 1, consumeKVEvents, advanceResolvedTs, 0, false)
 
 	eventsCh1 <- mockInitializedEvent(11, uint64(subID))
 	targetTs := oracle.GoTimeToTS(pdClock.CurrentTime())
@@ -704,7 +704,7 @@ func TestGetResolvedTargetTs(t *testing.T) {
 	consumeKVEvents := func(_ []common.RawKVEntry, _ func()) bool { return false }
 	advanceResolvedTs := func(ts uint64) {}
 
-	span := client.newSubscribedSpan(SubscriptionID(1), heartbeatpb.TableSpan{
+	span := client.newSubscribedSpan("test/changefeed", SubscriptionID(1), heartbeatpb.TableSpan{
 		TableID:  1,
 		StartKey: []byte{'a'},
 		EndKey:   []byte{'z'},

--- a/logservice/schemastore/ddl_job_fetcher.go
+++ b/logservice/schemastore/ddl_job_fetcher.go
@@ -96,7 +96,7 @@ func (p *ddlJobFetcher) run(startTs uint64) error {
 		advanceSubSpanResolvedTs := func(ts uint64) {
 			p.tryAdvanceResolvedTs(subID, ts)
 		}
-		p.subClient.Subscribe(subID, span, startTs, p.input, advanceSubSpanResolvedTs, 0, ddlPullerFilterLoop)
+		p.subClient.Subscribe("schema-store/ddl-job-fetcher", subID, span, startTs, p.input, advanceSubSpanResolvedTs, 0, ddlPullerFilterLoop)
 	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

This PR provides a baseline-only build to verify whether an existing changefeed creates new incremental scan tasks while another old-start-ts changefeed is catching up. It is intentionally separate from the scan-priority implementation PR so the original behavior can be compared against the experiment.

### What is changed and how it works?

- Thread `changefeedID` into `SubscriptionClient.Subscribe` and store it in `subscribedSpan` for logging only.
- Add `changefeedID` to the existing `subscribes span done` log.
- Add a new `cdc region scan task enqueued` log when a region scan task is pushed into the logpuller region task queue.
- The new scan-task log includes `changefeedID`, `subscriptionID`, `tableID`, `startTs`, `regionID`, region epoch, task `priority` (`high` or `low`), and span.
- Use a fixed synthetic id for schema-store DDL subscriptions.

This PR does not change task priority calculation, retry behavior, kvproto fields, or TiKV/CSE request behavior.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
  - `make fmt`
  - `go test ./logservice/logpuller ./logservice/eventstore ./logservice/schemastore -run '^$'`

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No compatibility impact. The change is observability-only. The added log is intentionally used for baseline experiments and should not be enabled for high-volume production diagnosis without considering log volume.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription handling so changefeed-specific identifiers are consistently passed through background processing.
  * Added clearer logging when region scan tasks are queued, making it easier to trace subscription activity and task priority.
  * Updated related test coverage to match the revised subscription flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->