### PR TITLE
kafka: use default option when meeting authorization and ACLs fails

### DIFF
--- a/pkg/sink/kafka/options.go
+++ b/pkg/sink/kafka/options.go
@@ -607,10 +607,13 @@ func adjustOptions(
 			TopicMaxMessageBytesConfigName,
 			BrokerMessageMaxBytesConfigName,
 		)
+		var topicMaxMessageBytes int
 		if err != nil {
-			return errors.Trace(err)
+			log.Warn("TiCDC cannot find `max.message.bytes` from topic's configuration, use the option `MaxMessageBytes` as default")
+			topicMaxMessageBytes = options.MaxMessageBytes
+			// return errors.Trace(err)
 		}
-		topicMaxMessageBytes, err := strconv.Atoi(topicMaxMessageBytesStr)
+		topicMaxMessageBytes, err = strconv.Atoi(topicMaxMessageBytesStr)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -643,12 +646,13 @@ func adjustOptions(
 		return nil
 	}
 
+	var brokerMessageMaxBytes int
 	brokerMessageMaxBytesStr, err := admin.GetBrokerConfig(BrokerMessageMaxBytesConfigName)
 	if err != nil {
-		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration")
-		return errors.Trace(err)
+		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration, use the option `MaxMessageBytes` as default")
+		brokerMessageMaxBytes = options.MaxMessageBytes
 	}
-	brokerMessageMaxBytes, err := strconv.Atoi(brokerMessageMaxBytesStr)
+	brokerMessageMaxBytes, err = strconv.Atoi(brokerMessageMaxBytesStr)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -717,9 +721,9 @@ func validateMinInsyncReplicas(
 				"to the minimum number of in-sync replicas" +
 				"if you want to use `required-acks` = -1." +
 				"Otherwise, TiCDC will not be able to send messages to the topic.")
-			return nil
 		}
-		return err
+		log.Warn("TiCDC meets error when get `min.insync.replicas` from broker's configuration, assume the config is valid")
+		return nil
 	}
 	minInsyncReplicas, err := strconv.Atoi(minInsyncReplicasStr)
 	if err != nil {

--- a/pkg/sink/kafka/options.go
+++ b/pkg/sink/kafka/options.go
@@ -611,11 +611,11 @@ func adjustOptions(
 		if err != nil {
 			log.Warn("TiCDC cannot find `max.message.bytes` from topic's configuration, use the option `MaxMessageBytes` as default")
 			topicMaxMessageBytes = options.MaxMessageBytes
-			// return errors.Trace(err)
-		}
-		topicMaxMessageBytes, err = strconv.Atoi(topicMaxMessageBytesStr)
-		if err != nil {
-			return errors.Trace(err)
+		} else {
+			topicMaxMessageBytes, err = strconv.Atoi(topicMaxMessageBytesStr)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 
 		maxMessageBytes := topicMaxMessageBytes - maxMessageBytesOverhead
@@ -651,10 +651,11 @@ func adjustOptions(
 	if err != nil {
 		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration, use the option `MaxMessageBytes` as default")
 		brokerMessageMaxBytes = options.MaxMessageBytes
-	}
-	brokerMessageMaxBytes, err = strconv.Atoi(brokerMessageMaxBytesStr)
-	if err != nil {
-		return errors.Trace(err)
+	} else {
+		brokerMessageMaxBytes, err = strconv.Atoi(brokerMessageMaxBytesStr)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	// when create the topic, `max.message.bytes` is decided by the broker,


### PR DESCRIPTION
<!--
Thank you for contributing to TiCDC! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/ticdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/ticdc/issues/5563

### What is changed and how it works?
If ticdc fails to authorize acl on the kafka server, try using the default option instead of throwing an error when creating the changefeed. The change will fail later.
This is to prevent the changefeed from being created if the user does not grant the relevant acl permissions.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

| Kafka | Bad config | Topic `DescribeConfigs` granted? | `changefeed create` | Post-create result |
| --- | --- | --- | --- | --- |
| 2.8.0 | `max.message.bytes=1024` | No | Success | `warning`, broker rejects large DML with message-too-large |
| 2.8.0 | `max.message.bytes=1024` | Yes | Success | `warning`, TiCDC detects `ErrMessageTooLarge` using adjusted `maxMessageBytes=896` |
| 3.7.0 | `max.message.bytes=1024` | No | Success | `warning`, broker rejects large DML with message-too-large |
| 3.7.0 | `max.message.bytes=1024` | Yes | Success | `warning`, TiCDC detects `ErrMessageTooLarge` using adjusted `maxMessageBytes=896` |
| 2.8.0 | `min.insync.replicas=2`, RF=1 | No | Success | `warning`, Kafka send fails after DDL |
| 2.8.0 | `min.insync.replicas=2`, RF=1 | Yes | Fail at create | TiCDC rejects invalid config before creating the changefeed |
| 3.7.0 | `min.insync.replicas=2`, RF=1 | No | Success | `normal` in this local broker test |
| 3.7.0 | `min.insync.replicas=2`, RF=1 | Yes | Fail at create | TiCDC rejects invalid config before creating the changefeed |


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Avoid creating changefeed when meeting authorization and ACL failure
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when reading Kafka configuration values.
  * If topic or broker settings can’t be fetched, the app now logs a warning and continues using a safe fallback instead of failing outright.
  * Validation of minimum in-sync replicas is now less likely to block progress when configuration lookup errors occur, while still reporting invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->